### PR TITLE
[RVV 0.7.1] Use `xthead` as the prefix of rvv 0.7.1 extension name

### DIFF
--- a/clang/test/Driver/riscv-arch.c
+++ b/clang/test/Driver/riscv-arch.c
@@ -416,9 +416,9 @@
 // RUN:   FileCheck -check-prefix=RV32-V-GOODVERS %s
 // RV32-V-GOODVERS: "-target-feature" "+v"
 
-// RUN: %clang --target=riscv32-unknown-elf -march=rv32iv0p7 -### %s -c 2>&1 | \
+// RUN: %clang --target=riscv32-unknown-elf -march=rv32i_xtheadv -### %s -c 2>&1 | \
 // RUN:   FileCheck -check-prefix=RV32-V0P7-GOODVERS %s
-// RV32-V0P7-GOODVERS: "-target-feature" "+v0p7"
+// RV32-V0P7-GOODVERS: "-target-feature" "+xtheadv"
 
 // RUN: %clang --target=riscv32-unknown-elf -march=rv32iv1p0_zvl32b0p1 -### %s -c 2>&1 | \
 // RUN:   FileCheck -check-prefix=RV32-ZVL-BADVERS %s

--- a/clang/test/Preprocessor/riscv-target-features.c
+++ b/clang/test/Preprocessor/riscv-target-features.c
@@ -223,13 +223,12 @@
 // CHECK-V-EXT: __riscv_vector 1
 
 // RUN: %clang -target riscv32-unknown-linux-gnu \
-// RUN: -march=rv32iv0p7 -x c -E -dM %s \
+// RUN: -march=rv32i_xtheadv -x c -E -dM %s \
 // RUN: -o - | FileCheck --check-prefix=CHECK-V0P7-EXT %s
 // RUN: %clang -target riscv64-unknown-linux-gnu \
-// RUN: -march=rv64iv0p7 -x c -E -dM %s \
+// RUN: -march=rv64i_xtheadv -x c -E -dM %s \
 // RUN: -o - | FileCheck --check-prefix=CHECK-V0P7-EXT %s
-// CHECK-V0P7-EXT: __riscv_v 7000{{$}}
-// CHECK-V0P7-EXT: __riscv_vector 1
+// CHECK-V0P7-EXT: __riscv_xtheadv 7000{{$}}
 
 // RUN: %clang -target riscv32-unknown-linux-gnu \
 // RUN: -march=rv32izfhmin1p0 -x c -E -dM %s \

