### PR TITLE
[RVV 0.7.1] Add pragma about rvv 0.7.1

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1645,6 +1645,9 @@ public:
   /// Indicate RISC-V SiFive vector builtin functions enabled or not.
   bool DeclareRISCVSiFiveVectorBuiltins = false;
 
+  /// Indicate RISC-V vector 0.7.1 builtin functions enabled or not.
+  bool DeclareRISCVV0p7Builtins = false;
+
 private:
   std::unique_ptr<sema::RISCVIntrinsicManager> RVIntrinsicManager;
 

--- a/clang/lib/Parse/ParsePragma.cpp
+++ b/clang/lib/Parse/ParsePragma.cpp
@@ -4042,10 +4042,11 @@ void PragmaRISCVHandler::HandlePragma(Preprocessor &PP,
 
   PP.Lex(Tok);
   II = Tok.getIdentifierInfo();
-  if (!II || !(II->isStr("vector") || II->isStr("sifive_vector"))) {
+  if (!II || !(II->isStr("vector") || II->isStr("sifive_vector") ||
+               II->isStr("vector0p7"))) {
     PP.Diag(Tok.getLocation(), diag::warn_pragma_invalid_argument)
         << PP.getSpelling(Tok) << "riscv" << /*Expected=*/true
-        << "'vector' or 'sifive_vector'";
+        << "'vector', 'sifive_vector' or 'vector0p7'";
     return;
   }
 
@@ -4060,4 +4061,6 @@ void PragmaRISCVHandler::HandlePragma(Preprocessor &PP,
     Actions.DeclareRISCVVBuiltins = true;
   else if (II->isStr("sifive_vector"))
     Actions.DeclareRISCVSiFiveVectorBuiltins = true;
+  else if (II->isStr("vector0p7"))
+    Actions.DeclareRISCVV0p7Builtins = true;
 }

--- a/clang/lib/Sema/SemaLookup.cpp
+++ b/clang/lib/Sema/SemaLookup.cpp
@@ -933,7 +933,8 @@ bool Sema::LookupBuiltin(LookupResult &R) {
         }
       }
 
-      if (DeclareRISCVVBuiltins || DeclareRISCVSiFiveVectorBuiltins) {
+      if (DeclareRISCVVBuiltins || DeclareRISCVSiFiveVectorBuiltins ||
+          DeclareRISCVV0p7Builtins) {
         if (!RVIntrinsicManager)
           RVIntrinsicManager = CreateRISCVIntrinsicManager(*this);
 

--- a/clang/test/Driver/riscv-arch.c
+++ b/clang/test/Driver/riscv-arch.c
@@ -416,6 +416,10 @@
 // RUN:   FileCheck -check-prefix=RV32-V-GOODVERS %s
 // RV32-V-GOODVERS: "-target-feature" "+v"
 
+// RUN: %clang --target=riscv32-unknown-elf -march=rv32iv0p7 -### %s -c 2>&1 | \
+// RUN:   FileCheck -check-prefix=RV32-V0P7-GOODVERS %s
+// RV32-V0P7-GOODVERS: "-target-feature" "+v0p7"
+
 // RUN: %clang --target=riscv32-unknown-elf -march=rv32iv1p0_zvl32b0p1 -### %s -c 2>&1 | \
 // RUN:   FileCheck -check-prefix=RV32-ZVL-BADVERS %s
 // RV32-ZVL-BADVERS: error: invalid arch name 'rv32iv1p0_zvl32b0p1'

--- a/clang/test/Preprocessor/riscv-target-features.c
+++ b/clang/test/Preprocessor/riscv-target-features.c
@@ -223,6 +223,15 @@
 // CHECK-V-EXT: __riscv_vector 1
 
 // RUN: %clang -target riscv32-unknown-linux-gnu \
+// RUN: -march=rv32iv0p7 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-V0P7-EXT %s
+// RUN: %clang -target riscv64-unknown-linux-gnu \
+// RUN: -march=rv64iv0p7 -x c -E -dM %s \
+// RUN: -o - | FileCheck --check-prefix=CHECK-V0P7-EXT %s
+// CHECK-V0P7-EXT: __riscv_v 7000{{$}}
+// CHECK-V0P7-EXT: __riscv_vector 1
+
+// RUN: %clang -target riscv32-unknown-linux-gnu \
 // RUN: -march=rv32izfhmin1p0 -x c -E -dM %s \
 // RUN: -o - | FileCheck --check-prefix=CHECK-ZFHMIN-EXT %s
 // RUN: %clang -target riscv64-unknown-linux-gnu \

--- a/clang/test/Sema/riscv-bad-intrinsic-pragma.c
+++ b/clang/test/Sema/riscv-bad-intrinsic-pragma.c
@@ -2,7 +2,7 @@
 // RUN:            2>&1 | FileCheck %s
 
 #pragma clang riscv intrinsic vvvv
-// CHECK:      warning: unexpected argument 'vvvv' to '#pragma riscv'; expected 'vector' or 'sifive_vector' [-Wignored-pragmas]
+// CHECK:      warning: unexpected argument 'vvvv' to '#pragma riscv'; expected 'vector', 'sifive_vector' or 'vector0p7' [-Wignored-pragmas]
 
 #pragma clang riscv what + 3241
 // CHECK:      warning: unexpected argument 'what' to '#pragma riscv'; expected 'intrinsic' [-Wignored-pragmas]

--- a/llvm/lib/Support/RISCVISAInfo.cpp
+++ b/llvm/lib/Support/RISCVISAInfo.cpp
@@ -64,6 +64,7 @@ static const RISCVSupportedExtension SupportedExtensions[] = {
     {"svpbmt", RISCVExtensionVersion{1, 0}},
 
     {"v", RISCVExtensionVersion{1, 0}},
+    {"v", RISCVExtensionVersion{0, 7}},
 
     // vendor-defined ('X') extensions
     {"xcvbitmanip", RISCVExtensionVersion{1, 0}},


### PR DESCRIPTION
This PR is the first step towards rvv 0.7.1, including:
- Added a new pragma for rvv 0.7.1 as  `#pragma clang riscv intrinsic vector0p7`
- Added support for specifying vector extension version in `-march` as `v0p7` (instead of `v` which stands for rvv 1.0)
- Clang now tells cc1 `-target-feature +v0p7` instead of `+v`, (though this is unnecessary at the moment, but it may help the assembler to choose the correct binary encoding).
- Updated unit tests

Future work:
- TableGen for something like `riscv_vector0p7.td`, much like the approach here: https://reviews.llvm.org/D148308