### PR TITLE
[RVV 0.7.1] reject when both `v` and `xtheadv` are specified

### DIFF
--- a/llvm/lib/Support/RISCVISAInfo.cpp
+++ b/llvm/lib/Support/RISCVISAInfo.cpp
@@ -965,6 +965,11 @@ Error RISCVISAInfo::checkDependency() {
         errc::invalid_argument,
         "'xtheadvamo' requires 'a' extension to also be specified");
 
+  if (Exts.count("xtheadv") && HasVector)
+    return createStringError(
+        errc::invalid_argument,
+        "'xtheadv' extension is incompatible with 'v' or 'zve*' extension");
+
   // Additional dependency checks.
   // TODO: The 'q' extension requires rv64.
   // TODO: It is illegal to specify 'e' extensions with 'f' and 'd'.

--- a/llvm/unittests/Support/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/Support/RISCVISAInfoTest.cpp
@@ -474,6 +474,12 @@ TEST(ParseArchString, RejectsConflictingExtensions) {
     EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
               "'zcf' is only supported for 'rv32'");
   }
+
+  for (StringRef Input : {"rv64iv_xtheadv", "rv32iv_xtheadv"}) {
+    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
+              "'xtheadv' extension is incompatible with "
+              "'v' or 'zve*' extension");
+  }
 }
 
 TEST(ToFeatureVector, IIsDroppedAndExperimentalExtensionsArePrefixed) {


### PR DESCRIPTION
Discovered during porting rvv0.7.1 assembler tests from binutils