--- a/llvm/lib/Support/RISCVISAInfo.cpp
+++ b/llvm/lib/Support/RISCVISAInfo.cpp
@@ -960,6 +960,11 @@ Error RISCVISAInfo::checkDependency() {
     return createStringError(errc::invalid_argument,
                              "'zcf' is only supported for 'rv32'");
 
+  if (Exts.count("xtheadvamo") && !Exts.count("a"))
+    return createStringError(
+        errc::invalid_argument,
+        "'xtheadvamo' requires 'a' extension to also be specified");
+
   // Additional dependency checks.
   // TODO: The 'q' extension requires rv64.
   // TODO: It is illegal to specify 'e' extensions with 'f' and 'd'.
@@ -970,6 +975,7 @@ Error RISCVISAInfo::checkDependency() {
 static const char *ImpliedExtsD[] = {"f"};
 static const char *ImpliedExtsF[] = {"zicsr"};
 static const char *ImpliedExtsV[] = {"zvl128b", "zve64d"};
+static const char *ImpliedExtsXTHeadVamo[] = {"xtheadv"};
 static const char *ImpliedExtsXTHeadVdot[] = {"v"};
 static const char *ImpliedExtsXsfvcp[] = {"zve32x"};
 static const char *ImpliedExtsZacas[] = {"a"};
@@ -1037,6 +1043,7 @@ static constexpr ImpliedExtsEntry ImpliedExts[] = {
     {{"f"}, {ImpliedExtsF}},
     {{"v"}, {ImpliedExtsV}},
     {{"xsfvcp"}, {ImpliedExtsXsfvcp}},
+    {{"xtheadvamo"}, {ImpliedExtsXTHeadVamo}},
     {{"xtheadvdot"}, {ImpliedExtsXTHeadVdot}},
     {{"zacas"}, {ImpliedExtsZacas}},
     {{"zcb"}, {ImpliedExtsZcb}},

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -891,3 +891,36 @@ def FeatureTaggedGlobals : SubtargetFeature<"tagged-globals",
     "AllowTaggedGlobals",
     "true", "Use an instruction sequence for taking the address of a global "
     "that allows a memory tag in the upper address bits">;
+
+//===----------------------------------------------------------------------===//
+// T-Head in RuyiSDK specific features and extensions (mostly rvv 0.7.1)
+//===----------------------------------------------------------------------===//
+
+def FeatureVendorXTHeadV
+    : SubtargetFeature<"xtheadv", "HasVendorXTHeadV", "true",
+                       "'xtheadv' (T-Head Base Vector Instructions)">;
+def HasVendorXTHeadV : Predicate<"Subtarget->hasVendorXTHeadV()">,
+                                  AssemblerPredicate<(all_of FeatureVendorXTHeadV),
+                                  "'xtheadv' (T-Head Base Vector Instructions)">;
+
+def FeatureVendorXTHeadVlsseg
+    : SubtargetFeature<"xtheadvlsseg", "HasVendorXTHeadVlsseg", "true",
+                       "'xtheadvlsseg' (T-Head Vector Load/Store Segment Instructions)">;
+def HasVendorXTHeadVlsseg : Predicate<"Subtarget->hasVendorXTHeadVlsseg()">,
+                                      AssemblerPredicate<(all_of FeatureVendorXTHeadVlsseg),
+                                      "'xtheadvlsseg' (T-Head Vector Load/Store Segment Instructions)">;
+
+def FeatureVendorXTHeadVamo
+    : SubtargetFeature<"xtheadvamo", "HasVendorXTHeadVamo", "true",
+                       "'xtheadvamo' (T-Head Vector AMO Operations)",
+                       [FeatureStdExtA]>;
+def HasVendorXTHeadVamo : Predicate<"Subtarget->hasVendorXTHeadVamo()">,
+                                    AssemblerPredicate<(all_of FeatureVendorXTHeadVamo),
+                                    "'xtheadvamo' (T-Head Vector AMO Operations)">;
+
+def FeatureVendorXTHeadVediv
+    : SubtargetFeature<"xtheadvediv", "HasVendorXTHeadVediv", "true",
+                       "'xtheadvediv' (T-Head Divided Element Extension)">;
+def HasVendorXTHeadVediv : Predicate<"Subtarget->hasVendorXTHeadVediv()">,
+                                     AssemblerPredicate<(all_of FeatureVendorXTHeadVediv),
+                                     "'xtheadvediv' (T-Head Divided Element Extension)">;

--- a/llvm/test/MC/RISCV/attribute-arch.s
+++ b/llvm/test/MC/RISCV/attribute-arch.s
@@ -290,3 +290,16 @@
 
 .attribute arch, "rv32i_xcvmac"
 # CHECK: attribute      5, "rv32i2p1_xcvmac1p0"
+
+.attribute arch, "rv32i_xtheadv"
+# CHECK: attribute      5, "rv32i2p1_xtheadv0p7"
+
+.attribute arch, "rv32i_xtheadv_xtheadvamo_xtheadvediv_xtheadvlsseg"
+# CHECK: attribute      5, "rv32i2p1_xtheadv0p7_xtheadvamo0p7_xtheadvediv0p7_xtheadvlsseg0p7"
+
+.attribute arch, "rv32i_xtheadv"
+# CHECK: attribute      5, "rv32i2p1_xtheadv0p7"
+
+.attribute arch, "rv64i_xtheadv_xtheadvamo_xtheadvediv_xtheadvlsseg"
+# CHECK: attribute      5, "rv64i2p1_xtheadv0p7_xtheadvamo0p7_xtheadvediv0p7_xtheadvlsseg0p7"
+


### PR DESCRIPTION
This PR supersedes #1 by:
- Replaced `v0p7` with `xtheadv` 
- Added `xthead{vamo, vediv, vlsseg}` according to [rvv-0.7.1 spec](https://github.com/riscv/riscv-v-spec/releases/tag/0.7.1).
- Added corresponding features to `RISCVFeatures.td`

Future work:
- Add `RISCVInstrInfoXTheadV.td` for the asm parser/disassembler. This is a huge task, and we might want to cherry-pick some code from https://github.com/Terapines/llvm-project (note: this repo can't be automatically cherry-picked, so some merging work is required)