### PR TITLE
[RVV 0.7.1] port assembler tests from binutils

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadV.td
@@ -432,8 +432,8 @@ defm XVNMSUB_V : VMAC_MV_V_X<"vnmsub", 0b101011>;
 let Constraints = "@earlyclobber $vd", RVVConstraint = WidenV in {
 defm XVWMACCU_V : VWMAC_MV_V_X<"vwmaccu", 0b111100>;
 defm XVWMACC_V : VWMAC_MV_V_X<"vwmacc", 0b111101>;
-defm XVWMACCSU_V : VWMAC_MV_V_X<"vwmaccsu", 0b111111>;
-defm XVWMACCUS_V : VWMAC_MV_X<"vwmaccus", 0b111110>;
+defm XVWMACCSU_V : VWMAC_MV_V_X<"vwmaccsu", 0b111110>;
+defm XVWMACCUS_V : VWMAC_MV_X<"vwmaccus", 0b111111>;
 } // Constraints = "@earlyclobber $vd", RVVConstraint = WidenV
 
 // Vector Integer Merge Instructions

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadV.td
@@ -164,6 +164,48 @@ multiclass XVNSHT_IV_V_X_I<string opcodestr, bits<6> funct6> {
                   ReadVMask]>;
 }
 
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
+// rvv 0.7.1 set vm=1 for `op vd, vs2, vs1, v0`
+class XVALUmVV<bits<6> funct6, RISCVVFormat opv, string opcodestr>
+    : RVInstVV<funct6, opv, (outs VR:$vd),
+                (ins VR:$vs2, VR:$vs1, VMV0:$v0),
+                opcodestr, "$vd, $vs2, $vs1, v0"> {
+  let vm = 1;
+}
+
+// rvv 0.7.1 set vm=1 for `op vd, vs2, rs1, v0`
+class XVALUmVX<bits<6> funct6, RISCVVFormat opv, string opcodestr>
+    : RVInstVX<funct6, opv, (outs VR:$vd),
+                (ins VR:$vs2, GPR:$rs1, VMV0:$v0),
+                opcodestr, "$vd, $vs2, $rs1, v0"> {
+  let vm = 1;
+}
+
+// rvv 0.7.1 set vm=1 for `op vd, vs2, imm, v0`
+class XVALUmVI<bits<6> funct6, string opcodestr, Operand optype = simm5>
+    : RVInstIVI<funct6, (outs VR:$vd),
+                (ins VR:$vs2, optype:$imm, VMV0:$v0),
+                opcodestr, "$vd, $vs2, $imm, v0"> {
+  let vm = 1;
+}
+
+multiclass XVALUm_IV_V_X<string opcodestr, bits<6> funct6> {
+  def VM : XVALUmVV<funct6, OPIVV, opcodestr # ".vvm">,
+           Sched<[WriteVICALUV_WorstCase, ReadVICALUV_WorstCase,
+                  ReadVICALUV_WorstCase, ReadVMask]>;
+  def XM : XVALUmVX<funct6, OPIVX, opcodestr # ".vxm">,
+           Sched<[WriteVICALUX_WorstCase, ReadVICALUV_WorstCase,
+                  ReadVICALUX_WorstCase, ReadVMask]>;
+}
+
+multiclass XVALUm_IV_V_X_I<string opcodestr, bits<6> funct6>
+    : XVALUm_IV_V_X<opcodestr, funct6> {
+  def IM : XVALUmVI<funct6, opcodestr # ".vim">,
+           Sched<[WriteVICALUI_WorstCase, ReadVICALUV_WorstCase,
+                  ReadVMask]>;
+}
+} // hasSideEffects = 0, mayLoad = 0, mayStore = 0
+
 //===----------------------------------------------------------------------===//
 // Instructions
 //===----------------------------------------------------------------------===//
@@ -314,15 +356,13 @@ defm XVWSUB_W : VALU_MV_V_X<"vwsub", 0b110111, "w">;
 } // Constraints = "@earlyclobber $vd"
 
 // Vector Integer Add-with-Carry / Subtract-with-Borrow Instructions
-defm XVADC_V : VALUm_IV_V_X_I<"vadc", 0b010000>;
+defm XVADC_V : XVALUm_IV_V_X_I<"vadc", 0b010000>;
 let Constraints = "@earlyclobber $vd", RVVConstraint = NoConstraint in {
-defm XVMADC_V : VALUm_IV_V_X_I<"vmadc", 0b010001>;
-defm XVMADC_V : VALUNoVm_IV_V_X_I<"vmadc", 0b010001>;
+defm XVMADC_V : XVALUm_IV_V_X_I<"vmadc", 0b010001>;
 } // Constraints = "@earlyclobber $vd", RVVConstraint = NoConstraint
-defm XVSBC_V : VALUm_IV_V_X<"vsbc", 0b010010>;
+defm XVSBC_V : XVALUm_IV_V_X<"vsbc", 0b010010>;
 let Constraints = "@earlyclobber $vd", RVVConstraint = NoConstraint in {
-defm XVMSBC_V : VALUm_IV_V_X<"vmsbc", 0b010011>;
-defm XVMSBC_V : VALUNoVm_IV_V_X<"vmsbc", 0b010011>;
+defm XVMSBC_V : XVALUm_IV_V_X<"vmsbc", 0b010011>;
 } // Constraints = "@earlyclobber $vd", RVVConstraint = NoConstraint
 
 // Vector Bitwise Logical Instructions

--- a/llvm/test/MC/RISCV/rvv0p71/add.s
+++ b/llvm/test/MC/RISCV/rvv0p71/add.s
@@ -142,78 +142,60 @@ vwadd.wx v8, v4, a0
 
 vadc.vvm v8, v4, v20, v0
 # CHECK-INST: vadc.vvm v8, v4, v20, v0
-# CHECK-ENCODING: [0x57,0x04,0x4a,0x40]
+# CHECK-ENCODING: [0x57,0x04,0x4a,0x42]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 04 4a 40 <unknown>
+# CHECK-UNKNOWN: 57 04 4a 42 <unknown>
 
 vadc.vvm v4, v4, v20, v0
 # CHECK-INST: vadc.vvm v4, v4, v20, v0
-# CHECK-ENCODING: [0x57,0x02,0x4a,0x40]
+# CHECK-ENCODING: [0x57,0x02,0x4a,0x42]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 02 4a 40 <unknown>
+# CHECK-UNKNOWN: 57 02 4a 42 <unknown>
 
 vadc.vvm v8, v4, v8, v0
 # CHECK-INST: vadc.vvm v8, v4, v8, v0
-# CHECK-ENCODING: [0x57,0x04,0x44,0x40]
+# CHECK-ENCODING: [0x57,0x04,0x44,0x42]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 04 44 40 <unknown>
+# CHECK-UNKNOWN: 57 04 44 42 <unknown>
 
 vadc.vxm v8, v4, a0, v0
 # CHECK-INST: vadc.vxm v8, v4, a0, v0
-# CHECK-ENCODING: [0x57,0x44,0x45,0x40]
+# CHECK-ENCODING: [0x57,0x44,0x45,0x42]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 44 45 40 <unknown>
+# CHECK-UNKNOWN: 57 44 45 42 <unknown>
 
 vadc.vim v8, v4, 15, v0
 # CHECK-INST: vadc.vim v8, v4, 15, v0
-# CHECK-ENCODING: [0x57,0xb4,0x47,0x40]
+# CHECK-ENCODING: [0x57,0xb4,0x47,0x42]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 b4 47 40 <unknown>
+# CHECK-UNKNOWN: 57 b4 47 42 <unknown>
 
 vmadc.vvm v8, v4, v20, v0
 # CHECK-INST: vmadc.vvm v8, v4, v20, v0
-# CHECK-ENCODING: [0x57,0x04,0x4a,0x44]
-# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 04 4a 44 <unknown>
-
-vmadc.vvm v4, v4, v20, v0
-# CHECK-INST: vmadc.vvm v4, v4, v20, v0
-# CHECK-ENCODING: [0x57,0x02,0x4a,0x44]
-# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 02 4a 44 <unknown>
-
-vmadc.vvm v8, v4, v8, v0
-# CHECK-INST: vmadc.vvm v8, v4, v8, v0
-# CHECK-ENCODING: [0x57,0x04,0x44,0x44]
-# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 04 44 44 <unknown>
-
-vmadc.vxm v8, v4, a0, v0
-# CHECK-INST: vmadc.vxm v8, v4, a0, v0
-# CHECK-ENCODING: [0x57,0x44,0x45,0x44]
-# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 44 45 44 <unknown>
-
-vmadc.vim v8, v4, 15, v0
-# CHECK-INST: vmadc.vim v8, v4, 15, v0
-# CHECK-ENCODING: [0x57,0xb4,0x47,0x44]
-# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 b4 47 44 <unknown>
-
-vmadc.vv v8, v4, v20
-# CHECK-INST: vmadc.vv v8, v4, v20
 # CHECK-ENCODING: [0x57,0x04,0x4a,0x46]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 04 4a 46 <unknown>
 
-vmadc.vx v8, v4, a0
-# CHECK-INST: vmadc.vx v8, v4, a0
+vmadc.vvm v4, v4, v20, v0
+# CHECK-INST: vmadc.vvm v4, v4, v20, v0
+# CHECK-ENCODING: [0x57,0x02,0x4a,0x46]
+# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
+# CHECK-UNKNOWN: 57 02 4a 46 <unknown>
+
+vmadc.vvm v8, v4, v8, v0
+# CHECK-INST: vmadc.vvm v8, v4, v8, v0
+# CHECK-ENCODING: [0x57,0x04,0x44,0x46]
+# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
+# CHECK-UNKNOWN: 57 04 44 46 <unknown>
+
+vmadc.vxm v8, v4, a0, v0
+# CHECK-INST: vmadc.vxm v8, v4, a0, v0
 # CHECK-ENCODING: [0x57,0x44,0x45,0x46]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 44 45 46 <unknown>
 
-vmadc.vi v8, v4, 15
-# CHECK-INST: vmadc.vi v8, v4, 15
+vmadc.vim v8, v4, 15, v0
+# CHECK-INST: vmadc.vim v8, v4, 15, v0
 # CHECK-ENCODING: [0x57,0xb4,0x47,0x46]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 b4 47 46 <unknown>

--- a/llvm/test/MC/RISCV/rvv0p71/macc.s
+++ b/llvm/test/MC/RISCV/rvv0p71/macc.s
@@ -154,39 +154,39 @@ vwmacc.vx v8, a0, v4
 
 vwmaccsu.vv v8, v20, v4, v0.t
 # CHECK-INST: vwmaccsu.vv v8, v20, v4, v0.t
-# CHECK-ENCODING: [0x57,0x24,0x4a,0xfc]
+# CHECK-ENCODING: [0x57,0x24,0x4a,0xf8]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 24 4a fc <unknown>
+# CHECK-UNKNOWN: 57 24 4a f8 <unknown>
 
 vwmaccsu.vv v8, v20, v4
 # CHECK-INST: vwmaccsu.vv v8, v20, v4
-# CHECK-ENCODING: [0x57,0x24,0x4a,0xfe]
+# CHECK-ENCODING: [0x57,0x24,0x4a,0xfa]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 24 4a fe <unknown>
+# CHECK-UNKNOWN: 57 24 4a fa <unknown>
 
 vwmaccsu.vx v8, a0, v4, v0.t
 # CHECK-INST: vwmaccsu.vx v8, a0, v4, v0.t
-# CHECK-ENCODING: [0x57,0x64,0x45,0xfc]
-# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 64 45 fc <unknown>
-
-vwmaccsu.vx v8, a0, v4
-# CHECK-INST: vwmaccsu.vx v8, a0, v4
-# CHECK-ENCODING: [0x57,0x64,0x45,0xfe]
-# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 64 45 fe <unknown>
-
-vwmaccus.vx v8, a0, v4, v0.t
-# CHECK-INST: vwmaccus.vx v8, a0, v4, v0.t
 # CHECK-ENCODING: [0x57,0x64,0x45,0xf8]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 64 45 f8 <unknown>
 
-vwmaccus.vx v8, a0, v4
-# CHECK-INST: vwmaccus.vx v8, a0, v4
+vwmaccsu.vx v8, a0, v4
+# CHECK-INST: vwmaccsu.vx v8, a0, v4
 # CHECK-ENCODING: [0x57,0x64,0x45,0xfa]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 64 45 fa <unknown>
+
+vwmaccus.vx v8, a0, v4, v0.t
+# CHECK-INST: vwmaccus.vx v8, a0, v4, v0.t
+# CHECK-ENCODING: [0x57,0x64,0x45,0xfc]
+# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
+# CHECK-UNKNOWN: 57 64 45 fc <unknown>
+
+vwmaccus.vx v8, a0, v4
+# CHECK-INST: vwmaccus.vx v8, a0, v4
+# CHECK-ENCODING: [0x57,0x64,0x45,0xfe]
+# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
+# CHECK-UNKNOWN: 57 64 45 fe <unknown>
 
 vwsmaccu.vv v8, v20, v4, v0.t
 # CHECK-INST: vwsmaccu.vv v8, v20, v4, v0.t

--- a/llvm/test/MC/RISCV/rvv0p71/sub.s
+++ b/llvm/test/MC/RISCV/rvv0p71/sub.s
@@ -154,60 +154,48 @@ vwsub.wx v8, v4, a0
 
 vsbc.vvm v8, v4, v20, v0
 # CHECK-INST: vsbc.vvm v8, v4, v20, v0
-# CHECK-ENCODING: [0x57,0x04,0x4a,0x48]
+# CHECK-ENCODING: [0x57,0x04,0x4a,0x4a]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 04 4a 48 <unknown>
+# CHECK-UNKNOWN: 57 04 4a 4a <unknown>
 
 vsbc.vvm v4, v4, v20, v0
 # CHECK-INST: vsbc.vvm v4, v4, v20, v0
-# CHECK-ENCODING: [0x57,0x02,0x4a,0x48]
+# CHECK-ENCODING: [0x57,0x02,0x4a,0x4a]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 02 4a 48 <unknown>
+# CHECK-UNKNOWN: 57 02 4a 4a <unknown>
 
 vsbc.vvm v8, v4, v8, v0
 # CHECK-INST: vsbc.vvm v8, v4, v8, v0
-# CHECK-ENCODING: [0x57,0x04,0x44,0x48]
+# CHECK-ENCODING: [0x57,0x04,0x44,0x4a]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 04 44 48 <unknown>
+# CHECK-UNKNOWN: 57 04 44 4a <unknown>
 
 vsbc.vxm v8, v4, a0, v0
 # CHECK-INST: vsbc.vxm v8, v4, a0, v0
-# CHECK-ENCODING: [0x57,0x44,0x45,0x48]
+# CHECK-ENCODING: [0x57,0x44,0x45,0x4a]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 44 45 48 <unknown>
+# CHECK-UNKNOWN: 57 44 45 4a <unknown>
 
 vmsbc.vvm v8, v4, v20, v0
 # CHECK-INST: vmsbc.vvm v8, v4, v20, v0
-# CHECK-ENCODING: [0x57,0x04,0x4a,0x4c]
-# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 04 4a 4c <unknown>
-
-vmsbc.vvm v4, v4, v20, v0
-# CHECK-INST: vmsbc.vvm v4, v4, v20, v0
-# CHECK-ENCODING: [0x57,0x02,0x4a,0x4c]
-# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 02 4a 4c <unknown>
-
-vmsbc.vvm v8, v4, v8, v0
-# CHECK-INST: vmsbc.vvm v8, v4, v8, v0
-# CHECK-ENCODING: [0x57,0x04,0x44,0x4c]
-# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 04 44 4c <unknown>
-
-vmsbc.vxm v8, v4, a0, v0
-# CHECK-INST: vmsbc.vxm v8, v4, a0, v0
-# CHECK-ENCODING: [0x57,0x44,0x45,0x4c]
-# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
-# CHECK-UNKNOWN: 57 44 45 4c <unknown>
-
-vmsbc.vv v8, v4, v20
-# CHECK-INST: vmsbc.vv v8, v4, v20
 # CHECK-ENCODING: [0x57,0x04,0x4a,0x4e]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 04 4a 4e <unknown>
 
-vmsbc.vx v8, v4, a0
-# CHECK-INST: vmsbc.vx v8, v4, a0
+vmsbc.vvm v4, v4, v20, v0
+# CHECK-INST: vmsbc.vvm v4, v4, v20, v0
+# CHECK-ENCODING: [0x57,0x02,0x4a,0x4e]
+# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
+# CHECK-UNKNOWN: 57 02 4a 4e <unknown>
+
+vmsbc.vvm v8, v4, v8, v0
+# CHECK-INST: vmsbc.vvm v8, v4, v8, v0
+# CHECK-ENCODING: [0x57,0x04,0x44,0x4e]
+# CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
+# CHECK-UNKNOWN: 57 04 44 4e <unknown>
+
+vmsbc.vxm v8, v4, a0, v0
+# CHECK-INST: vmsbc.vxm v8, v4, a0, v0
 # CHECK-ENCODING: [0x57,0x44,0x45,0x4e]
 # CHECK-ERROR: instruction requires the following: 'V' (Vector Extension for Application Processors), 'Zve32x' or 'Zve64x' (Vector Extensions for Embedded Processors){{$}}
 # CHECK-UNKNOWN: 57 44 45 4e <unknown>

--- a/llvm/test/MC/RISCV/rvv0p71/vector-insns.s
+++ b/llvm/test/MC/RISCV/rvv0p71/vector-insns.s
@@ -4490,51 +4490,51 @@ vwsub.wx v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xdc]
 
 vadc.vvm v4, v8, v12, v0
-# CHECK-INST: vadc.vvm v4, v8, v12, v0
+# CHECK-INST: vadc.vvm	v4, v8, v12, v0
 # CHECK-ENCODING: [0x57,0x02,0x86,0x42]
 
 vadc.vxm v4, v8, a1, v0
-# CHECK-INST: vadc.vxm v4, v8, a1, v0
+# CHECK-INST: vadc.vxm	v4, v8, a1, v0
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x42]
 
 vadc.vim v4, v8, 15, v0
-# CHECK-INST: vadc.vim v4, v8, 15, v0
+# CHECK-INST: vadc.vim	v4, v8, 15, v0
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x42]
 
 vadc.vim v4, v8, -16, v0
-# CHECK-INST: vadc.vim v4, v8, -16, v0
+# CHECK-INST: vadc.vim	v4, v8, -16, v0
 # CHECK-ENCODING: [0x57,0x32,0x88,0x42]
 
 vmadc.vvm v4, v8, v12, v0
-# CHECK-INST: vmadc.vvm v4, v8, v12, v0
+# CHECK-INST: vmadc.vvm	v4, v8, v12, v0
 # CHECK-ENCODING: [0x57,0x02,0x86,0x46]
 
 vmadc.vxm v4, v8, a1, v0
-# CHECK-INST: vmadc.vxm v4, v8, a1, v0
+# CHECK-INST: vmadc.vxm	v4, v8, a1, v0
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x46]
 
 vmadc.vim v4, v8, 15, v0
-# CHECK-INST: vmadc.vim v4, v8, 15, v0
+# CHECK-INST: vmadc.vim	v4, v8, 15, v0
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x46]
 
 vmadc.vim v4, v8, -16, v0
-# CHECK-INST: vmadc.vim v4, v8, -16, v0
+# CHECK-INST: vmadc.vim	v4, v8, -16, v0
 # CHECK-ENCODING: [0x57,0x32,0x88,0x46]
 
 vsbc.vvm v4, v8, v12, v0
-# CHECK-INST: vsbc.vvm v4, v8, v12, v0
+# CHECK-INST: vsbc.vvm	v4, v8, v12, v0
 # CHECK-ENCODING: [0x57,0x02,0x86,0x4a]
 
 vsbc.vxm v4, v8, a1, v0
-# CHECK-INST: vsbc.vxm v4, v8, a1, v0
+# CHECK-INST: vsbc.vxm	v4, v8, a1, v0
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x4a]
 
 vmsbc.vvm v4, v8, v12, v0
-# CHECK-INST: vmsbc.vvm v4, v8, v12, v0
+# CHECK-INST: vmsbc.vvm	v4, v8, v12, v0
 # CHECK-ENCODING: [0x57,0x02,0x86,0x4e]
 
 vmsbc.vxm v4, v8, a1, v0
-# CHECK-INST: vmsbc.vxm v4, v8, a1, v0
+# CHECK-INST: vmsbc.vxm	v4, v8, a1, v0
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x4e]
 
 # TODO: rvv 0.7.1
@@ -5404,7 +5404,7 @@ vwmacc.vx v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xf4]
 
 vwmaccsu.vv v4, v12, v8
-# CHECK-INST: vwmaccsu.vv v4, v12, v8
+# CHECK-INST: vwmaccsu.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x22,0x86,0xfa]
 
 vwmaccsu.vx v4, a1, v8
@@ -5412,7 +5412,7 @@ vwmaccsu.vx v4, a1, v8
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xfa]
 
 vwmaccsu.vv v4, v12, v8, v0.t
-# CHECK-INST: vwmaccsu.vv v4, v12, v8, v0.t
+# CHECK-INST: vwmaccsu.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xf8]
 
 vwmaccsu.vx v4, a1, v8, v0.t

--- a/llvm/test/MC/RISCV/rvv0p71/vector-insns.s
+++ b/llvm/test/MC/RISCV/rvv0p71/vector-insns.s
@@ -1014,79 +1014,79 @@ vlseg8eff.v v4, (a0), v0.t
 
 # TODO: rvv 0.7.1 with A
 # vamoaddw.v v4, v8, (a1), v4
-# vamoaddw.v x0, v8, (a1), v4
+# vamoaddw.v zero, v8, (a1), v4
 # vamoaddd.v v4, v8, (a1), v4
-# vamoaddd.v x0, v8, (a1), v4
+# vamoaddd.v zero, v8, (a1), v4
 # vamoaddw.v v4, v8, (a1), v4, v0.t
-# vamoaddw.v x0, v8, (a1), v4, v0.t
+# vamoaddw.v zero, v8, (a1), v4, v0.t
 # vamoaddd.v v4, v8, (a1), v4, v0.t
-# vamoaddd.v x0, v8, (a1), v4, v0.t
+# vamoaddd.v zero, v8, (a1), v4, v0.t
 # vamoswapw.v v4, v8, (a1), v4
-# vamoswapw.v x0, v8, (a1), v4
+# vamoswapw.v zero, v8, (a1), v4
 # vamoswapd.v v4, v8, (a1), v4
-# vamoswapd.v x0, v8, (a1), v4
+# vamoswapd.v zero, v8, (a1), v4
 # vamoswapw.v v4, v8, (a1), v4, v0.t
-# vamoswapw.v x0, v8, (a1), v4, v0.t
+# vamoswapw.v zero, v8, (a1), v4, v0.t
 # vamoswapd.v v4, v8, (a1), v4, v0.t
-# vamoswapd.v x0, v8, (a1), v4, v0.t
+# vamoswapd.v zero, v8, (a1), v4, v0.t
 
 # vamoxorw.v v4, v8, (a1), v4
-# vamoxorw.v x0, v8, (a1), v4
+# vamoxorw.v zero, v8, (a1), v4
 # vamoxord.v v4, v8, (a1), v4
-# vamoxord.v x0, v8, (a1), v4
+# vamoxord.v zero, v8, (a1), v4
 # vamoxorw.v v4, v8, (a1), v4, v0.t
-# vamoxorw.v x0, v8, (a1), v4, v0.t
+# vamoxorw.v zero, v8, (a1), v4, v0.t
 # vamoxord.v v4, v8, (a1), v4, v0.t
-# vamoxord.v x0, v8, (a1), v4, v0.t
+# vamoxord.v zero, v8, (a1), v4, v0.t
 # vamoandw.v v4, v8, (a1), v4
-# vamoandw.v x0, v8, (a1), v4
+# vamoandw.v zero, v8, (a1), v4
 # vamoandd.v v4, v8, (a1), v4
-# vamoandd.v x0, v8, (a1), v4
+# vamoandd.v zero, v8, (a1), v4
 # vamoandw.v v4, v8, (a1), v4, v0.t
-# vamoandw.v x0, v8, (a1), v4, v0.t
+# vamoandw.v zero, v8, (a1), v4, v0.t
 # vamoandd.v v4, v8, (a1), v4, v0.t
-# vamoandd.v x0, v8, (a1), v4, v0.t
+# vamoandd.v zero, v8, (a1), v4, v0.t
 # vamoorw.v v4, v8, (a1), v4
-# vamoorw.v x0, v8, (a1), v4
+# vamoorw.v zero, v8, (a1), v4
 # vamoord.v v4, v8, (a1), v4
-# vamoord.v x0, v8, (a1), v4
+# vamoord.v zero, v8, (a1), v4
 # vamoorw.v v4, v8, (a1), v4, v0.t
-# vamoorw.v x0, v8, (a1), v4, v0.t
+# vamoorw.v zero, v8, (a1), v4, v0.t
 # vamoord.v v4, v8, (a1), v4, v0.t
-# vamoord.v x0, v8, (a1), v4, v0.t
+# vamoord.v zero, v8, (a1), v4, v0.t
 
 # vamominw.v v4, v8, (a1), v4
-# vamominw.v x0, v8, (a1), v4
+# vamominw.v zero, v8, (a1), v4
 # vamomind.v v4, v8, (a1), v4
-# vamomind.v x0, v8, (a1), v4
+# vamomind.v zero, v8, (a1), v4
 # vamominw.v v4, v8, (a1), v4, v0.t
-# vamominw.v x0, v8, (a1), v4, v0.t
+# vamominw.v zero, v8, (a1), v4, v0.t
 # vamomind.v v4, v8, (a1), v4, v0.t
-# vamomind.v x0, v8, (a1), v4, v0.t
+# vamomind.v zero, v8, (a1), v4, v0.t
 # vamomaxw.v v4, v8, (a1), v4
-# vamomaxw.v x0, v8, (a1), v4
+# vamomaxw.v zero, v8, (a1), v4
 # vamomaxd.v v4, v8, (a1), v4
-# vamomaxd.v x0, v8, (a1), v4
+# vamomaxd.v zero, v8, (a1), v4
 # vamomaxw.v v4, v8, (a1), v4, v0.t
-# vamomaxw.v x0, v8, (a1), v4, v0.t
+# vamomaxw.v zero, v8, (a1), v4, v0.t
 # vamomaxd.v v4, v8, (a1), v4, v0.t
-# vamomaxd.v x0, v8, (a1), v4, v0.t
+# vamomaxd.v zero, v8, (a1), v4, v0.t
 # vamominuw.v v4, v8, (a1), v4
-# vamominuw.v x0, v8, (a1), v4
+# vamominuw.v zero, v8, (a1), v4
 # vamominud.v v4, v8, (a1), v4
-# vamominud.v x0, v8, (a1), v4
+# vamominud.v zero, v8, (a1), v4
 # vamominuw.v v4, v8, (a1), v4, v0.t
-# vamominuw.v x0, v8, (a1), v4, v0.t
+# vamominuw.v zero, v8, (a1), v4, v0.t
 # vamominud.v v4, v8, (a1), v4, v0.t
-# vamominud.v x0, v8, (a1), v4, v0.t
+# vamominud.v zero, v8, (a1), v4, v0.t
 # vamomaxuw.v v4, v8, (a1), v4
-# vamomaxuw.v x0, v8, (a1), v4
+# vamomaxuw.v zero, v8, (a1), v4
 # vamomaxud.v v4, v8, (a1), v4
-# vamomaxud.v x0, v8, (a1), v4
+# vamomaxud.v zero, v8, (a1), v4
 # vamomaxuw.v v4, v8, (a1), v4, v0.t
-# vamomaxuw.v x0, v8, (a1), v4, v0.t
+# vamomaxuw.v zero, v8, (a1), v4, v0.t
 # vamomaxud.v v4, v8, (a1), v4, v0.t
-# vamomaxud.v x0, v8, (a1), v4, v0.t
+# vamomaxud.v zero, v8, (a1), v4, v0.t
 
 vadd.vv v4, v8, v12
 vadd.vx v4, v8, a1

--- a/llvm/test/MC/RISCV/rvv0p71/vector-insns.s
+++ b/llvm/test/MC/RISCV/rvv0p71/vector-insns.s
@@ -5408,7 +5408,7 @@ vwmaccsu.vv v4, v12, v8
 # CHECK-ENCODING: [0x57,0x22,0x86,0xfa]
 
 vwmaccsu.vx v4, a1, v8
-# CHECK-INST: vwmaccus.vx	v4, a1, v8
+# CHECK-INST: vwmaccsu.vx	v4, a1, v8
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xfa]
 
 vwmaccsu.vv v4, v12, v8, v0.t
@@ -5416,15 +5416,15 @@ vwmaccsu.vv v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xf8]
 
 vwmaccsu.vx v4, a1, v8, v0.t
-# CHECK-INST: vwmaccus.vx	v4, a1, v8, v0.t
+# CHECK-INST: vwmaccsu.vx	v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xf8]
 
 vwmaccus.vx v4, a1, v8
-# CHECK-INST: vwmaccsu.vx	v4, a1, v8
+# CHECK-INST: vwmaccus.vx	v4, a1, v8
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xfe]
 
 vwmaccus.vx v4, a1, v8, v0.t
-# CHECK-INST: vwmaccsu.vx	v4, a1, v8, v0.t
+# CHECK-INST: vwmaccus.vx	v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xfc]
 
 vdivu.vv v4, v8, v12

--- a/llvm/test/MC/RISCV/rvv0p71/vector-insns.s
+++ b/llvm/test/MC/RISCV/rvv0p71/vector-insns.s
@@ -1,1263 +1,4930 @@
 # Adapted from https://github.com/riscvarchive/riscv-binutils-gdb/blob/1aeeeab05f3c39e2bfc6e99384490d4c7f484ba0/gas/testsuite/gas/riscv/vector-insns.s
+# Golden value for this test: https://github.com/riscvarchive/riscv-binutils-gdb/blob/1aeeeab05f3c39e2bfc6e99384490d4c7f484ba0/gas/testsuite/gas/riscv/vector-insns.d
+# Generated using the script: https://gist.github.com/imkiva/05facf1a51ff8abfeeeea8fa7bc307ad#file-rvvtestgen-java
 
 # RUN: llvm-mc -triple=riscv64 -show-encoding --mattr=+f,+a,+xtheadv,+xtheadvlsseg,+xtheadvamo %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 vsetvl a0, a1, a2
+# CHECK-INST: vsetvl a0, a1, a2
+# CHECK-ENCODING: [0x57,0xf5,0xc5,0x80]
+
 vsetvli a0, a1, 0
+# CHECK-INST: vsetvli a0, a1, 0
+# CHECK-ENCODING: [0x57,0xf5,0x05,0x00]
+
 vsetvli a0, a1, 0x7ff
+# CHECK-INST: vsetvli a0, a1, 0x7ff
+# CHECK-ENCODING: [0x57,0xf5,0xf5,0x7f]
+
 vsetvli a0, a1, e16,m2,d4
+# CHECK-INST: vsetvli a0, a1, e16,m2,d4
+# CHECK-ENCODING: [0x57,0xf5,0x55,0x04]
 
 vlb.v v4, (a0)
+# CHECK-INST: vlb.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x12]
+
 vlb.v v4, 0(a0)
+# CHECK-INST: vlb.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x12]
+
 vlb.v v4, (a0), v0.t
+# CHECK-INST: vlb.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x10]
+
 vlh.v v4, (a0)
+# CHECK-INST: vlh.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x12]
+
 vlh.v v4, 0(a0)
+# CHECK-INST: vlh.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x12]
+
 vlh.v v4, (a0), v0.t
+# CHECK-INST: vlh.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x10]
+
 vlw.v v4, (a0)
+# CHECK-INST: vlw.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x12]
+
 vlw.v v4, 0(a0)
+# CHECK-INST: vlw.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x12]
+
 vlw.v v4, (a0), v0.t
+# CHECK-INST: vlw.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x10]
+
 vlbu.v v4, (a0)
+# CHECK-INST: vlbu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x02]
+
 vlbu.v v4, 0(a0)
+# CHECK-INST: vlbu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x02]
+
 vlbu.v v4, (a0), v0.t
+# CHECK-INST: vlbu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x00]
+
 vlhu.v v4, (a0)
+# CHECK-INST: vlhu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x02]
+
 vlhu.v v4, 0(a0)
+# CHECK-INST: vlhu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x02]
+
 vlhu.v v4, (a0), v0.t
+# CHECK-INST: vlhu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x00]
+
 vlwu.v v4, (a0)
+# CHECK-INST: vlwu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x02]
+
 vlwu.v v4, 0(a0)
+# CHECK-INST: vlwu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x02]
+
 vlwu.v v4, (a0), v0.t
+# CHECK-INST: vlwu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x00]
+
 vle.v v4, (a0)
+# CHECK-INST: vle.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x02]
+
 vle.v v4, 0(a0)
+# CHECK-INST: vle.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x02]
+
 vle.v v4, (a0), v0.t
+# CHECK-INST: vle.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0x00]
+
 vsb.v v4, (a0)
+# CHECK-INST: vsb.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0x02]
+
 vsb.v v4, 0(a0)
+# CHECK-INST: vsb.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0x02]
+
 vsb.v v4, (a0), v0.t
+# CHECK-INST: vsb.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x02,0x05,0x00]
+
 vsh.v v4, (a0)
+# CHECK-INST: vsh.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0x02]
+
 vsh.v v4, 0(a0)
+# CHECK-INST: vsh.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0x02]
+
 vsh.v v4, (a0), v0.t
+# CHECK-INST: vsh.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x52,0x05,0x00]
+
 vsw.v v4, (a0)
+# CHECK-INST: vsw.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0x02]
+
 vsw.v v4, 0(a0)
+# CHECK-INST: vsw.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0x02]
+
 vsw.v v4, (a0), v0.t
+# CHECK-INST: vsw.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x62,0x05,0x00]
+
 vse.v v4, (a0)
+# CHECK-INST: vse.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0x02]
+
 vse.v v4, 0(a0)
+# CHECK-INST: vse.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0x02]
+
 vse.v v4, (a0), v0.t
+# CHECK-INST: vse.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x72,0x05,0x00]
 
 vlsb.v v4, (a0), a1
+# CHECK-INST: vlsb.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x1a]
+
 vlsb.v v4, 0(a0), a1
+# CHECK-INST: vlsb.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x1a]
+
 vlsb.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsb.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x18]
+
 vlsh.v v4, (a0), a1
+# CHECK-INST: vlsh.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x1a]
+
 vlsh.v v4, 0(a0), a1
+# CHECK-INST: vlsh.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x1a]
+
 vlsh.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsh.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x18]
+
 vlsw.v v4, (a0), a1
+# CHECK-INST: vlsw.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x1a]
+
 vlsw.v v4, 0(a0), a1
+# CHECK-INST: vlsw.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x1a]
+
 vlsw.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsw.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x18]
+
 vlsbu.v v4, (a0), a1
+# CHECK-INST: vlsbu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x0a]
+
 vlsbu.v v4, 0(a0), a1
+# CHECK-INST: vlsbu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x0a]
+
 vlsbu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsbu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x08]
+
 vlshu.v v4, (a0), a1
+# CHECK-INST: vlshu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x0a]
+
 vlshu.v v4, 0(a0), a1
+# CHECK-INST: vlshu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x0a]
+
 vlshu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlshu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x08]
+
 vlswu.v v4, (a0), a1
+# CHECK-INST: vlswu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x0a]
+
 vlswu.v v4, 0(a0), a1
+# CHECK-INST: vlswu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x0a]
+
 vlswu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlswu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x08]
+
 vlse.v v4, (a0), a1
+# CHECK-INST: vlse.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x0a]
+
 vlse.v v4, 0(a0), a1
+# CHECK-INST: vlse.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x0a]
+
 vlse.v v4, (a0), a1, v0.t
+# CHECK-INST: vlse.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x08]
+
 vssb.v v4, (a0), a1
+# CHECK-INST: vssb.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x0a]
+
 vssb.v v4, 0(a0), a1
+# CHECK-INST: vssb.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x0a]
+
 vssb.v v4, (a0), a1, v0.t
+# CHECK-INST: vssb.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x08]
+
 vssh.v v4, (a0), a1
+# CHECK-INST: vssh.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x0a]
+
 vssh.v v4, 0(a0), a1
+# CHECK-INST: vssh.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x0a]
+
 vssh.v v4, (a0), a1, v0.t
+# CHECK-INST: vssh.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x08]
+
 vssw.v v4, (a0), a1
+# CHECK-INST: vssw.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x0a]
+
 vssw.v v4, 0(a0), a1
+# CHECK-INST: vssw.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x0a]
+
 vssw.v v4, (a0), a1, v0.t
+# CHECK-INST: vssw.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x08]
+
 vsse.v v4, (a0), a1
+# CHECK-INST: vsse.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x0a]
+
 vsse.v v4, 0(a0), a1
+# CHECK-INST: vsse.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x0a]
+
 vsse.v v4, (a0), a1, v0.t
+# CHECK-INST: vsse.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x08]
 
 vlxb.v v4, (a0), v12
+# CHECK-INST: vlxb.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x1e]
+
 vlxb.v v4, 0(a0), v12
+# CHECK-INST: vlxb.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x1e]
+
 vlxb.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxb.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x1c]
+
 vlxh.v v4, (a0), v12
+# CHECK-INST: vlxh.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x1e]
+
 vlxh.v v4, 0(a0), v12
+# CHECK-INST: vlxh.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x1e]
+
 vlxh.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxh.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x1c]
+
 vlxw.v v4, (a0), v12
+# CHECK-INST: vlxw.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x1e]
+
 vlxw.v v4, 0(a0), v12
+# CHECK-INST: vlxw.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x1e]
+
 vlxw.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxw.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x1c]
+
 vlxbu.v v4, (a0), v12
+# CHECK-INST: vlxbu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x0e]
+
 vlxbu.v v4, 0(a0), v12
+# CHECK-INST: vlxbu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x0e]
+
 vlxbu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxbu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x0c]
+
 vlxhu.v v4, (a0), v12
+# CHECK-INST: vlxhu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x0e]
+
 vlxhu.v v4, 0(a0), v12
+# CHECK-INST: vlxhu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x0e]
+
 vlxhu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxhu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x0c]
+
 vlxwu.v v4, (a0), v12
+# CHECK-INST: vlxwu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x0e]
+
 vlxwu.v v4, 0(a0), v12
+# CHECK-INST: vlxwu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x0e]
+
 vlxwu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxwu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x0c]
+
 vlxe.v v4, (a0), v12
+# CHECK-INST: vlxe.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x0e]
+
 vlxe.v v4, 0(a0), v12
+# CHECK-INST: vlxe.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x0e]
+
 vlxe.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxe.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x0c]
+
 vsxb.v v4, (a0), v12
+# CHECK-INST: vsxb.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x0e]
+
 vsxb.v v4, 0(a0), v12
+# CHECK-INST: vsxb.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x0e]
+
 vsxb.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxb.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x0c]
+
 vsxh.v v4, (a0), v12
+# CHECK-INST: vsxh.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x0e]
+
 vsxh.v v4, 0(a0), v12
+# CHECK-INST: vsxh.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x0e]
+
 vsxh.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxh.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x0c]
+
 vsxw.v v4, (a0), v12
+# CHECK-INST: vsxw.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x0e]
+
 vsxw.v v4, 0(a0), v12
+# CHECK-INST: vsxw.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x0e]
+
 vsxw.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxw.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x0c]
+
 vsxe.v v4, (a0), v12
+# CHECK-INST: vsxe.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x0e]
+
 vsxe.v v4, 0(a0), v12
+# CHECK-INST: vsxe.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x0e]
+
 vsxe.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxe.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x0c]
+
 vsuxb.v v4, (a0), v12
+# CHECK-INST: vsuxb.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x1e]
+
 vsuxb.v v4, 0(a0), v12
+# CHECK-INST: vsuxb.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x1e]
+
 vsuxb.v v4, (a0), v12, v0.t
+# CHECK-INST: vsuxb.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x1c]
+
 vsuxh.v v4, (a0), v12
+# CHECK-INST: vsuxh.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x1e]
+
 vsuxh.v v4, 0(a0), v12
+# CHECK-INST: vsuxh.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x1e]
+
 vsuxh.v v4, (a0), v12, v0.t
+# CHECK-INST: vsuxh.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x1c]
+
 vsuxw.v v4, (a0), v12
+# CHECK-INST: vsuxw.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x1e]
+
 vsuxw.v v4, 0(a0), v12
+# CHECK-INST: vsuxw.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x1e]
+
 vsuxw.v v4, (a0), v12, v0.t
+# CHECK-INST: vsuxw.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x1c]
+
 vsuxe.v v4, (a0), v12
+# CHECK-INST: vsuxe.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x1e]
+
 vsuxe.v v4, 0(a0), v12
+# CHECK-INST: vsuxe.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x1e]
+
 vsuxe.v v4, (a0), v12, v0.t
+# CHECK-INST: vsuxe.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x1c]
 
 vlbff.v v4, (a0)
+# CHECK-INST: vlbff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x13]
+
 vlbff.v v4, 0(a0)
+# CHECK-INST: vlbff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x13]
+
 vlbff.v v4, (a0), v0.t
+# CHECK-INST: vlbff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x11]
+
 vlhff.v v4, (a0)
+# CHECK-INST: vlhff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x13]
+
 vlhff.v v4, 0(a0)
+# CHECK-INST: vlhff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x13]
+
 vlhff.v v4, (a0), v0.t
+# CHECK-INST: vlhff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x11]
+
 vlwff.v v4, (a0)
+# CHECK-INST: vlwff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x13]
+
 vlwff.v v4, 0(a0)
+# CHECK-INST: vlwff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x13]
+
 vlwff.v v4, (a0), v0.t
+# CHECK-INST: vlwff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x11]
+
 vlbuff.v v4, (a0)
+# CHECK-INST: vlbuff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x03]
+
 vlbuff.v v4, 0(a0)
+# CHECK-INST: vlbuff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x03]
+
 vlbuff.v v4, (a0), v0.t
+# CHECK-INST: vlbuff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x01]
+
 vlhuff.v v4, (a0)
+# CHECK-INST: vlhuff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x03]
+
 vlhuff.v v4, 0(a0)
+# CHECK-INST: vlhuff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x03]
+
 vlhuff.v v4, (a0), v0.t
+# CHECK-INST: vlhuff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x01]
+
 vlwuff.v v4, (a0)
+# CHECK-INST: vlwuff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x03]
+
 vlwuff.v v4, 0(a0)
+# CHECK-INST: vlwuff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x03]
+
 vlwuff.v v4, (a0), v0.t
+# CHECK-INST: vlwuff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x01]
+
 vleff.v v4, (a0)
+# CHECK-INST: vleff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x03]
+
 vleff.v v4, 0(a0)
+# CHECK-INST: vleff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x03]
+
 vleff.v v4, (a0), v0.t
+# CHECK-INST: vleff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0x01]
 
 vlseg2b.v v4, (a0)
+# CHECK-INST: vlseg2b.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x32]
+
 vlseg2b.v v4, 0(a0)
+# CHECK-INST: vlseg2b.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x32]
+
 vlseg2b.v v4, (a0), v0.t
+# CHECK-INST: vlseg2b.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x30]
+
 vlseg2h.v v4, (a0)
+# CHECK-INST: vlseg2h.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x32]
+
 vlseg2h.v v4, 0(a0)
+# CHECK-INST: vlseg2h.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x32]
+
 vlseg2h.v v4, (a0), v0.t
+# CHECK-INST: vlseg2h.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x30]
+
 vlseg2w.v v4, (a0)
+# CHECK-INST: vlseg2w.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x32]
+
 vlseg2w.v v4, 0(a0)
+# CHECK-INST: vlseg2w.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x32]
+
 vlseg2w.v v4, (a0), v0.t
+# CHECK-INST: vlseg2w.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x30]
+
 vlseg2bu.v v4, (a0)
+# CHECK-INST: vlseg2bu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x22]
+
 vlseg2bu.v v4, 0(a0)
+# CHECK-INST: vlseg2bu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x22]
+
 vlseg2bu.v v4, (a0), v0.t
+# CHECK-INST: vlseg2bu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x20]
+
 vlseg2hu.v v4, (a0)
+# CHECK-INST: vlseg2hu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x22]
+
 vlseg2hu.v v4, 0(a0)
+# CHECK-INST: vlseg2hu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x22]
+
 vlseg2hu.v v4, (a0), v0.t
+# CHECK-INST: vlseg2hu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x20]
+
 vlseg2wu.v v4, (a0)
+# CHECK-INST: vlseg2wu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x22]
+
 vlseg2wu.v v4, 0(a0)
+# CHECK-INST: vlseg2wu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x22]
+
 vlseg2wu.v v4, (a0), v0.t
+# CHECK-INST: vlseg2wu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x20]
+
 vlseg2e.v v4, (a0)
+# CHECK-INST: vlseg2e.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x22]
+
 vlseg2e.v v4, 0(a0)
+# CHECK-INST: vlseg2e.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x22]
+
 vlseg2e.v v4, (a0), v0.t
+# CHECK-INST: vlseg2e.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0x20]
+
 vsseg2b.v v4, (a0)
+# CHECK-INST: vsseg2b.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0x22]
+
 vsseg2b.v v4, 0(a0)
+# CHECK-INST: vsseg2b.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0x22]
+
 vsseg2b.v v4, (a0), v0.t
+# CHECK-INST: vsseg2b.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x02,0x05,0x20]
+
 vsseg2h.v v4, (a0)
+# CHECK-INST: vsseg2h.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0x22]
+
 vsseg2h.v v4, 0(a0)
+# CHECK-INST: vsseg2h.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0x22]
+
 vsseg2h.v v4, (a0), v0.t
+# CHECK-INST: vsseg2h.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x52,0x05,0x20]
+
 vsseg2w.v v4, (a0)
+# CHECK-INST: vsseg2w.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0x22]
+
 vsseg2w.v v4, 0(a0)
+# CHECK-INST: vsseg2w.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0x22]
+
 vsseg2w.v v4, (a0), v0.t
+# CHECK-INST: vsseg2w.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x62,0x05,0x20]
+
 vsseg2e.v v4, (a0)
+# CHECK-INST: vsseg2e.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0x22]
+
 vsseg2e.v v4, 0(a0)
+# CHECK-INST: vsseg2e.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0x22]
+
 vsseg2e.v v4, (a0), v0.t
+# CHECK-INST: vsseg2e.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x72,0x05,0x20]
 
 vlseg3b.v v4, (a0)
+# CHECK-INST: vlseg3b.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x52]
+
 vlseg3b.v v4, 0(a0)
+# CHECK-INST: vlseg3b.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x52]
+
 vlseg3b.v v4, (a0), v0.t
+# CHECK-INST: vlseg3b.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x50]
+
 vlseg3h.v v4, (a0)
+# CHECK-INST: vlseg3h.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x52]
+
 vlseg3h.v v4, 0(a0)
+# CHECK-INST: vlseg3h.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x52]
+
 vlseg3h.v v4, (a0), v0.t
+# CHECK-INST: vlseg3h.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x50]
+
 vlseg3w.v v4, (a0)
+# CHECK-INST: vlseg3w.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x52]
+
 vlseg3w.v v4, 0(a0)
+# CHECK-INST: vlseg3w.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x52]
+
 vlseg3w.v v4, (a0), v0.t
+# CHECK-INST: vlseg3w.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x50]
+
 vlseg3bu.v v4, (a0)
+# CHECK-INST: vlseg3bu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x42]
+
 vlseg3bu.v v4, 0(a0)
+# CHECK-INST: vlseg3bu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x42]
+
 vlseg3bu.v v4, (a0), v0.t
+# CHECK-INST: vlseg3bu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x40]
+
 vlseg3hu.v v4, (a0)
+# CHECK-INST: vlseg3hu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x42]
+
 vlseg3hu.v v4, 0(a0)
+# CHECK-INST: vlseg3hu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x42]
+
 vlseg3hu.v v4, (a0), v0.t
+# CHECK-INST: vlseg3hu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x40]
+
 vlseg3wu.v v4, (a0)
+# CHECK-INST: vlseg3wu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x42]
+
 vlseg3wu.v v4, 0(a0)
+# CHECK-INST: vlseg3wu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x42]
+
 vlseg3wu.v v4, (a0), v0.t
+# CHECK-INST: vlseg3wu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x40]
+
 vlseg3e.v v4, (a0)
+# CHECK-INST: vlseg3e.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x42]
+
 vlseg3e.v v4, 0(a0)
+# CHECK-INST: vlseg3e.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x42]
+
 vlseg3e.v v4, (a0), v0.t
+# CHECK-INST: vlseg3e.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0x40]
+
 vsseg3b.v v4, (a0)
+# CHECK-INST: vsseg3b.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0x42]
+
 vsseg3b.v v4, 0(a0)
+# CHECK-INST: vsseg3b.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0x42]
+
 vsseg3b.v v4, (a0), v0.t
+# CHECK-INST: vsseg3b.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x02,0x05,0x40]
+
 vsseg3h.v v4, (a0)
+# CHECK-INST: vsseg3h.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0x42]
+
 vsseg3h.v v4, 0(a0)
+# CHECK-INST: vsseg3h.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0x42]
+
 vsseg3h.v v4, (a0), v0.t
+# CHECK-INST: vsseg3h.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x52,0x05,0x40]
+
 vsseg3w.v v4, (a0)
+# CHECK-INST: vsseg3w.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0x42]
+
 vsseg3w.v v4, 0(a0)
+# CHECK-INST: vsseg3w.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0x42]
+
 vsseg3w.v v4, (a0), v0.t
+# CHECK-INST: vsseg3w.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x62,0x05,0x40]
+
 vsseg3e.v v4, (a0)
+# CHECK-INST: vsseg3e.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0x42]
+
 vsseg3e.v v4, 0(a0)
+# CHECK-INST: vsseg3e.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0x42]
+
 vsseg3e.v v4, (a0), v0.t
+# CHECK-INST: vsseg3e.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x72,0x05,0x40]
 
 vlseg4b.v v4, (a0)
+# CHECK-INST: vlseg4b.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x72]
+
 vlseg4b.v v4, 0(a0)
+# CHECK-INST: vlseg4b.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x72]
+
 vlseg4b.v v4, (a0), v0.t
+# CHECK-INST: vlseg4b.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x70]
+
 vlseg4h.v v4, (a0)
+# CHECK-INST: vlseg4h.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x72]
+
 vlseg4h.v v4, 0(a0)
+# CHECK-INST: vlseg4h.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x72]
+
 vlseg4h.v v4, (a0), v0.t
+# CHECK-INST: vlseg4h.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x70]
+
 vlseg4w.v v4, (a0)
+# CHECK-INST: vlseg4w.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x72]
+
 vlseg4w.v v4, 0(a0)
+# CHECK-INST: vlseg4w.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x72]
+
 vlseg4w.v v4, (a0), v0.t
+# CHECK-INST: vlseg4w.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x70]
+
 vlseg4bu.v v4, (a0)
+# CHECK-INST: vlseg4bu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x62]
+
 vlseg4bu.v v4, 0(a0)
+# CHECK-INST: vlseg4bu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x62]
+
 vlseg4bu.v v4, (a0), v0.t
+# CHECK-INST: vlseg4bu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x60]
+
 vlseg4hu.v v4, (a0)
+# CHECK-INST: vlseg4hu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x62]
+
 vlseg4hu.v v4, 0(a0)
+# CHECK-INST: vlseg4hu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x62]
+
 vlseg4hu.v v4, (a0), v0.t
+# CHECK-INST: vlseg4hu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x60]
+
 vlseg4wu.v v4, (a0)
+# CHECK-INST: vlseg4wu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x62]
+
 vlseg4wu.v v4, 0(a0)
+# CHECK-INST: vlseg4wu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x62]
+
 vlseg4wu.v v4, (a0), v0.t
+# CHECK-INST: vlseg4wu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x60]
+
 vlseg4e.v v4, (a0)
+# CHECK-INST: vlseg4e.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x62]
+
 vlseg4e.v v4, 0(a0)
+# CHECK-INST: vlseg4e.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x62]
+
 vlseg4e.v v4, (a0), v0.t
+# CHECK-INST: vlseg4e.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0x60]
+
 vsseg4b.v v4, (a0)
+# CHECK-INST: vsseg4b.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0x62]
+
 vsseg4b.v v4, 0(a0)
+# CHECK-INST: vsseg4b.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0x62]
+
 vsseg4b.v v4, (a0), v0.t
+# CHECK-INST: vsseg4b.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x02,0x05,0x60]
+
 vsseg4h.v v4, (a0)
+# CHECK-INST: vsseg4h.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0x62]
+
 vsseg4h.v v4, 0(a0)
+# CHECK-INST: vsseg4h.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0x62]
+
 vsseg4h.v v4, (a0), v0.t
+# CHECK-INST: vsseg4h.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x52,0x05,0x60]
+
 vsseg4w.v v4, (a0)
+# CHECK-INST: vsseg4w.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0x62]
+
 vsseg4w.v v4, 0(a0)
+# CHECK-INST: vsseg4w.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0x62]
+
 vsseg4w.v v4, (a0), v0.t
+# CHECK-INST: vsseg4w.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x62,0x05,0x60]
+
 vsseg4e.v v4, (a0)
+# CHECK-INST: vsseg4e.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0x62]
+
 vsseg4e.v v4, 0(a0)
+# CHECK-INST: vsseg4e.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0x62]
+
 vsseg4e.v v4, (a0), v0.t
+# CHECK-INST: vsseg4e.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x72,0x05,0x60]
 
 vlseg5b.v v4, (a0)
+# CHECK-INST: vlseg5b.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x92]
+
 vlseg5b.v v4, 0(a0)
+# CHECK-INST: vlseg5b.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x92]
+
 vlseg5b.v v4, (a0), v0.t
+# CHECK-INST: vlseg5b.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x90]
+
 vlseg5h.v v4, (a0)
+# CHECK-INST: vlseg5h.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x92]
+
 vlseg5h.v v4, 0(a0)
+# CHECK-INST: vlseg5h.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x92]
+
 vlseg5h.v v4, (a0), v0.t
+# CHECK-INST: vlseg5h.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x90]
+
 vlseg5w.v v4, (a0)
+# CHECK-INST: vlseg5w.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x92]
+
 vlseg5w.v v4, 0(a0)
+# CHECK-INST: vlseg5w.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x92]
+
 vlseg5w.v v4, (a0), v0.t
+# CHECK-INST: vlseg5w.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x90]
+
 vlseg5bu.v v4, (a0)
+# CHECK-INST: vlseg5bu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x82]
+
 vlseg5bu.v v4, 0(a0)
+# CHECK-INST: vlseg5bu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x82]
+
 vlseg5bu.v v4, (a0), v0.t
+# CHECK-INST: vlseg5bu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x80]
+
 vlseg5hu.v v4, (a0)
+# CHECK-INST: vlseg5hu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x82]
+
 vlseg5hu.v v4, 0(a0)
+# CHECK-INST: vlseg5hu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x82]
+
 vlseg5hu.v v4, (a0), v0.t
+# CHECK-INST: vlseg5hu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x80]
+
 vlseg5wu.v v4, (a0)
+# CHECK-INST: vlseg5wu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x82]
+
 vlseg5wu.v v4, 0(a0)
+# CHECK-INST: vlseg5wu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x82]
+
 vlseg5wu.v v4, (a0), v0.t
+# CHECK-INST: vlseg5wu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x80]
+
 vlseg5e.v v4, (a0)
+# CHECK-INST: vlseg5e.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x82]
+
 vlseg5e.v v4, 0(a0)
+# CHECK-INST: vlseg5e.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x82]
+
 vlseg5e.v v4, (a0), v0.t
+# CHECK-INST: vlseg5e.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0x80]
+
 vsseg5b.v v4, (a0)
+# CHECK-INST: vsseg5b.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0x82]
+
 vsseg5b.v v4, 0(a0)
+# CHECK-INST: vsseg5b.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0x82]
+
 vsseg5b.v v4, (a0), v0.t
+# CHECK-INST: vsseg5b.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x02,0x05,0x80]
+
 vsseg5h.v v4, (a0)
+# CHECK-INST: vsseg5h.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0x82]
+
 vsseg5h.v v4, 0(a0)
+# CHECK-INST: vsseg5h.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0x82]
+
 vsseg5h.v v4, (a0), v0.t
+# CHECK-INST: vsseg5h.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x52,0x05,0x80]
+
 vsseg5w.v v4, (a0)
+# CHECK-INST: vsseg5w.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0x82]
+
 vsseg5w.v v4, 0(a0)
+# CHECK-INST: vsseg5w.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0x82]
+
 vsseg5w.v v4, (a0), v0.t
+# CHECK-INST: vsseg5w.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x62,0x05,0x80]
+
 vsseg5e.v v4, (a0)
+# CHECK-INST: vsseg5e.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0x82]
+
 vsseg5e.v v4, 0(a0)
+# CHECK-INST: vsseg5e.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0x82]
+
 vsseg5e.v v4, (a0), v0.t
+# CHECK-INST: vsseg5e.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x72,0x05,0x80]
 
 vlseg6b.v v4, (a0)
+# CHECK-INST: vlseg6b.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xb2]
+
 vlseg6b.v v4, 0(a0)
+# CHECK-INST: vlseg6b.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xb2]
+
 vlseg6b.v v4, (a0), v0.t
+# CHECK-INST: vlseg6b.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0xb0]
+
 vlseg6h.v v4, (a0)
+# CHECK-INST: vlseg6h.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xb2]
+
 vlseg6h.v v4, 0(a0)
+# CHECK-INST: vlseg6h.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xb2]
+
 vlseg6h.v v4, (a0), v0.t
+# CHECK-INST: vlseg6h.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0xb0]
+
 vlseg6w.v v4, (a0)
+# CHECK-INST: vlseg6w.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xb2]
+
 vlseg6w.v v4, 0(a0)
+# CHECK-INST: vlseg6w.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xb2]
+
 vlseg6w.v v4, (a0), v0.t
+# CHECK-INST: vlseg6w.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0xb0]
+
 vlseg6bu.v v4, (a0)
+# CHECK-INST: vlseg6bu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xa2]
+
 vlseg6bu.v v4, 0(a0)
+# CHECK-INST: vlseg6bu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xa2]
+
 vlseg6bu.v v4, (a0), v0.t
+# CHECK-INST: vlseg6bu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0xa0]
+
 vlseg6hu.v v4, (a0)
+# CHECK-INST: vlseg6hu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xa2]
+
 vlseg6hu.v v4, 0(a0)
+# CHECK-INST: vlseg6hu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xa2]
+
 vlseg6hu.v v4, (a0), v0.t
+# CHECK-INST: vlseg6hu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0xa0]
+
 vlseg6wu.v v4, (a0)
+# CHECK-INST: vlseg6wu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xa2]
+
 vlseg6wu.v v4, 0(a0)
+# CHECK-INST: vlseg6wu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xa2]
+
 vlseg6wu.v v4, (a0), v0.t
+# CHECK-INST: vlseg6wu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0xa0]
+
 vlseg6e.v v4, (a0)
+# CHECK-INST: vlseg6e.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0xa2]
+
 vlseg6e.v v4, 0(a0)
+# CHECK-INST: vlseg6e.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0xa2]
+
 vlseg6e.v v4, (a0), v0.t
+# CHECK-INST: vlseg6e.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0xa0]
+
 vsseg6b.v v4, (a0)
+# CHECK-INST: vsseg6b.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0xa2]
+
 vsseg6b.v v4, 0(a0)
+# CHECK-INST: vsseg6b.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0xa2]
+
 vsseg6b.v v4, (a0), v0.t
+# CHECK-INST: vsseg6b.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x02,0x05,0xa0]
+
 vsseg6h.v v4, (a0)
+# CHECK-INST: vsseg6h.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0xa2]
+
 vsseg6h.v v4, 0(a0)
+# CHECK-INST: vsseg6h.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0xa2]
+
 vsseg6h.v v4, (a0), v0.t
+# CHECK-INST: vsseg6h.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x52,0x05,0xa0]
+
 vsseg6w.v v4, (a0)
+# CHECK-INST: vsseg6w.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0xa2]
+
 vsseg6w.v v4, 0(a0)
+# CHECK-INST: vsseg6w.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0xa2]
+
 vsseg6w.v v4, (a0), v0.t
+# CHECK-INST: vsseg6w.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x62,0x05,0xa0]
+
 vsseg6e.v v4, (a0)
+# CHECK-INST: vsseg6e.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0xa2]
+
 vsseg6e.v v4, 0(a0)
+# CHECK-INST: vsseg6e.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0xa2]
+
 vsseg6e.v v4, (a0), v0.t
+# CHECK-INST: vsseg6e.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x72,0x05,0xa0]
 
 vlseg7b.v v4, (a0)
+# CHECK-INST: vlseg7b.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xd2]
+
 vlseg7b.v v4, 0(a0)
+# CHECK-INST: vlseg7b.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xd2]
+
 vlseg7b.v v4, (a0), v0.t
+# CHECK-INST: vlseg7b.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0xd0]
+
 vlseg7h.v v4, (a0)
+# CHECK-INST: vlseg7h.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xd2]
+
 vlseg7h.v v4, 0(a0)
+# CHECK-INST: vlseg7h.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xd2]
+
 vlseg7h.v v4, (a0), v0.t
+# CHECK-INST: vlseg7h.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0xd0]
+
 vlseg7w.v v4, (a0)
+# CHECK-INST: vlseg7w.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xd2]
+
 vlseg7w.v v4, 0(a0)
+# CHECK-INST: vlseg7w.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xd2]
+
 vlseg7w.v v4, (a0), v0.t
+# CHECK-INST: vlseg7w.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0xd0]
+
 vlseg7bu.v v4, (a0)
+# CHECK-INST: vlseg7bu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xc2]
+
 vlseg7bu.v v4, 0(a0)
+# CHECK-INST: vlseg7bu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xc2]
+
 vlseg7bu.v v4, (a0), v0.t
+# CHECK-INST: vlseg7bu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0xc0]
+
 vlseg7hu.v v4, (a0)
+# CHECK-INST: vlseg7hu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xc2]
+
 vlseg7hu.v v4, 0(a0)
+# CHECK-INST: vlseg7hu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xc2]
+
 vlseg7hu.v v4, (a0), v0.t
+# CHECK-INST: vlseg7hu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0xc0]
+
 vlseg7wu.v v4, (a0)
+# CHECK-INST: vlseg7wu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xc2]
+
 vlseg7wu.v v4, 0(a0)
+# CHECK-INST: vlseg7wu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xc2]
+
 vlseg7wu.v v4, (a0), v0.t
+# CHECK-INST: vlseg7wu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0xc0]
+
 vlseg7e.v v4, (a0)
+# CHECK-INST: vlseg7e.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0xc2]
+
 vlseg7e.v v4, 0(a0)
+# CHECK-INST: vlseg7e.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0xc2]
+
 vlseg7e.v v4, (a0), v0.t
+# CHECK-INST: vlseg7e.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0xc0]
+
 vsseg7b.v v4, (a0)
+# CHECK-INST: vsseg7b.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0xc2]
+
 vsseg7b.v v4, 0(a0)
+# CHECK-INST: vsseg7b.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0xc2]
+
 vsseg7b.v v4, (a0), v0.t
+# CHECK-INST: vsseg7b.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x02,0x05,0xc0]
+
 vsseg7h.v v4, (a0)
+# CHECK-INST: vsseg7h.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0xc2]
+
 vsseg7h.v v4, 0(a0)
+# CHECK-INST: vsseg7h.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0xc2]
+
 vsseg7h.v v4, (a0), v0.t
+# CHECK-INST: vsseg7h.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x52,0x05,0xc0]
+
 vsseg7w.v v4, (a0)
+# CHECK-INST: vsseg7w.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0xc2]
+
 vsseg7w.v v4, 0(a0)
+# CHECK-INST: vsseg7w.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0xc2]
+
 vsseg7w.v v4, (a0), v0.t
+# CHECK-INST: vsseg7w.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x62,0x05,0xc0]
+
 vsseg7e.v v4, (a0)
+# CHECK-INST: vsseg7e.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0xc2]
+
 vsseg7e.v v4, 0(a0)
+# CHECK-INST: vsseg7e.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0xc2]
+
 vsseg7e.v v4, (a0), v0.t
+# CHECK-INST: vsseg7e.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x72,0x05,0xc0]
 
 vlseg8b.v v4, (a0)
+# CHECK-INST: vlseg8b.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xf2]
+
 vlseg8b.v v4, 0(a0)
+# CHECK-INST: vlseg8b.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xf2]
+
 vlseg8b.v v4, (a0), v0.t
+# CHECK-INST: vlseg8b.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0xf0]
+
 vlseg8h.v v4, (a0)
+# CHECK-INST: vlseg8h.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xf2]
+
 vlseg8h.v v4, 0(a0)
+# CHECK-INST: vlseg8h.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xf2]
+
 vlseg8h.v v4, (a0), v0.t
+# CHECK-INST: vlseg8h.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0xf0]
+
 vlseg8w.v v4, (a0)
+# CHECK-INST: vlseg8w.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xf2]
+
 vlseg8w.v v4, 0(a0)
+# CHECK-INST: vlseg8w.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xf2]
+
 vlseg8w.v v4, (a0), v0.t
+# CHECK-INST: vlseg8w.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0xf0]
+
 vlseg8bu.v v4, (a0)
+# CHECK-INST: vlseg8bu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xe2]
+
 vlseg8bu.v v4, 0(a0)
+# CHECK-INST: vlseg8bu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xe2]
+
 vlseg8bu.v v4, (a0), v0.t
+# CHECK-INST: vlseg8bu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0xe0]
+
 vlseg8hu.v v4, (a0)
+# CHECK-INST: vlseg8hu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xe2]
+
 vlseg8hu.v v4, 0(a0)
+# CHECK-INST: vlseg8hu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xe2]
+
 vlseg8hu.v v4, (a0), v0.t
+# CHECK-INST: vlseg8hu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0xe0]
+
 vlseg8wu.v v4, (a0)
+# CHECK-INST: vlseg8wu.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xe2]
+
 vlseg8wu.v v4, 0(a0)
+# CHECK-INST: vlseg8wu.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xe2]
+
 vlseg8wu.v v4, (a0), v0.t
+# CHECK-INST: vlseg8wu.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0xe0]
+
 vlseg8e.v v4, (a0)
+# CHECK-INST: vlseg8e.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0xe2]
+
 vlseg8e.v v4, 0(a0)
+# CHECK-INST: vlseg8e.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0xe2]
+
 vlseg8e.v v4, (a0), v0.t
+# CHECK-INST: vlseg8e.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0xe0]
+
 vsseg8b.v v4, (a0)
+# CHECK-INST: vsseg8b.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0xe2]
+
 vsseg8b.v v4, 0(a0)
+# CHECK-INST: vsseg8b.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x02,0x05,0xe2]
+
 vsseg8b.v v4, (a0), v0.t
+# CHECK-INST: vsseg8b.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x02,0x05,0xe0]
+
 vsseg8h.v v4, (a0)
+# CHECK-INST: vsseg8h.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0xe2]
+
 vsseg8h.v v4, 0(a0)
+# CHECK-INST: vsseg8h.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x52,0x05,0xe2]
+
 vsseg8h.v v4, (a0), v0.t
+# CHECK-INST: vsseg8h.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x52,0x05,0xe0]
+
 vsseg8w.v v4, (a0)
+# CHECK-INST: vsseg8w.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0xe2]
+
 vsseg8w.v v4, 0(a0)
+# CHECK-INST: vsseg8w.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x62,0x05,0xe2]
+
 vsseg8w.v v4, (a0), v0.t
+# CHECK-INST: vsseg8w.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x62,0x05,0xe0]
+
 vsseg8e.v v4, (a0)
+# CHECK-INST: vsseg8e.v v4, (a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0xe2]
+
 vsseg8e.v v4, 0(a0)
+# CHECK-INST: vsseg8e.v v4, 0(a0)
+# CHECK-ENCODING: [0x27,0x72,0x05,0xe2]
+
 vsseg8e.v v4, (a0), v0.t
+# CHECK-INST: vsseg8e.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x27,0x72,0x05,0xe0]
 
 vlsseg2b.v v4, (a0), a1
+# CHECK-INST: vlsseg2b.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x3a]
+
 vlsseg2b.v v4, 0(a0), a1
+# CHECK-INST: vlsseg2b.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x3a]
+
 vlsseg2b.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg2b.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x38]
+
 vlsseg2h.v v4, (a0), a1
+# CHECK-INST: vlsseg2h.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x3a]
+
 vlsseg2h.v v4, 0(a0), a1
+# CHECK-INST: vlsseg2h.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x3a]
+
 vlsseg2h.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg2h.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x38]
+
 vlsseg2w.v v4, (a0), a1
+# CHECK-INST: vlsseg2w.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x3a]
+
 vlsseg2w.v v4, 0(a0), a1
+# CHECK-INST: vlsseg2w.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x3a]
+
 vlsseg2w.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg2w.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x38]
+
 vlsseg2bu.v v4, (a0), a1
+# CHECK-INST: vlsseg2bu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x2a]
+
 vlsseg2bu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg2bu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x2a]
+
 vlsseg2bu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg2bu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x28]
+
 vlsseg2hu.v v4, (a0), a1
+# CHECK-INST: vlsseg2hu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x2a]
+
 vlsseg2hu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg2hu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x2a]
+
 vlsseg2hu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg2hu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x28]
+
 vlsseg2wu.v v4, (a0), a1
+# CHECK-INST: vlsseg2wu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x2a]
+
 vlsseg2wu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg2wu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x2a]
+
 vlsseg2wu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg2wu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x28]
+
 vlsseg2e.v v4, (a0), a1
+# CHECK-INST: vlsseg2e.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x2a]
+
 vlsseg2e.v v4, 0(a0), a1
+# CHECK-INST: vlsseg2e.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x2a]
+
 vlsseg2e.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg2e.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x28]
+
 vssseg2b.v v4, (a0), a1
+# CHECK-INST: vssseg2b.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x2a]
+
 vssseg2b.v v4, 0(a0), a1
+# CHECK-INST: vssseg2b.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x2a]
+
 vssseg2b.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg2b.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x28]
+
 vssseg2h.v v4, (a0), a1
+# CHECK-INST: vssseg2h.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x2a]
+
 vssseg2h.v v4, 0(a0), a1
+# CHECK-INST: vssseg2h.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x2a]
+
 vssseg2h.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg2h.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x28]
+
 vssseg2w.v v4, (a0), a1
+# CHECK-INST: vssseg2w.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x2a]
+
 vssseg2w.v v4, 0(a0), a1
+# CHECK-INST: vssseg2w.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x2a]
+
 vssseg2w.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg2w.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x28]
+
 vssseg2e.v v4, (a0), a1
+# CHECK-INST: vssseg2e.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x2a]
+
 vssseg2e.v v4, 0(a0), a1
+# CHECK-INST: vssseg2e.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x2a]
+
 vssseg2e.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg2e.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x28]
 
 vlsseg3b.v v4, (a0), a1
+# CHECK-INST: vlsseg3b.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x5a]
+
 vlsseg3b.v v4, 0(a0), a1
+# CHECK-INST: vlsseg3b.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x5a]
+
 vlsseg3b.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg3b.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x58]
+
 vlsseg3h.v v4, (a0), a1
+# CHECK-INST: vlsseg3h.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x5a]
+
 vlsseg3h.v v4, 0(a0), a1
+# CHECK-INST: vlsseg3h.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x5a]
+
 vlsseg3h.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg3h.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x58]
+
 vlsseg3w.v v4, (a0), a1
+# CHECK-INST: vlsseg3w.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x5a]
+
 vlsseg3w.v v4, 0(a0), a1
+# CHECK-INST: vlsseg3w.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x5a]
+
 vlsseg3w.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg3w.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x58]
+
 vlsseg3bu.v v4, (a0), a1
+# CHECK-INST: vlsseg3bu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x4a]
+
 vlsseg3bu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg3bu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x4a]
+
 vlsseg3bu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg3bu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x48]
+
 vlsseg3hu.v v4, (a0), a1
+# CHECK-INST: vlsseg3hu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x4a]
+
 vlsseg3hu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg3hu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x4a]
+
 vlsseg3hu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg3hu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x48]
+
 vlsseg3wu.v v4, (a0), a1
+# CHECK-INST: vlsseg3wu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x4a]
+
 vlsseg3wu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg3wu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x4a]
+
 vlsseg3wu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg3wu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x48]
+
 vlsseg3e.v v4, (a0), a1
+# CHECK-INST: vlsseg3e.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x4a]
+
 vlsseg3e.v v4, 0(a0), a1
+# CHECK-INST: vlsseg3e.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x4a]
+
 vlsseg3e.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg3e.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x48]
+
 vssseg3b.v v4, (a0), a1
+# CHECK-INST: vssseg3b.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x4a]
+
 vssseg3b.v v4, 0(a0), a1
+# CHECK-INST: vssseg3b.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x4a]
+
 vssseg3b.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg3b.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x48]
+
 vssseg3h.v v4, (a0), a1
+# CHECK-INST: vssseg3h.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x4a]
+
 vssseg3h.v v4, 0(a0), a1
+# CHECK-INST: vssseg3h.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x4a]
+
 vssseg3h.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg3h.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x48]
+
 vssseg3w.v v4, (a0), a1
+# CHECK-INST: vssseg3w.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x4a]
+
 vssseg3w.v v4, 0(a0), a1
+# CHECK-INST: vssseg3w.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x4a]
+
 vssseg3w.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg3w.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x48]
+
 vssseg3e.v v4, (a0), a1
+# CHECK-INST: vssseg3e.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x4a]
+
 vssseg3e.v v4, 0(a0), a1
+# CHECK-INST: vssseg3e.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x4a]
+
 vssseg3e.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg3e.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x48]
 
 vlsseg4b.v v4, (a0), a1
+# CHECK-INST: vlsseg4b.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x7a]
+
 vlsseg4b.v v4, 0(a0), a1
+# CHECK-INST: vlsseg4b.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x7a]
+
 vlsseg4b.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg4b.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x78]
+
 vlsseg4h.v v4, (a0), a1
+# CHECK-INST: vlsseg4h.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x7a]
+
 vlsseg4h.v v4, 0(a0), a1
+# CHECK-INST: vlsseg4h.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x7a]
+
 vlsseg4h.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg4h.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x78]
+
 vlsseg4w.v v4, (a0), a1
+# CHECK-INST: vlsseg4w.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x7a]
+
 vlsseg4w.v v4, 0(a0), a1
+# CHECK-INST: vlsseg4w.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x7a]
+
 vlsseg4w.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg4w.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x78]
+
 vlsseg4bu.v v4, (a0), a1
+# CHECK-INST: vlsseg4bu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x6a]
+
 vlsseg4bu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg4bu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x6a]
+
 vlsseg4bu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg4bu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x68]
+
 vlsseg4hu.v v4, (a0), a1
+# CHECK-INST: vlsseg4hu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x6a]
+
 vlsseg4hu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg4hu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x6a]
+
 vlsseg4hu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg4hu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x68]
+
 vlsseg4wu.v v4, (a0), a1
+# CHECK-INST: vlsseg4wu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x6a]
+
 vlsseg4wu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg4wu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x6a]
+
 vlsseg4wu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg4wu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x68]
+
 vlsseg4e.v v4, (a0), a1
+# CHECK-INST: vlsseg4e.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x6a]
+
 vlsseg4e.v v4, 0(a0), a1
+# CHECK-INST: vlsseg4e.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x6a]
+
 vlsseg4e.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg4e.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x68]
+
 vssseg4b.v v4, (a0), a1
+# CHECK-INST: vssseg4b.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x6a]
+
 vssseg4b.v v4, 0(a0), a1
+# CHECK-INST: vssseg4b.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x6a]
+
 vssseg4b.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg4b.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x68]
+
 vssseg4h.v v4, (a0), a1
+# CHECK-INST: vssseg4h.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x6a]
+
 vssseg4h.v v4, 0(a0), a1
+# CHECK-INST: vssseg4h.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x6a]
+
 vssseg4h.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg4h.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x68]
+
 vssseg4w.v v4, (a0), a1
+# CHECK-INST: vssseg4w.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x6a]
+
 vssseg4w.v v4, 0(a0), a1
+# CHECK-INST: vssseg4w.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x6a]
+
 vssseg4w.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg4w.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x68]
+
 vssseg4e.v v4, (a0), a1
+# CHECK-INST: vssseg4e.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x6a]
+
 vssseg4e.v v4, 0(a0), a1
+# CHECK-INST: vssseg4e.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x6a]
+
 vssseg4e.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg4e.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x68]
 
 vlsseg5b.v v4, (a0), a1
+# CHECK-INST: vlsseg5b.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x9a]
+
 vlsseg5b.v v4, 0(a0), a1
+# CHECK-INST: vlsseg5b.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x9a]
+
 vlsseg5b.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg5b.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x98]
+
 vlsseg5h.v v4, (a0), a1
+# CHECK-INST: vlsseg5h.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x9a]
+
 vlsseg5h.v v4, 0(a0), a1
+# CHECK-INST: vlsseg5h.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x9a]
+
 vlsseg5h.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg5h.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x98]
+
 vlsseg5w.v v4, (a0), a1
+# CHECK-INST: vlsseg5w.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x9a]
+
 vlsseg5w.v v4, 0(a0), a1
+# CHECK-INST: vlsseg5w.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x9a]
+
 vlsseg5w.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg5w.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x98]
+
 vlsseg5bu.v v4, (a0), a1
+# CHECK-INST: vlsseg5bu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x8a]
+
 vlsseg5bu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg5bu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x8a]
+
 vlsseg5bu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg5bu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0x88]
+
 vlsseg5hu.v v4, (a0), a1
+# CHECK-INST: vlsseg5hu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x8a]
+
 vlsseg5hu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg5hu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x8a]
+
 vlsseg5hu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg5hu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0x88]
+
 vlsseg5wu.v v4, (a0), a1
+# CHECK-INST: vlsseg5wu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x8a]
+
 vlsseg5wu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg5wu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x8a]
+
 vlsseg5wu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg5wu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0x88]
+
 vlsseg5e.v v4, (a0), a1
+# CHECK-INST: vlsseg5e.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x8a]
+
 vlsseg5e.v v4, 0(a0), a1
+# CHECK-INST: vlsseg5e.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x8a]
+
 vlsseg5e.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg5e.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xb5,0x88]
+
 vssseg5b.v v4, (a0), a1
+# CHECK-INST: vssseg5b.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x8a]
+
 vssseg5b.v v4, 0(a0), a1
+# CHECK-INST: vssseg5b.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x8a]
+
 vssseg5b.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg5b.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xb5,0x88]
+
 vssseg5h.v v4, (a0), a1
+# CHECK-INST: vssseg5h.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x8a]
+
 vssseg5h.v v4, 0(a0), a1
+# CHECK-INST: vssseg5h.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x8a]
+
 vssseg5h.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg5h.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xb5,0x88]
+
 vssseg5w.v v4, (a0), a1
+# CHECK-INST: vssseg5w.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x8a]
+
 vssseg5w.v v4, 0(a0), a1
+# CHECK-INST: vssseg5w.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x8a]
+
 vssseg5w.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg5w.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xb5,0x88]
+
 vssseg5e.v v4, (a0), a1
+# CHECK-INST: vssseg5e.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x8a]
+
 vssseg5e.v v4, 0(a0), a1
+# CHECK-INST: vssseg5e.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x8a]
+
 vssseg5e.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg5e.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xb5,0x88]
 
 vlsseg6b.v v4, (a0), a1
+# CHECK-INST: vlsseg6b.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xba]
+
 vlsseg6b.v v4, 0(a0), a1
+# CHECK-INST: vlsseg6b.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xba]
+
 vlsseg6b.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg6b.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xb8]
+
 vlsseg6h.v v4, (a0), a1
+# CHECK-INST: vlsseg6h.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xba]
+
 vlsseg6h.v v4, 0(a0), a1
+# CHECK-INST: vlsseg6h.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xba]
+
 vlsseg6h.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg6h.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xb8]
+
 vlsseg6w.v v4, (a0), a1
+# CHECK-INST: vlsseg6w.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xba]
+
 vlsseg6w.v v4, 0(a0), a1
+# CHECK-INST: vlsseg6w.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xba]
+
 vlsseg6w.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg6w.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xb8]
+
 vlsseg6bu.v v4, (a0), a1
+# CHECK-INST: vlsseg6bu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xaa]
+
 vlsseg6bu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg6bu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xaa]
+
 vlsseg6bu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg6bu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xa8]
+
 vlsseg6hu.v v4, (a0), a1
+# CHECK-INST: vlsseg6hu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xaa]
+
 vlsseg6hu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg6hu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xaa]
+
 vlsseg6hu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg6hu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xa8]
+
 vlsseg6wu.v v4, (a0), a1
+# CHECK-INST: vlsseg6wu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xaa]
+
 vlsseg6wu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg6wu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xaa]
+
 vlsseg6wu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg6wu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xa8]
+
 vlsseg6e.v v4, (a0), a1
+# CHECK-INST: vlsseg6e.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0xaa]
+
 vlsseg6e.v v4, 0(a0), a1
+# CHECK-INST: vlsseg6e.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0xaa]
+
 vlsseg6e.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg6e.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xb5,0xa8]
+
 vssseg6b.v v4, (a0), a1
+# CHECK-INST: vssseg6b.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0xaa]
+
 vssseg6b.v v4, 0(a0), a1
+# CHECK-INST: vssseg6b.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0xaa]
+
 vssseg6b.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg6b.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xb5,0xa8]
+
 vssseg6h.v v4, (a0), a1
+# CHECK-INST: vssseg6h.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0xaa]
+
 vssseg6h.v v4, 0(a0), a1
+# CHECK-INST: vssseg6h.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0xaa]
+
 vssseg6h.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg6h.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xb5,0xa8]
+
 vssseg6w.v v4, (a0), a1
+# CHECK-INST: vssseg6w.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0xaa]
+
 vssseg6w.v v4, 0(a0), a1
+# CHECK-INST: vssseg6w.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0xaa]
+
 vssseg6w.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg6w.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xb5,0xa8]
+
 vssseg6e.v v4, (a0), a1
+# CHECK-INST: vssseg6e.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0xaa]
+
 vssseg6e.v v4, 0(a0), a1
+# CHECK-INST: vssseg6e.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0xaa]
+
 vssseg6e.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg6e.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xb5,0xa8]
 
 vlsseg7b.v v4, (a0), a1
+# CHECK-INST: vlsseg7b.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xda]
+
 vlsseg7b.v v4, 0(a0), a1
+# CHECK-INST: vlsseg7b.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xda]
+
 vlsseg7b.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg7b.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xd8]
+
 vlsseg7h.v v4, (a0), a1
+# CHECK-INST: vlsseg7h.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xda]
+
 vlsseg7h.v v4, 0(a0), a1
+# CHECK-INST: vlsseg7h.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xda]
+
 vlsseg7h.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg7h.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xd8]
+
 vlsseg7w.v v4, (a0), a1
+# CHECK-INST: vlsseg7w.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xda]
+
 vlsseg7w.v v4, 0(a0), a1
+# CHECK-INST: vlsseg7w.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xda]
+
 vlsseg7w.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg7w.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xd8]
+
 vlsseg7bu.v v4, (a0), a1
+# CHECK-INST: vlsseg7bu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xca]
+
 vlsseg7bu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg7bu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xca]
+
 vlsseg7bu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg7bu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xc8]
+
 vlsseg7hu.v v4, (a0), a1
+# CHECK-INST: vlsseg7hu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xca]
+
 vlsseg7hu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg7hu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xca]
+
 vlsseg7hu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg7hu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xc8]
+
 vlsseg7wu.v v4, (a0), a1
+# CHECK-INST: vlsseg7wu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xca]
+
 vlsseg7wu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg7wu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xca]
+
 vlsseg7wu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg7wu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xc8]
+
 vlsseg7e.v v4, (a0), a1
+# CHECK-INST: vlsseg7e.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0xca]
+
 vlsseg7e.v v4, 0(a0), a1
+# CHECK-INST: vlsseg7e.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0xca]
+
 vlsseg7e.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg7e.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xb5,0xc8]
+
 vssseg7b.v v4, (a0), a1
+# CHECK-INST: vssseg7b.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0xca]
+
 vssseg7b.v v4, 0(a0), a1
+# CHECK-INST: vssseg7b.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0xca]
+
 vssseg7b.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg7b.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xb5,0xc8]
+
 vssseg7h.v v4, (a0), a1
+# CHECK-INST: vssseg7h.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0xca]
+
 vssseg7h.v v4, 0(a0), a1
+# CHECK-INST: vssseg7h.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0xca]
+
 vssseg7h.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg7h.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xb5,0xc8]
+
 vssseg7w.v v4, (a0), a1
+# CHECK-INST: vssseg7w.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0xca]
+
 vssseg7w.v v4, 0(a0), a1
+# CHECK-INST: vssseg7w.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0xca]
+
 vssseg7w.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg7w.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xb5,0xc8]
+
 vssseg7e.v v4, (a0), a1
+# CHECK-INST: vssseg7e.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0xca]
+
 vssseg7e.v v4, 0(a0), a1
+# CHECK-INST: vssseg7e.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0xca]
+
 vssseg7e.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg7e.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xb5,0xc8]
 
 vlsseg8b.v v4, (a0), a1
+# CHECK-INST: vlsseg8b.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xfa]
+
 vlsseg8b.v v4, 0(a0), a1
+# CHECK-INST: vlsseg8b.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xfa]
+
 vlsseg8b.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg8b.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xf8]
+
 vlsseg8h.v v4, (a0), a1
+# CHECK-INST: vlsseg8h.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xfa]
+
 vlsseg8h.v v4, 0(a0), a1
+# CHECK-INST: vlsseg8h.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xfa]
+
 vlsseg8h.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg8h.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xf8]
+
 vlsseg8w.v v4, (a0), a1
+# CHECK-INST: vlsseg8w.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xfa]
+
 vlsseg8w.v v4, 0(a0), a1
+# CHECK-INST: vlsseg8w.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xfa]
+
 vlsseg8w.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg8w.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xf8]
+
 vlsseg8bu.v v4, (a0), a1
+# CHECK-INST: vlsseg8bu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xea]
+
 vlsseg8bu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg8bu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xea]
+
 vlsseg8bu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg8bu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xb5,0xe8]
+
 vlsseg8hu.v v4, (a0), a1
+# CHECK-INST: vlsseg8hu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xea]
+
 vlsseg8hu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg8hu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xea]
+
 vlsseg8hu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg8hu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xb5,0xe8]
+
 vlsseg8wu.v v4, (a0), a1
+# CHECK-INST: vlsseg8wu.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xea]
+
 vlsseg8wu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg8wu.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xea]
+
 vlsseg8wu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg8wu.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xb5,0xe8]
+
 vlsseg8e.v v4, (a0), a1
+# CHECK-INST: vlsseg8e.v v4, (a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0xea]
+
 vlsseg8e.v v4, 0(a0), a1
+# CHECK-INST: vlsseg8e.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x07,0x72,0xb5,0xea]
+
 vlsseg8e.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg8e.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xb5,0xe8]
+
 vssseg8b.v v4, (a0), a1
+# CHECK-INST: vssseg8b.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0xea]
+
 vssseg8b.v v4, 0(a0), a1
+# CHECK-INST: vssseg8b.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x02,0xb5,0xea]
+
 vssseg8b.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg8b.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xb5,0xe8]
+
 vssseg8h.v v4, (a0), a1
+# CHECK-INST: vssseg8h.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0xea]
+
 vssseg8h.v v4, 0(a0), a1
+# CHECK-INST: vssseg8h.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x52,0xb5,0xea]
+
 vssseg8h.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg8h.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xb5,0xe8]
+
 vssseg8w.v v4, (a0), a1
+# CHECK-INST: vssseg8w.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0xea]
+
 vssseg8w.v v4, 0(a0), a1
+# CHECK-INST: vssseg8w.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x62,0xb5,0xea]
+
 vssseg8w.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg8w.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xb5,0xe8]
+
 vssseg8e.v v4, (a0), a1
+# CHECK-INST: vssseg8e.v v4, (a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0xea]
+
 vssseg8e.v v4, 0(a0), a1
+# CHECK-INST: vssseg8e.v v4, 0(a0), a1
+# CHECK-ENCODING: [0x27,0x72,0xb5,0xea]
+
 vssseg8e.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg8e.v v4, (a0), a1, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xb5,0xe8]
 
 vlxseg2b.v v4, (a0), v12
+# CHECK-INST: vlxseg2b.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x3e]
+
 vlxseg2b.v v4, 0(a0), v12
+# CHECK-INST: vlxseg2b.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x3e]
+
 vlxseg2b.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg2b.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x3c]
+
 vlxseg2h.v v4, (a0), v12
+# CHECK-INST: vlxseg2h.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x3e]
+
 vlxseg2h.v v4, 0(a0), v12
+# CHECK-INST: vlxseg2h.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x3e]
+
 vlxseg2h.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg2h.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x3c]
+
 vlxseg2w.v v4, (a0), v12
+# CHECK-INST: vlxseg2w.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x3e]
+
 vlxseg2w.v v4, 0(a0), v12
+# CHECK-INST: vlxseg2w.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x3e]
+
 vlxseg2w.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg2w.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x3c]
+
 vlxseg2bu.v v4, (a0), v12
+# CHECK-INST: vlxseg2bu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x2e]
+
 vlxseg2bu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg2bu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x2e]
+
 vlxseg2bu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg2bu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x2c]
+
 vlxseg2hu.v v4, (a0), v12
+# CHECK-INST: vlxseg2hu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x2e]
+
 vlxseg2hu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg2hu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x2e]
+
 vlxseg2hu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg2hu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x2c]
+
 vlxseg2wu.v v4, (a0), v12
+# CHECK-INST: vlxseg2wu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x2e]
+
 vlxseg2wu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg2wu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x2e]
+
 vlxseg2wu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg2wu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x2c]
+
 vlxseg2e.v v4, (a0), v12
+# CHECK-INST: vlxseg2e.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x2e]
+
 vlxseg2e.v v4, 0(a0), v12
+# CHECK-INST: vlxseg2e.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x2e]
+
 vlxseg2e.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg2e.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x2c]
+
 vsxseg2b.v v4, (a0), v12
+# CHECK-INST: vsxseg2b.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x2e]
+
 vsxseg2b.v v4, 0(a0), v12
+# CHECK-INST: vsxseg2b.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x2e]
+
 vsxseg2b.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg2b.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x2c]
+
 vsxseg2h.v v4, (a0), v12
+# CHECK-INST: vsxseg2h.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x2e]
+
 vsxseg2h.v v4, 0(a0), v12
+# CHECK-INST: vsxseg2h.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x2e]
+
 vsxseg2h.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg2h.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x2c]
+
 vsxseg2w.v v4, (a0), v12
+# CHECK-INST: vsxseg2w.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x2e]
+
 vsxseg2w.v v4, 0(a0), v12
+# CHECK-INST: vsxseg2w.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x2e]
+
 vsxseg2w.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg2w.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x2c]
+
 vsxseg2e.v v4, (a0), v12
+# CHECK-INST: vsxseg2e.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x2e]
+
 vsxseg2e.v v4, 0(a0), v12
+# CHECK-INST: vsxseg2e.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x2e]
+
 vsxseg2e.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg2e.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x2c]
 
 vlxseg3b.v v4, (a0), v12
+# CHECK-INST: vlxseg3b.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x5e]
+
 vlxseg3b.v v4, 0(a0), v12
+# CHECK-INST: vlxseg3b.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x5e]
+
 vlxseg3b.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg3b.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x5c]
+
 vlxseg3h.v v4, (a0), v12
+# CHECK-INST: vlxseg3h.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x5e]
+
 vlxseg3h.v v4, 0(a0), v12
+# CHECK-INST: vlxseg3h.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x5e]
+
 vlxseg3h.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg3h.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x5c]
+
 vlxseg3w.v v4, (a0), v12
+# CHECK-INST: vlxseg3w.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x5e]
+
 vlxseg3w.v v4, 0(a0), v12
+# CHECK-INST: vlxseg3w.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x5e]
+
 vlxseg3w.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg3w.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x5c]
+
 vlxseg3bu.v v4, (a0), v12
+# CHECK-INST: vlxseg3bu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x4e]
+
 vlxseg3bu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg3bu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x4e]
+
 vlxseg3bu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg3bu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x4c]
+
 vlxseg3hu.v v4, (a0), v12
+# CHECK-INST: vlxseg3hu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x4e]
+
 vlxseg3hu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg3hu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x4e]
+
 vlxseg3hu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg3hu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x4c]
+
 vlxseg3wu.v v4, (a0), v12
+# CHECK-INST: vlxseg3wu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x4e]
+
 vlxseg3wu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg3wu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x4e]
+
 vlxseg3wu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg3wu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x4c]
+
 vlxseg3e.v v4, (a0), v12
+# CHECK-INST: vlxseg3e.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x4e]
+
 vlxseg3e.v v4, 0(a0), v12
+# CHECK-INST: vlxseg3e.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x4e]
+
 vlxseg3e.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg3e.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x4c]
+
 vsxseg3b.v v4, (a0), v12
+# CHECK-INST: vsxseg3b.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x4e]
+
 vsxseg3b.v v4, 0(a0), v12
+# CHECK-INST: vsxseg3b.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x4e]
+
 vsxseg3b.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg3b.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x4c]
+
 vsxseg3h.v v4, (a0), v12
+# CHECK-INST: vsxseg3h.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x4e]
+
 vsxseg3h.v v4, 0(a0), v12
+# CHECK-INST: vsxseg3h.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x4e]
+
 vsxseg3h.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg3h.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x4c]
+
 vsxseg3w.v v4, (a0), v12
+# CHECK-INST: vsxseg3w.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x4e]
+
 vsxseg3w.v v4, 0(a0), v12
+# CHECK-INST: vsxseg3w.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x4e]
+
 vsxseg3w.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg3w.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x4c]
+
 vsxseg3e.v v4, (a0), v12
+# CHECK-INST: vsxseg3e.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x4e]
+
 vsxseg3e.v v4, 0(a0), v12
+# CHECK-INST: vsxseg3e.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x4e]
+
 vsxseg3e.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg3e.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x4c]
 
 vlxseg4b.v v4, (a0), v12
+# CHECK-INST: vlxseg4b.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x7e]
+
 vlxseg4b.v v4, 0(a0), v12
+# CHECK-INST: vlxseg4b.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x7e]
+
 vlxseg4b.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg4b.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x7c]
+
 vlxseg4h.v v4, (a0), v12
+# CHECK-INST: vlxseg4h.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x7e]
+
 vlxseg4h.v v4, 0(a0), v12
+# CHECK-INST: vlxseg4h.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x7e]
+
 vlxseg4h.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg4h.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x7c]
+
 vlxseg4w.v v4, (a0), v12
+# CHECK-INST: vlxseg4w.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x7e]
+
 vlxseg4w.v v4, 0(a0), v12
+# CHECK-INST: vlxseg4w.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x7e]
+
 vlxseg4w.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg4w.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x7c]
+
 vlxseg4bu.v v4, (a0), v12
+# CHECK-INST: vlxseg4bu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x6e]
+
 vlxseg4bu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg4bu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x6e]
+
 vlxseg4bu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg4bu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x6c]
+
 vlxseg4hu.v v4, (a0), v12
+# CHECK-INST: vlxseg4hu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x6e]
+
 vlxseg4hu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg4hu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x6e]
+
 vlxseg4hu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg4hu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x6c]
+
 vlxseg4wu.v v4, (a0), v12
+# CHECK-INST: vlxseg4wu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x6e]
+
 vlxseg4wu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg4wu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x6e]
+
 vlxseg4wu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg4wu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x6c]
+
 vlxseg4e.v v4, (a0), v12
+# CHECK-INST: vlxseg4e.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x6e]
+
 vlxseg4e.v v4, 0(a0), v12
+# CHECK-INST: vlxseg4e.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x6e]
+
 vlxseg4e.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg4e.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x6c]
+
 vsxseg4b.v v4, (a0), v12
+# CHECK-INST: vsxseg4b.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x6e]
+
 vsxseg4b.v v4, 0(a0), v12
+# CHECK-INST: vsxseg4b.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x6e]
+
 vsxseg4b.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg4b.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x6c]
+
 vsxseg4h.v v4, (a0), v12
+# CHECK-INST: vsxseg4h.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x6e]
+
 vsxseg4h.v v4, 0(a0), v12
+# CHECK-INST: vsxseg4h.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x6e]
+
 vsxseg4h.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg4h.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x6c]
+
 vsxseg4w.v v4, (a0), v12
+# CHECK-INST: vsxseg4w.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x6e]
+
 vsxseg4w.v v4, 0(a0), v12
+# CHECK-INST: vsxseg4w.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x6e]
+
 vsxseg4w.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg4w.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x6c]
+
 vsxseg4e.v v4, (a0), v12
+# CHECK-INST: vsxseg4e.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x6e]
+
 vsxseg4e.v v4, 0(a0), v12
+# CHECK-INST: vsxseg4e.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x6e]
+
 vsxseg4e.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg4e.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x6c]
 
 vlxseg5b.v v4, (a0), v12
+# CHECK-INST: vlxseg5b.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x9e]
+
 vlxseg5b.v v4, 0(a0), v12
+# CHECK-INST: vlxseg5b.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x9e]
+
 vlxseg5b.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg5b.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x9c]
+
 vlxseg5h.v v4, (a0), v12
+# CHECK-INST: vlxseg5h.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x9e]
+
 vlxseg5h.v v4, 0(a0), v12
+# CHECK-INST: vlxseg5h.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x9e]
+
 vlxseg5h.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg5h.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x9c]
+
 vlxseg5w.v v4, (a0), v12
+# CHECK-INST: vlxseg5w.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x9e]
+
 vlxseg5w.v v4, 0(a0), v12
+# CHECK-INST: vlxseg5w.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x9e]
+
 vlxseg5w.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg5w.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x9c]
+
 vlxseg5bu.v v4, (a0), v12
+# CHECK-INST: vlxseg5bu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x8e]
+
 vlxseg5bu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg5bu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x8e]
+
 vlxseg5bu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg5bu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0x8c]
+
 vlxseg5hu.v v4, (a0), v12
+# CHECK-INST: vlxseg5hu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x8e]
+
 vlxseg5hu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg5hu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x8e]
+
 vlxseg5hu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg5hu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0x8c]
+
 vlxseg5wu.v v4, (a0), v12
+# CHECK-INST: vlxseg5wu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x8e]
+
 vlxseg5wu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg5wu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x8e]
+
 vlxseg5wu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg5wu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0x8c]
+
 vlxseg5e.v v4, (a0), v12
+# CHECK-INST: vlxseg5e.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x8e]
+
 vlxseg5e.v v4, 0(a0), v12
+# CHECK-INST: vlxseg5e.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x8e]
+
 vlxseg5e.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg5e.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xc5,0x8c]
+
 vsxseg5b.v v4, (a0), v12
+# CHECK-INST: vsxseg5b.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x8e]
+
 vsxseg5b.v v4, 0(a0), v12
+# CHECK-INST: vsxseg5b.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x8e]
+
 vsxseg5b.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg5b.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xc5,0x8c]
+
 vsxseg5h.v v4, (a0), v12
+# CHECK-INST: vsxseg5h.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x8e]
+
 vsxseg5h.v v4, 0(a0), v12
+# CHECK-INST: vsxseg5h.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x8e]
+
 vsxseg5h.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg5h.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xc5,0x8c]
+
 vsxseg5w.v v4, (a0), v12
+# CHECK-INST: vsxseg5w.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x8e]
+
 vsxseg5w.v v4, 0(a0), v12
+# CHECK-INST: vsxseg5w.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x8e]
+
 vsxseg5w.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg5w.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xc5,0x8c]
+
 vsxseg5e.v v4, (a0), v12
+# CHECK-INST: vsxseg5e.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x8e]
+
 vsxseg5e.v v4, 0(a0), v12
+# CHECK-INST: vsxseg5e.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x8e]
+
 vsxseg5e.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg5e.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xc5,0x8c]
 
 vlxseg6b.v v4, (a0), v12
+# CHECK-INST: vlxseg6b.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xbe]
+
 vlxseg6b.v v4, 0(a0), v12
+# CHECK-INST: vlxseg6b.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xbe]
+
 vlxseg6b.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg6b.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xbc]
+
 vlxseg6h.v v4, (a0), v12
+# CHECK-INST: vlxseg6h.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xbe]
+
 vlxseg6h.v v4, 0(a0), v12
+# CHECK-INST: vlxseg6h.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xbe]
+
 vlxseg6h.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg6h.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xbc]
+
 vlxseg6w.v v4, (a0), v12
+# CHECK-INST: vlxseg6w.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xbe]
+
 vlxseg6w.v v4, 0(a0), v12
+# CHECK-INST: vlxseg6w.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xbe]
+
 vlxseg6w.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg6w.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xbc]
+
 vlxseg6bu.v v4, (a0), v12
+# CHECK-INST: vlxseg6bu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xae]
+
 vlxseg6bu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg6bu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xae]
+
 vlxseg6bu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg6bu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xac]
+
 vlxseg6hu.v v4, (a0), v12
+# CHECK-INST: vlxseg6hu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xae]
+
 vlxseg6hu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg6hu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xae]
+
 vlxseg6hu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg6hu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xac]
+
 vlxseg6wu.v v4, (a0), v12
+# CHECK-INST: vlxseg6wu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xae]
+
 vlxseg6wu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg6wu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xae]
+
 vlxseg6wu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg6wu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xac]
+
 vlxseg6e.v v4, (a0), v12
+# CHECK-INST: vlxseg6e.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0xae]
+
 vlxseg6e.v v4, 0(a0), v12
+# CHECK-INST: vlxseg6e.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0xae]
+
 vlxseg6e.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg6e.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xc5,0xac]
+
 vsxseg6b.v v4, (a0), v12
+# CHECK-INST: vsxseg6b.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0xae]
+
 vsxseg6b.v v4, 0(a0), v12
+# CHECK-INST: vsxseg6b.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0xae]
+
 vsxseg6b.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg6b.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xc5,0xac]
+
 vsxseg6h.v v4, (a0), v12
+# CHECK-INST: vsxseg6h.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0xae]
+
 vsxseg6h.v v4, 0(a0), v12
+# CHECK-INST: vsxseg6h.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0xae]
+
 vsxseg6h.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg6h.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xc5,0xac]
+
 vsxseg6w.v v4, (a0), v12
+# CHECK-INST: vsxseg6w.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0xae]
+
 vsxseg6w.v v4, 0(a0), v12
+# CHECK-INST: vsxseg6w.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0xae]
+
 vsxseg6w.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg6w.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xc5,0xac]
+
 vsxseg6e.v v4, (a0), v12
+# CHECK-INST: vsxseg6e.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0xae]
+
 vsxseg6e.v v4, 0(a0), v12
+# CHECK-INST: vsxseg6e.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0xae]
+
 vsxseg6e.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg6e.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xc5,0xac]
 
 vlxseg7b.v v4, (a0), v12
+# CHECK-INST: vlxseg7b.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xde]
+
 vlxseg7b.v v4, 0(a0), v12
+# CHECK-INST: vlxseg7b.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xde]
+
 vlxseg7b.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg7b.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xdc]
+
 vlxseg7h.v v4, (a0), v12
+# CHECK-INST: vlxseg7h.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xde]
+
 vlxseg7h.v v4, 0(a0), v12
+# CHECK-INST: vlxseg7h.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xde]
+
 vlxseg7h.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg7h.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xdc]
+
 vlxseg7w.v v4, (a0), v12
+# CHECK-INST: vlxseg7w.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xde]
+
 vlxseg7w.v v4, 0(a0), v12
+# CHECK-INST: vlxseg7w.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xde]
+
 vlxseg7w.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg7w.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xdc]
+
 vlxseg7bu.v v4, (a0), v12
+# CHECK-INST: vlxseg7bu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xce]
+
 vlxseg7bu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg7bu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xce]
+
 vlxseg7bu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg7bu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xcc]
+
 vlxseg7hu.v v4, (a0), v12
+# CHECK-INST: vlxseg7hu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xce]
+
 vlxseg7hu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg7hu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xce]
+
 vlxseg7hu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg7hu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xcc]
+
 vlxseg7wu.v v4, (a0), v12
+# CHECK-INST: vlxseg7wu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xce]
+
 vlxseg7wu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg7wu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xce]
+
 vlxseg7wu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg7wu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xcc]
+
 vlxseg7e.v v4, (a0), v12
+# CHECK-INST: vlxseg7e.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0xce]
+
 vlxseg7e.v v4, 0(a0), v12
+# CHECK-INST: vlxseg7e.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0xce]
+
 vlxseg7e.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg7e.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xc5,0xcc]
+
 vsxseg7b.v v4, (a0), v12
+# CHECK-INST: vsxseg7b.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0xce]
+
 vsxseg7b.v v4, 0(a0), v12
+# CHECK-INST: vsxseg7b.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0xce]
+
 vsxseg7b.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg7b.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xc5,0xcc]
+
 vsxseg7h.v v4, (a0), v12
+# CHECK-INST: vsxseg7h.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0xce]
+
 vsxseg7h.v v4, 0(a0), v12
+# CHECK-INST: vsxseg7h.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0xce]
+
 vsxseg7h.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg7h.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xc5,0xcc]
+
 vsxseg7w.v v4, (a0), v12
+# CHECK-INST: vsxseg7w.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0xce]
+
 vsxseg7w.v v4, 0(a0), v12
+# CHECK-INST: vsxseg7w.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0xce]
+
 vsxseg7w.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg7w.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xc5,0xcc]
+
 vsxseg7e.v v4, (a0), v12
+# CHECK-INST: vsxseg7e.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0xce]
+
 vsxseg7e.v v4, 0(a0), v12
+# CHECK-INST: vsxseg7e.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0xce]
+
 vsxseg7e.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg7e.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xc5,0xcc]
 
 vlxseg8b.v v4, (a0), v12
+# CHECK-INST: vlxseg8b.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xfe]
+
 vlxseg8b.v v4, 0(a0), v12
+# CHECK-INST: vlxseg8b.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xfe]
+
 vlxseg8b.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg8b.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xfc]
+
 vlxseg8h.v v4, (a0), v12
+# CHECK-INST: vlxseg8h.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xfe]
+
 vlxseg8h.v v4, 0(a0), v12
+# CHECK-INST: vlxseg8h.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xfe]
+
 vlxseg8h.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg8h.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xfc]
+
 vlxseg8w.v v4, (a0), v12
+# CHECK-INST: vlxseg8w.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xfe]
+
 vlxseg8w.v v4, 0(a0), v12
+# CHECK-INST: vlxseg8w.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xfe]
+
 vlxseg8w.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg8w.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xfc]
+
 vlxseg8bu.v v4, (a0), v12
+# CHECK-INST: vlxseg8bu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xee]
+
 vlxseg8bu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg8bu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xee]
+
 vlxseg8bu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg8bu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x02,0xc5,0xec]
+
 vlxseg8hu.v v4, (a0), v12
+# CHECK-INST: vlxseg8hu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xee]
+
 vlxseg8hu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg8hu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xee]
+
 vlxseg8hu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg8hu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x52,0xc5,0xec]
+
 vlxseg8wu.v v4, (a0), v12
+# CHECK-INST: vlxseg8wu.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xee]
+
 vlxseg8wu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg8wu.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xee]
+
 vlxseg8wu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg8wu.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x62,0xc5,0xec]
+
 vlxseg8e.v v4, (a0), v12
+# CHECK-INST: vlxseg8e.v v4, (a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0xee]
+
 vlxseg8e.v v4, 0(a0), v12
+# CHECK-INST: vlxseg8e.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x07,0x72,0xc5,0xee]
+
 vlxseg8e.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg8e.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x07,0x72,0xc5,0xec]
+
 vsxseg8b.v v4, (a0), v12
+# CHECK-INST: vsxseg8b.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0xee]
+
 vsxseg8b.v v4, 0(a0), v12
+# CHECK-INST: vsxseg8b.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x02,0xc5,0xee]
+
 vsxseg8b.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg8b.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x02,0xc5,0xec]
+
 vsxseg8h.v v4, (a0), v12
+# CHECK-INST: vsxseg8h.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0xee]
+
 vsxseg8h.v v4, 0(a0), v12
+# CHECK-INST: vsxseg8h.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x52,0xc5,0xee]
+
 vsxseg8h.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg8h.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x52,0xc5,0xec]
+
 vsxseg8w.v v4, (a0), v12
+# CHECK-INST: vsxseg8w.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0xee]
+
 vsxseg8w.v v4, 0(a0), v12
+# CHECK-INST: vsxseg8w.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x62,0xc5,0xee]
+
 vsxseg8w.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg8w.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x62,0xc5,0xec]
+
 vsxseg8e.v v4, (a0), v12
+# CHECK-INST: vsxseg8e.v v4, (a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0xee]
+
 vsxseg8e.v v4, 0(a0), v12
+# CHECK-INST: vsxseg8e.v v4, 0(a0), v12
+# CHECK-ENCODING: [0x27,0x72,0xc5,0xee]
+
 vsxseg8e.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg8e.v v4, (a0), v12, v0.t
+# CHECK-ENCODING: [0x27,0x72,0xc5,0xec]
 
 vlseg2bff.v v4, (a0)
+# CHECK-INST: vlseg2bff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x33]
+
 vlseg2bff.v v4, 0(a0)
+# CHECK-INST: vlseg2bff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x33]
+
 vlseg2bff.v v4, (a0), v0.t
+# CHECK-INST: vlseg2bff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x31]
+
 vlseg2hff.v v4, (a0)
+# CHECK-INST: vlseg2hff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x33]
+
 vlseg2hff.v v4, 0(a0)
+# CHECK-INST: vlseg2hff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x33]
+
 vlseg2hff.v v4, (a0), v0.t
+# CHECK-INST: vlseg2hff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x31]
+
 vlseg2wff.v v4, (a0)
+# CHECK-INST: vlseg2wff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x33]
+
 vlseg2wff.v v4, 0(a0)
+# CHECK-INST: vlseg2wff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x33]
+
 vlseg2wff.v v4, (a0), v0.t
+# CHECK-INST: vlseg2wff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x31]
+
 vlseg2buff.v v4, (a0)
+# CHECK-INST: vlseg2buff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x23]
+
 vlseg2buff.v v4, 0(a0)
+# CHECK-INST: vlseg2buff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x23]
+
 vlseg2buff.v v4, (a0), v0.t
+# CHECK-INST: vlseg2buff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x21]
+
 vlseg2huff.v v4, (a0)
+# CHECK-INST: vlseg2huff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x23]
+
 vlseg2huff.v v4, 0(a0)
+# CHECK-INST: vlseg2huff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x23]
+
 vlseg2huff.v v4, (a0), v0.t
+# CHECK-INST: vlseg2huff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x21]
+
 vlseg2wuff.v v4, (a0)
+# CHECK-INST: vlseg2wuff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x23]
+
 vlseg2wuff.v v4, 0(a0)
+# CHECK-INST: vlseg2wuff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x23]
+
 vlseg2wuff.v v4, (a0), v0.t
+# CHECK-INST: vlseg2wuff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x21]
+
 vlseg2eff.v v4, (a0)
+# CHECK-INST: vlseg2eff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x23]
+
 vlseg2eff.v v4, 0(a0)
+# CHECK-INST: vlseg2eff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x23]
+
 vlseg2eff.v v4, (a0), v0.t
+# CHECK-INST: vlseg2eff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0x21]
 
 vlseg3bff.v v4, (a0)
+# CHECK-INST: vlseg3bff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x53]
+
 vlseg3bff.v v4, 0(a0)
+# CHECK-INST: vlseg3bff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x53]
+
 vlseg3bff.v v4, (a0), v0.t
+# CHECK-INST: vlseg3bff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x51]
+
 vlseg3hff.v v4, (a0)
+# CHECK-INST: vlseg3hff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x53]
+
 vlseg3hff.v v4, 0(a0)
+# CHECK-INST: vlseg3hff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x53]
+
 vlseg3hff.v v4, (a0), v0.t
+# CHECK-INST: vlseg3hff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x51]
+
 vlseg3wff.v v4, (a0)
+# CHECK-INST: vlseg3wff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x53]
+
 vlseg3wff.v v4, 0(a0)
+# CHECK-INST: vlseg3wff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x53]
+
 vlseg3wff.v v4, (a0), v0.t
+# CHECK-INST: vlseg3wff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x51]
+
 vlseg3buff.v v4, (a0)
+# CHECK-INST: vlseg3buff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x43]
+
 vlseg3buff.v v4, 0(a0)
+# CHECK-INST: vlseg3buff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x43]
+
 vlseg3buff.v v4, (a0), v0.t
+# CHECK-INST: vlseg3buff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x41]
+
 vlseg3huff.v v4, (a0)
+# CHECK-INST: vlseg3huff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x43]
+
 vlseg3huff.v v4, 0(a0)
+# CHECK-INST: vlseg3huff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x43]
+
 vlseg3huff.v v4, (a0), v0.t
+# CHECK-INST: vlseg3huff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x41]
+
 vlseg3wuff.v v4, (a0)
+# CHECK-INST: vlseg3wuff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x43]
+
 vlseg3wuff.v v4, 0(a0)
+# CHECK-INST: vlseg3wuff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x43]
+
 vlseg3wuff.v v4, (a0), v0.t
+# CHECK-INST: vlseg3wuff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x41]
+
 vlseg3eff.v v4, (a0)
+# CHECK-INST: vlseg3eff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x43]
+
 vlseg3eff.v v4, 0(a0)
+# CHECK-INST: vlseg3eff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x43]
+
 vlseg3eff.v v4, (a0), v0.t
+# CHECK-INST: vlseg3eff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0x41]
 
 vlseg4bff.v v4, (a0)
+# CHECK-INST: vlseg4bff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x73]
+
 vlseg4bff.v v4, 0(a0)
+# CHECK-INST: vlseg4bff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x73]
+
 vlseg4bff.v v4, (a0), v0.t
+# CHECK-INST: vlseg4bff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x71]
+
 vlseg4hff.v v4, (a0)
+# CHECK-INST: vlseg4hff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x73]
+
 vlseg4hff.v v4, 0(a0)
+# CHECK-INST: vlseg4hff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x73]
+
 vlseg4hff.v v4, (a0), v0.t
+# CHECK-INST: vlseg4hff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x71]
+
 vlseg4wff.v v4, (a0)
+# CHECK-INST: vlseg4wff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x73]
+
 vlseg4wff.v v4, 0(a0)
+# CHECK-INST: vlseg4wff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x73]
+
 vlseg4wff.v v4, (a0), v0.t
+# CHECK-INST: vlseg4wff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x71]
+
 vlseg4buff.v v4, (a0)
+# CHECK-INST: vlseg4buff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x63]
+
 vlseg4buff.v v4, 0(a0)
+# CHECK-INST: vlseg4buff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x63]
+
 vlseg4buff.v v4, (a0), v0.t
+# CHECK-INST: vlseg4buff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x61]
+
 vlseg4huff.v v4, (a0)
+# CHECK-INST: vlseg4huff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x63]
+
 vlseg4huff.v v4, 0(a0)
+# CHECK-INST: vlseg4huff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x63]
+
 vlseg4huff.v v4, (a0), v0.t
+# CHECK-INST: vlseg4huff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x61]
+
 vlseg4wuff.v v4, (a0)
+# CHECK-INST: vlseg4wuff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x63]
+
 vlseg4wuff.v v4, 0(a0)
+# CHECK-INST: vlseg4wuff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x63]
+
 vlseg4wuff.v v4, (a0), v0.t
+# CHECK-INST: vlseg4wuff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x61]
+
 vlseg4eff.v v4, (a0)
+# CHECK-INST: vlseg4eff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x63]
+
 vlseg4eff.v v4, 0(a0)
+# CHECK-INST: vlseg4eff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x63]
+
 vlseg4eff.v v4, (a0), v0.t
+# CHECK-INST: vlseg4eff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0x61]
 
 vlseg5bff.v v4, (a0)
+# CHECK-INST: vlseg5bff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x93]
+
 vlseg5bff.v v4, 0(a0)
+# CHECK-INST: vlseg5bff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x93]
+
 vlseg5bff.v v4, (a0), v0.t
+# CHECK-INST: vlseg5bff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x91]
+
 vlseg5hff.v v4, (a0)
+# CHECK-INST: vlseg5hff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x93]
+
 vlseg5hff.v v4, 0(a0)
+# CHECK-INST: vlseg5hff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x93]
+
 vlseg5hff.v v4, (a0), v0.t
+# CHECK-INST: vlseg5hff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x91]
+
 vlseg5wff.v v4, (a0)
+# CHECK-INST: vlseg5wff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x93]
+
 vlseg5wff.v v4, 0(a0)
+# CHECK-INST: vlseg5wff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x93]
+
 vlseg5wff.v v4, (a0), v0.t
+# CHECK-INST: vlseg5wff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x91]
+
 vlseg5buff.v v4, (a0)
+# CHECK-INST: vlseg5buff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x83]
+
 vlseg5buff.v v4, 0(a0)
+# CHECK-INST: vlseg5buff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0x83]
+
 vlseg5buff.v v4, (a0), v0.t
+# CHECK-INST: vlseg5buff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0x81]
+
 vlseg5huff.v v4, (a0)
+# CHECK-INST: vlseg5huff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x83]
+
 vlseg5huff.v v4, 0(a0)
+# CHECK-INST: vlseg5huff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0x83]
+
 vlseg5huff.v v4, (a0), v0.t
+# CHECK-INST: vlseg5huff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0x81]
+
 vlseg5wuff.v v4, (a0)
+# CHECK-INST: vlseg5wuff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x83]
+
 vlseg5wuff.v v4, 0(a0)
+# CHECK-INST: vlseg5wuff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0x83]
+
 vlseg5wuff.v v4, (a0), v0.t
+# CHECK-INST: vlseg5wuff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0x81]
+
 vlseg5eff.v v4, (a0)
+# CHECK-INST: vlseg5eff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x83]
+
 vlseg5eff.v v4, 0(a0)
+# CHECK-INST: vlseg5eff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0x83]
+
 vlseg5eff.v v4, (a0), v0.t
+# CHECK-INST: vlseg5eff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0x81]
 
 vlseg6bff.v v4, (a0)
+# CHECK-INST: vlseg6bff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xb3]
+
 vlseg6bff.v v4, 0(a0)
+# CHECK-INST: vlseg6bff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xb3]
+
 vlseg6bff.v v4, (a0), v0.t
+# CHECK-INST: vlseg6bff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0xb1]
+
 vlseg6hff.v v4, (a0)
+# CHECK-INST: vlseg6hff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xb3]
+
 vlseg6hff.v v4, 0(a0)
+# CHECK-INST: vlseg6hff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xb3]
+
 vlseg6hff.v v4, (a0), v0.t
+# CHECK-INST: vlseg6hff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0xb1]
+
 vlseg6wff.v v4, (a0)
+# CHECK-INST: vlseg6wff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xb3]
+
 vlseg6wff.v v4, 0(a0)
+# CHECK-INST: vlseg6wff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xb3]
+
 vlseg6wff.v v4, (a0), v0.t
+# CHECK-INST: vlseg6wff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0xb1]
+
 vlseg6buff.v v4, (a0)
+# CHECK-INST: vlseg6buff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xa3]
+
 vlseg6buff.v v4, 0(a0)
+# CHECK-INST: vlseg6buff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xa3]
+
 vlseg6buff.v v4, (a0), v0.t
+# CHECK-INST: vlseg6buff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0xa1]
+
 vlseg6huff.v v4, (a0)
+# CHECK-INST: vlseg6huff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xa3]
+
 vlseg6huff.v v4, 0(a0)
+# CHECK-INST: vlseg6huff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xa3]
+
 vlseg6huff.v v4, (a0), v0.t
+# CHECK-INST: vlseg6huff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0xa1]
+
 vlseg6wuff.v v4, (a0)
+# CHECK-INST: vlseg6wuff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xa3]
+
 vlseg6wuff.v v4, 0(a0)
+# CHECK-INST: vlseg6wuff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xa3]
+
 vlseg6wuff.v v4, (a0), v0.t
+# CHECK-INST: vlseg6wuff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0xa1]
+
 vlseg6eff.v v4, (a0)
+# CHECK-INST: vlseg6eff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0xa3]
+
 vlseg6eff.v v4, 0(a0)
+# CHECK-INST: vlseg6eff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0xa3]
+
 vlseg6eff.v v4, (a0), v0.t
+# CHECK-INST: vlseg6eff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0xa1]
 
 vlseg7bff.v v4, (a0)
+# CHECK-INST: vlseg7bff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xd3]
+
 vlseg7bff.v v4, 0(a0)
+# CHECK-INST: vlseg7bff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xd3]
+
 vlseg7bff.v v4, (a0), v0.t
+# CHECK-INST: vlseg7bff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0xd1]
+
 vlseg7hff.v v4, (a0)
+# CHECK-INST: vlseg7hff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xd3]
+
 vlseg7hff.v v4, 0(a0)
+# CHECK-INST: vlseg7hff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xd3]
+
 vlseg7hff.v v4, (a0), v0.t
+# CHECK-INST: vlseg7hff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0xd1]
+
 vlseg7wff.v v4, (a0)
+# CHECK-INST: vlseg7wff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xd3]
+
 vlseg7wff.v v4, 0(a0)
+# CHECK-INST: vlseg7wff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xd3]
+
 vlseg7wff.v v4, (a0), v0.t
+# CHECK-INST: vlseg7wff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0xd1]
+
 vlseg7buff.v v4, (a0)
+# CHECK-INST: vlseg7buff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xc3]
+
 vlseg7buff.v v4, 0(a0)
+# CHECK-INST: vlseg7buff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xc3]
+
 vlseg7buff.v v4, (a0), v0.t
+# CHECK-INST: vlseg7buff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0xc1]
+
 vlseg7huff.v v4, (a0)
+# CHECK-INST: vlseg7huff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xc3]
+
 vlseg7huff.v v4, 0(a0)
+# CHECK-INST: vlseg7huff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xc3]
+
 vlseg7huff.v v4, (a0), v0.t
+# CHECK-INST: vlseg7huff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0xc1]
+
 vlseg7wuff.v v4, (a0)
+# CHECK-INST: vlseg7wuff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xc3]
+
 vlseg7wuff.v v4, 0(a0)
+# CHECK-INST: vlseg7wuff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xc3]
+
 vlseg7wuff.v v4, (a0), v0.t
+# CHECK-INST: vlseg7wuff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0xc1]
+
 vlseg7eff.v v4, (a0)
+# CHECK-INST: vlseg7eff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0xc3]
+
 vlseg7eff.v v4, 0(a0)
+# CHECK-INST: vlseg7eff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0xc3]
+
 vlseg7eff.v v4, (a0), v0.t
+# CHECK-INST: vlseg7eff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0xc1]
 
 vlseg8bff.v v4, (a0)
+# CHECK-INST: vlseg8bff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xf3]
+
 vlseg8bff.v v4, 0(a0)
+# CHECK-INST: vlseg8bff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xf3]
+
 vlseg8bff.v v4, (a0), v0.t
+# CHECK-INST: vlseg8bff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0xf1]
+
 vlseg8hff.v v4, (a0)
+# CHECK-INST: vlseg8hff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xf3]
+
 vlseg8hff.v v4, 0(a0)
+# CHECK-INST: vlseg8hff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xf3]
+
 vlseg8hff.v v4, (a0), v0.t
+# CHECK-INST: vlseg8hff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0xf1]
+
 vlseg8wff.v v4, (a0)
+# CHECK-INST: vlseg8wff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xf3]
+
 vlseg8wff.v v4, 0(a0)
+# CHECK-INST: vlseg8wff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xf3]
+
 vlseg8wff.v v4, (a0), v0.t
+# CHECK-INST: vlseg8wff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0xf1]
+
 vlseg8buff.v v4, (a0)
+# CHECK-INST: vlseg8buff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xe3]
+
 vlseg8buff.v v4, 0(a0)
+# CHECK-INST: vlseg8buff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x02,0x05,0xe3]
+
 vlseg8buff.v v4, (a0), v0.t
+# CHECK-INST: vlseg8buff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x02,0x05,0xe1]
+
 vlseg8huff.v v4, (a0)
+# CHECK-INST: vlseg8huff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xe3]
+
 vlseg8huff.v v4, 0(a0)
+# CHECK-INST: vlseg8huff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x52,0x05,0xe3]
+
 vlseg8huff.v v4, (a0), v0.t
+# CHECK-INST: vlseg8huff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x52,0x05,0xe1]
+
 vlseg8wuff.v v4, (a0)
+# CHECK-INST: vlseg8wuff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xe3]
+
 vlseg8wuff.v v4, 0(a0)
+# CHECK-INST: vlseg8wuff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x62,0x05,0xe3]
+
 vlseg8wuff.v v4, (a0), v0.t
+# CHECK-INST: vlseg8wuff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x62,0x05,0xe1]
+
 vlseg8eff.v v4, (a0)
+# CHECK-INST: vlseg8eff.v v4, (a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0xe3]
+
 vlseg8eff.v v4, 0(a0)
+# CHECK-INST: vlseg8eff.v v4, 0(a0)
+# CHECK-ENCODING: [0x07,0x72,0x05,0xe3]
+
 vlseg8eff.v v4, (a0), v0.t
+# CHECK-INST: vlseg8eff.v v4, (a0), v0.t
+# CHECK-ENCODING: [0x07,0x72,0x05,0xe1]
 
-# TODO: rvv 0.7.1 with A
+# TODO: rvv 0.7.1
 # vamoaddw.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamoaddw.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x06]
+
+# TODO: rvv 0.7.1
 # vamoaddw.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamoaddw.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x02]
+
+# TODO: rvv 0.7.1
 # vamoaddd.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamoaddd.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x06]
+
+# TODO: rvv 0.7.1
 # vamoaddd.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamoaddd.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x02]
+
+# TODO: rvv 0.7.1
 # vamoaddw.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoaddw.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x04]
+
+# TODO: rvv 0.7.1
 # vamoaddw.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoaddw.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x00]
+
+# TODO: rvv 0.7.1
 # vamoaddd.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoaddd.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x04]
+
+# TODO: rvv 0.7.1
 # vamoaddd.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoaddd.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x00]
+
+# TODO: rvv 0.7.1
 # vamoswapw.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamoswapw.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x0e]
+
+# TODO: rvv 0.7.1
 # vamoswapw.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamoswapw.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x0a]
+
+# TODO: rvv 0.7.1
 # vamoswapd.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamoswapd.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x0e]
+
+# TODO: rvv 0.7.1
 # vamoswapd.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamoswapd.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x0a]
+
+# TODO: rvv 0.7.1
 # vamoswapw.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoswapw.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x0c]
+
+# TODO: rvv 0.7.1
 # vamoswapw.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoswapw.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x08]
+
+# TODO: rvv 0.7.1
 # vamoswapd.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoswapd.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x0c]
+
+# TODO: rvv 0.7.1
 # vamoswapd.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoswapd.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x08]
 
+# TODO: rvv 0.7.1
 # vamoxorw.v v4, v8, (a1), v4
-# vamoxorw.v zero, v8, (a1), v4
-# vamoxord.v v4, v8, (a1), v4
-# vamoxord.v zero, v8, (a1), v4
-# vamoxorw.v v4, v8, (a1), v4, v0.t
-# vamoxorw.v zero, v8, (a1), v4, v0.t
-# vamoxord.v v4, v8, (a1), v4, v0.t
-# vamoxord.v zero, v8, (a1), v4, v0.t
-# vamoandw.v v4, v8, (a1), v4
-# vamoandw.v zero, v8, (a1), v4
-# vamoandd.v v4, v8, (a1), v4
-# vamoandd.v zero, v8, (a1), v4
-# vamoandw.v v4, v8, (a1), v4, v0.t
-# vamoandw.v zero, v8, (a1), v4, v0.t
-# vamoandd.v v4, v8, (a1), v4, v0.t
-# vamoandd.v zero, v8, (a1), v4, v0.t
-# vamoorw.v v4, v8, (a1), v4
-# vamoorw.v zero, v8, (a1), v4
-# vamoord.v v4, v8, (a1), v4
-# vamoord.v zero, v8, (a1), v4
-# vamoorw.v v4, v8, (a1), v4, v0.t
-# vamoorw.v zero, v8, (a1), v4, v0.t
-# vamoord.v v4, v8, (a1), v4, v0.t
-# vamoord.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoxorw.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x26]
 
+# TODO: rvv 0.7.1
+# vamoxorw.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamoxorw.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x22]
+
+# TODO: rvv 0.7.1
+# vamoxord.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamoxord.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x26]
+
+# TODO: rvv 0.7.1
+# vamoxord.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamoxord.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x22]
+
+# TODO: rvv 0.7.1
+# vamoxorw.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoxorw.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x24]
+
+# TODO: rvv 0.7.1
+# vamoxorw.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoxorw.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x20]
+
+# TODO: rvv 0.7.1
+# vamoxord.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoxord.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x24]
+
+# TODO: rvv 0.7.1
+# vamoxord.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoxord.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x20]
+
+# TODO: rvv 0.7.1
+# vamoandw.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamoandw.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x66]
+
+# TODO: rvv 0.7.1
+# vamoandw.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamoandw.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x62]
+
+# TODO: rvv 0.7.1
+# vamoandd.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamoandd.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x66]
+
+# TODO: rvv 0.7.1
+# vamoandd.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamoandd.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x62]
+
+# TODO: rvv 0.7.1
+# vamoandw.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoandw.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x64]
+
+# TODO: rvv 0.7.1
+# vamoandw.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoandw.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x60]
+
+# TODO: rvv 0.7.1
+# vamoandd.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoandd.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x64]
+
+# TODO: rvv 0.7.1
+# vamoandd.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoandd.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x60]
+
+# TODO: rvv 0.7.1
+# vamoorw.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamoorw.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x46]
+
+# TODO: rvv 0.7.1
+# vamoorw.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamoorw.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x42]
+
+# TODO: rvv 0.7.1
+# vamoord.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamoord.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x46]
+
+# TODO: rvv 0.7.1
+# vamoord.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamoord.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x42]
+
+# TODO: rvv 0.7.1
+# vamoorw.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoorw.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x44]
+
+# TODO: rvv 0.7.1
+# vamoorw.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoorw.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x40]
+
+# TODO: rvv 0.7.1
+# vamoord.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoord.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x44]
+
+# TODO: rvv 0.7.1
+# vamoord.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamoord.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x40]
+
+# TODO: rvv 0.7.1
 # vamominw.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamominw.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x86]
+
+# TODO: rvv 0.7.1
 # vamominw.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamominw.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x82]
+
+# TODO: rvv 0.7.1
 # vamomind.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamomind.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x86]
+
+# TODO: rvv 0.7.1
 # vamomind.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamomind.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x82]
+
+# TODO: rvv 0.7.1
 # vamominw.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamominw.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x84]
+
+# TODO: rvv 0.7.1
 # vamominw.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamominw.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0x80]
+
+# TODO: rvv 0.7.1
 # vamomind.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamomind.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x84]
+
+# TODO: rvv 0.7.1
 # vamomind.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamomind.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0x80]
+
+# TODO: rvv 0.7.1
 # vamomaxw.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamomaxw.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0xa6]
+
+# TODO: rvv 0.7.1
 # vamomaxw.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamomaxw.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0xa2]
+
+# TODO: rvv 0.7.1
 # vamomaxd.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamomaxd.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0xa6]
+
+# TODO: rvv 0.7.1
 # vamomaxd.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamomaxd.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0xa2]
+
+# TODO: rvv 0.7.1
 # vamomaxw.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamomaxw.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0xa4]
+
+# TODO: rvv 0.7.1
 # vamomaxw.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamomaxw.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0xa0]
+
+# TODO: rvv 0.7.1
 # vamomaxd.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamomaxd.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0xa4]
+
+# TODO: rvv 0.7.1
 # vamomaxd.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamomaxd.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0xa0]
+
+# TODO: rvv 0.7.1
 # vamominuw.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamominuw.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0xc6]
+
+# TODO: rvv 0.7.1
 # vamominuw.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamominuw.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0xc2]
+
+# TODO: rvv 0.7.1
 # vamominud.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamominud.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0xc6]
+
+# TODO: rvv 0.7.1
 # vamominud.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamominud.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0xc2]
+
+# TODO: rvv 0.7.1
 # vamominuw.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamominuw.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0xc4]
+
+# TODO: rvv 0.7.1
 # vamominuw.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamominuw.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0xc0]
+
+# TODO: rvv 0.7.1
 # vamominud.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamominud.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0xc4]
+
+# TODO: rvv 0.7.1
 # vamominud.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamominud.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0xc0]
+
+# TODO: rvv 0.7.1
 # vamomaxuw.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamomaxuw.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0xe6]
+
+# TODO: rvv 0.7.1
 # vamomaxuw.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamomaxuw.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0xe2]
+
+# TODO: rvv 0.7.1
 # vamomaxud.v v4, v8, (a1), v4
+# CHECK-INST-TODO: vamomaxud.v v4, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0xe6]
+
+# TODO: rvv 0.7.1
 # vamomaxud.v zero, v8, (a1), v4
+# CHECK-INST-TODO: vamomaxud.v zero, v8, (a1), v4
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0xe2]
+
+# TODO: rvv 0.7.1
 # vamomaxuw.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamomaxuw.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0xe4]
+
+# TODO: rvv 0.7.1
 # vamomaxuw.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamomaxuw.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xe2,0x85,0xe0]
+
+# TODO: rvv 0.7.1
 # vamomaxud.v v4, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamomaxud.v v4, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0xe4]
+
+# TODO: rvv 0.7.1
 # vamomaxud.v zero, v8, (a1), v4, v0.t
+# CHECK-INST-TODO: vamomaxud.v zero, v8, (a1), v4, v0.t
+# CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0xe0]
 
 vadd.vv v4, v8, v12
+# CHECK-INST: vadd.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x02]
+
 vadd.vx v4, v8, a1
+# CHECK-INST: vadd.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x02]
+
 vadd.vi v4, v8, 15
+# CHECK-INST: vadd.vi v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x02]
+
 vadd.vi v4, v8, -16
+# CHECK-INST: vadd.vi v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x02]
+
 vadd.vv v4, v8, v12, v0.t
+# CHECK-INST: vadd.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x00]
+
 vadd.vx v4, v8, a1, v0.t
+# CHECK-INST: vadd.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x00]
+
 vadd.vi v4, v8, 15, v0.t
+# CHECK-INST: vadd.vi v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x00]
+
 vadd.vi v4, v8, -16, v0.t
+# CHECK-INST: vadd.vi v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x00]
+
 vsub.vv v4, v8, v12
+# CHECK-INST: vsub.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x0a]
+
 vsub.vx v4, v8, a1
+# CHECK-INST: vsub.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x0a]
+
 vrsub.vx v4, v8, a1
+# CHECK-INST: vrsub.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x0e]
+
 vrsub.vi v4, v8, 15
+# CHECK-INST: vrsub.vi v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x0e]
+
 vrsub.vi v4, v8, -16
+# CHECK-INST: vrsub.vi v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x0e]
+
 vsub.vv v4, v8, v12, v0.t
+# CHECK-INST: vsub.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x08]
+
 vsub.vx v4, v8, a1, v0.t
+# CHECK-INST: vsub.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x08]
+
 vrsub.vx v4, v8, a1, v0.t
+# CHECK-INST: vrsub.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x0c]
+
 vrsub.vi v4, v8, 15, v0.t
+# CHECK-INST: vrsub.vi v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x0c]
+
 vrsub.vi v4, v8, -16, v0.t
+# CHECK-INST: vrsub.vi v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x0c]
 
 # TODO: rvv 0.7.1
 # Aliases
 # vwcvt.x.x.v v4, v8
+# CHECK-INST-TODO: vwcvt.x.x.v v4, v8
+# CHECK-ENCODING-TODO: [0x57,0x62,0x80,0xc6]
+
+# TODO: rvv 0.7.1
 # vwcvtu.x.x.v v4, v8
+# CHECK-INST-TODO: vwcvtu.x.x.v v4, v8
+# CHECK-ENCODING-TODO: [0x57,0x62,0x80,0xc2]
+
+# TODO: rvv 0.7.1
 # vwcvt.x.x.v v4, v8, v0.t
+# CHECK-INST-TODO: vwcvt.x.x.v v4, v8, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x62,0x80,0xc4]
+
+# TODO: rvv 0.7.1
 # vwcvtu.x.x.v v4, v8, v0.t
+# CHECK-INST-TODO: vwcvtu.x.x.v v4, v8, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x62,0x80,0xc0]
 
 vwaddu.vv v4, v8, v12
+# CHECK-INST: vwaddu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0xc2]
+
 vwaddu.vx v4, v8, a1
+# CHECK-INST: vwaddu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xc2]
+
 vwaddu.vv v4, v8, v12, v0.t
+# CHECK-INST: vwaddu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xc0]
+
 vwaddu.vx v4, v8, a1, v0.t
+# CHECK-INST: vwaddu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xc0]
+
 vwsubu.vv v4, v8, v12
+# CHECK-INST: vwsubu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0xca]
+
 vwsubu.vx v4, v8, a1
+# CHECK-INST: vwsubu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xca]
+
 vwsubu.vv v4, v8, v12, v0.t
+# CHECK-INST: vwsubu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xc8]
+
 vwsubu.vx v4, v8, a1, v0.t
+# CHECK-INST: vwsubu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xc8]
+
 vwadd.vv v4, v8, v12
+# CHECK-INST: vwadd.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0xc6]
+
 vwadd.vx v4, v8, a1
+# CHECK-INST: vwadd.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xc6]
+
 vwadd.vv v4, v8, v12, v0.t
+# CHECK-INST: vwadd.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xc4]
+
 vwadd.vx v4, v8, a1, v0.t
+# CHECK-INST: vwadd.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xc4]
+
 vwsub.vv v4, v8, v12
+# CHECK-INST: vwsub.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0xce]
+
 vwsub.vx v4, v8, a1
+# CHECK-INST: vwsub.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xce]
+
 vwsub.vv v4, v8, v12, v0.t
+# CHECK-INST: vwsub.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xcc]
+
 vwsub.vx v4, v8, a1, v0.t
+# CHECK-INST: vwsub.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xcc]
+
 vwaddu.wv v4, v8, v12
+# CHECK-INST: vwaddu.wv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0xd2]
+
 vwaddu.wx v4, v8, a1
+# CHECK-INST: vwaddu.wx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xd2]
+
 vwaddu.wv v4, v8, v12, v0.t
+# CHECK-INST: vwaddu.wv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xd0]
+
 vwaddu.wx v4, v8, a1, v0.t
+# CHECK-INST: vwaddu.wx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xd0]
+
 vwsubu.wv v4, v8, v12
+# CHECK-INST: vwsubu.wv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0xda]
+
 vwsubu.wx v4, v8, a1
+# CHECK-INST: vwsubu.wx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xda]
+
 vwsubu.wv v4, v8, v12, v0.t
+# CHECK-INST: vwsubu.wv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xd8]
+
 vwsubu.wx v4, v8, a1, v0.t
+# CHECK-INST: vwsubu.wx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xd8]
+
 vwadd.wv v4, v8, v12
+# CHECK-INST: vwadd.wv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0xd6]
+
 vwadd.wx v4, v8, a1
+# CHECK-INST: vwadd.wx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xd6]
+
 vwadd.wv v4, v8, v12, v0.t
+# CHECK-INST: vwadd.wv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xd4]
+
 vwadd.wx v4, v8, a1, v0.t
+# CHECK-INST: vwadd.wx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xd4]
+
 vwsub.wv v4, v8, v12
+# CHECK-INST: vwsub.wv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0xde]
+
 vwsub.wx v4, v8, a1
+# CHECK-INST: vwsub.wx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xde]
+
 vwsub.wv v4, v8, v12, v0.t
+# CHECK-INST: vwsub.wv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xdc]
+
 vwsub.wx v4, v8, a1, v0.t
+# CHECK-INST: vwsub.wx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xdc]
 
 vadc.vvm v4, v8, v12, v0
+# CHECK-INST: vadc.vvm v4, v8, v12, v0
+# CHECK-ENCODING: [0x57,0x02,0x86,0x42]
+
 vadc.vxm v4, v8, a1, v0
+# CHECK-INST: vadc.vxm v4, v8, a1, v0
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x42]
+
 vadc.vim v4, v8, 15, v0
+# CHECK-INST: vadc.vim v4, v8, 15, v0
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x42]
+
 vadc.vim v4, v8, -16, v0
+# CHECK-INST: vadc.vim v4, v8, -16, v0
+# CHECK-ENCODING: [0x57,0x32,0x88,0x42]
+
 vmadc.vvm v4, v8, v12, v0
+# CHECK-INST: vmadc.vvm v4, v8, v12, v0
+# CHECK-ENCODING: [0x57,0x02,0x86,0x46]
+
 vmadc.vxm v4, v8, a1, v0
+# CHECK-INST: vmadc.vxm v4, v8, a1, v0
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x46]
+
 vmadc.vim v4, v8, 15, v0
+# CHECK-INST: vmadc.vim v4, v8, 15, v0
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x46]
+
 vmadc.vim v4, v8, -16, v0
+# CHECK-INST: vmadc.vim v4, v8, -16, v0
+# CHECK-ENCODING: [0x57,0x32,0x88,0x46]
+
 vsbc.vvm v4, v8, v12, v0
+# CHECK-INST: vsbc.vvm v4, v8, v12, v0
+# CHECK-ENCODING: [0x57,0x02,0x86,0x4a]
+
 vsbc.vxm v4, v8, a1, v0
+# CHECK-INST: vsbc.vxm v4, v8, a1, v0
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x4a]
+
 vmsbc.vvm v4, v8, v12, v0
+# CHECK-INST: vmsbc.vvm v4, v8, v12, v0
+# CHECK-ENCODING: [0x57,0x02,0x86,0x4e]
+
 vmsbc.vxm v4, v8, a1, v0
+# CHECK-INST: vmsbc.vxm v4, v8, a1, v0
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x4e]
 
 # TODO: rvv 0.7.1
 # Aliases
 # vnot.v v4, v8
+# CHECK-INST-TODO: vnot.v v4, v8
+# CHECK-ENCODING-TODO: [0x57,0xb2,0x8f,0x2e]
+
+# TODO: rvv 0.7.1
 # vnot.v v4, v8, v0.t
+# CHECK-INST-TODO: vnot.v v4, v8, v0.t
+# CHECK-ENCODING-TODO: [0x57,0xb2,0x8f,0x2c]
 
 vand.vv v4, v8, v12
+# CHECK-INST: vand.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x26]
+
 vand.vx v4, v8, a1
+# CHECK-INST: vand.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x26]
+
 vand.vi v4, v8, 15
+# CHECK-INST: vand.vi v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x26]
+
 vand.vi v4, v8, -16
+# CHECK-INST: vand.vi v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x26]
+
 vand.vv v4, v8, v12, v0.t
+# CHECK-INST: vand.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x24]
+
 vand.vx v4, v8, a1, v0.t
+# CHECK-INST: vand.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x24]
+
 vand.vi v4, v8, 15, v0.t
+# CHECK-INST: vand.vi v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x24]
+
 vand.vi v4, v8, -16, v0.t
+# CHECK-INST: vand.vi v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x24]
+
 vor.vv v4, v8, v12
+# CHECK-INST: vor.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x2a]
+
 vor.vx v4, v8, a1
+# CHECK-INST: vor.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x2a]
+
 vor.vi v4, v8, 15
+# CHECK-INST: vor.vi v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x2a]
+
 vor.vi v4, v8, -16
+# CHECK-INST: vor.vi v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x2a]
+
 vor.vv v4, v8, v12, v0.t
+# CHECK-INST: vor.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x28]
+
 vor.vx v4, v8, a1, v0.t
+# CHECK-INST: vor.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x28]
+
 vor.vi v4, v8, 15, v0.t
+# CHECK-INST: vor.vi v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x28]
+
 vor.vi v4, v8, -16, v0.t
+# CHECK-INST: vor.vi v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x28]
+
 vxor.vv v4, v8, v12
+# CHECK-INST: vxor.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x2e]
+
 vxor.vx v4, v8, a1
+# CHECK-INST: vxor.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x2e]
+
 vxor.vi v4, v8, 15
+# CHECK-INST: vxor.vi v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x2e]
+
 vxor.vi v4, v8, -16
+# CHECK-INST: vxor.vi v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x2e]
+
 vxor.vv v4, v8, v12, v0.t
+# CHECK-INST: vxor.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x2c]
+
 vxor.vx v4, v8, a1, v0.t
+# CHECK-INST: vxor.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x2c]
+
 vxor.vi v4, v8, 15, v0.t
+# CHECK-INST: vxor.vi v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x2c]
+
 vxor.vi v4, v8, -16, v0.t
+# CHECK-INST: vxor.vi v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x2c]
 
 vsll.vv v4, v8, v12
+# CHECK-INST: vsll.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x96]
+
 vsll.vx v4, v8, a1
+# CHECK-INST: vsll.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x96]
+
 vsll.vi v4, v8, 1
+# CHECK-INST: vsll.vi v4, v8, 1
+# CHECK-ENCODING: [0x57,0xb2,0x80,0x96]
+
 vsll.vi v4, v8, 31
+# CHECK-INST: vsll.vi v4, v8, 31
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0x96]
+
 vsll.vv v4, v8, v12, v0.t
+# CHECK-INST: vsll.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x94]
+
 vsll.vx v4, v8, a1, v0.t
+# CHECK-INST: vsll.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x94]
+
 vsll.vi v4, v8, 1, v0.t
+# CHECK-INST: vsll.vi v4, v8, 1, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x80,0x94]
+
 vsll.vi v4, v8, 31, v0.t
+# CHECK-INST: vsll.vi v4, v8, 31, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0x94]
+
 vsrl.vv v4, v8, v12
+# CHECK-INST: vsrl.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0xa2]
+
 vsrl.vx v4, v8, a1
+# CHECK-INST: vsrl.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xa2]
+
 vsrl.vi v4, v8, 1
+# CHECK-INST: vsrl.vi v4, v8, 1
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xa2]
+
 vsrl.vi v4, v8, 31
+# CHECK-INST: vsrl.vi v4, v8, 31
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xa2]
+
 vsrl.vv v4, v8, v12, v0.t
+# CHECK-INST: vsrl.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0xa0]
+
 vsrl.vx v4, v8, a1, v0.t
+# CHECK-INST: vsrl.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xa0]
+
 vsrl.vi v4, v8, 1, v0.t
+# CHECK-INST: vsrl.vi v4, v8, 1, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xa0]
+
 vsrl.vi v4, v8, 31, v0.t
+# CHECK-INST: vsrl.vi v4, v8, 31, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xa0]
+
 vsra.vv v4, v8, v12
+# CHECK-INST: vsra.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0xa6]
+
 vsra.vx v4, v8, a1
+# CHECK-INST: vsra.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xa6]
+
 vsra.vi v4, v8, 1
+# CHECK-INST: vsra.vi v4, v8, 1
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xa6]
+
 vsra.vi v4, v8, 31
+# CHECK-INST: vsra.vi v4, v8, 31
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xa6]
+
 vsra.vv v4, v8, v12, v0.t
+# CHECK-INST: vsra.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0xa4]
+
 vsra.vx v4, v8, a1, v0.t
+# CHECK-INST: vsra.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xa4]
+
 vsra.vi v4, v8, 1, v0.t
+# CHECK-INST: vsra.vi v4, v8, 1, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xa4]
+
 vsra.vi v4, v8, 31, v0.t
+# CHECK-INST: vsra.vi v4, v8, 31, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xa4]
 
 vnsrl.vv v4, v8, v12
+# CHECK-INST: vnsrl.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0xb2]
+
 vnsrl.vx v4, v8, a1
+# CHECK-INST: vnsrl.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xb2]
+
 vnsrl.vi v4, v8, 1
+# CHECK-INST: vnsrl.vi v4, v8, 1
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xb2]
+
 vnsrl.vi v4, v8, 31
+# CHECK-INST: vnsrl.vi v4, v8, 31
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xb2]
+
 vnsrl.vv v4, v8, v12, v0.t
+# CHECK-INST: vnsrl.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0xb0]
+
 vnsrl.vx v4, v8, a1, v0.t
+# CHECK-INST: vnsrl.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xb0]
+
 vnsrl.vi v4, v8, 1, v0.t
+# CHECK-INST: vnsrl.vi v4, v8, 1, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xb0]
+
 vnsrl.vi v4, v8, 31, v0.t
+# CHECK-INST: vnsrl.vi v4, v8, 31, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xb0]
+
 vnsra.vv v4, v8, v12
+# CHECK-INST: vnsra.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0xb6]
+
 vnsra.vx v4, v8, a1
+# CHECK-INST: vnsra.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xb6]
+
 vnsra.vi v4, v8, 1
+# CHECK-INST: vnsra.vi v4, v8, 1
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xb6]
+
 vnsra.vi v4, v8, 31
+# CHECK-INST: vnsra.vi v4, v8, 31
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xb6]
+
 vnsra.vv v4, v8, v12, v0.t
+# CHECK-INST: vnsra.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0xb4]
+
 vnsra.vx v4, v8, a1, v0.t
+# CHECK-INST: vnsra.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xb4]
+
 vnsra.vi v4, v8, 1, v0.t
+# CHECK-INST: vnsra.vi v4, v8, 1, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xb4]
+
 vnsra.vi v4, v8, 31, v0.t
+# CHECK-INST: vnsra.vi v4, v8, 31, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xb4]
 
 # TODO: rvv 0.7.1
 # Aliases
 # vmsgt.vv v4, v8, v12
+# CHECK-INST-TODO: vmsgt.vv v4, v8, v12
+# CHECK-ENCODING-TODO: [0x57,0x02,0xc4,0x6e]
+
+# TODO: rvv 0.7.1
 # vmsgtu.vv v4, v8, v12
+# CHECK-INST-TODO: vmsgtu.vv v4, v8, v12
+# CHECK-ENCODING-TODO: [0x57,0x02,0xc4,0x6a]
+
+# TODO: rvv 0.7.1
 # vmsge.vv v4, v8, v12
+# CHECK-INST-TODO: vmsge.vv v4, v8, v12
+# CHECK-ENCODING-TODO: [0x57,0x02,0xc4,0x76]
+
+# TODO: rvv 0.7.1
 # vmsgeu.vv v4, v8, v12
+# CHECK-INST-TODO: vmsgeu.vv v4, v8, v12
+# CHECK-ENCODING-TODO: [0x57,0x02,0xc4,0x72]
+
+# TODO: rvv 0.7.1
 # vmsgt.vv v4, v8, v12, v0.t
+# CHECK-INST-TODO: vmsgt.vv v4, v8, v12, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x02,0xc4,0x6c]
+
+# TODO: rvv 0.7.1
 # vmsgtu.vv v4, v8, v12, v0.t
+# CHECK-INST-TODO: vmsgtu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x02,0xc4,0x68]
+
+# TODO: rvv 0.7.1
 # vmsge.vv v4, v8, v12, v0.t
+# CHECK-INST-TODO: vmsge.vv v4, v8, v12, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x02,0xc4,0x74]
+
+# TODO: rvv 0.7.1
 # vmsgeu.vv v4, v8, v12, v0.t
+# CHECK-INST-TODO: vmsgeu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x02,0xc4,0x70]
+
+# TODO: rvv 0.7.1
 # vmslt.vi v4, v8, 16
+# CHECK-INST-TODO: vmslt.vi v4, v8, 16
+# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x76]
+
+# TODO: rvv 0.7.1
 # vmslt.vi v4, v8, -15
+# CHECK-INST-TODO: vmslt.vi v4, v8, -15
+# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x76]
+
+# TODO: rvv 0.7.1
 # vmsltu.vi v4, v8, 16
+# CHECK-INST-TODO: vmsltu.vi v4, v8, 16
+# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x72]
+
+# TODO: rvv 0.7.1
 # vmsltu.vi v4, v8, -15
+# CHECK-INST-TODO: vmsltu.vi v4, v8, -15
+# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x72]
+
+# TODO: rvv 0.7.1
 # vmsge.vi v4, v8, 16
+# CHECK-INST-TODO: vmsge.vi v4, v8, 16
+# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x7e]
+
+# TODO: rvv 0.7.1
 # vmsge.vi v4, v8, -15
+# CHECK-INST-TODO: vmsge.vi v4, v8, -15
+# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x7e]
+
+# TODO: rvv 0.7.1
 # vmsgeu.vi v4, v8, 16
+# CHECK-INST-TODO: vmsgeu.vi v4, v8, 16
+# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x7a]
+
+# TODO: rvv 0.7.1
 # vmsgeu.vi v4, v8, -15
+# CHECK-INST-TODO: vmsgeu.vi v4, v8, -15
+# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x7a]
+
+# TODO: rvv 0.7.1
 # vmslt.vi v4, v8, 16, v0.t
+# CHECK-INST-TODO: vmslt.vi v4, v8, 16, v0.t
+# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x74]
+
+# TODO: rvv 0.7.1
 # vmslt.vi v4, v8, -15, v0.t
+# CHECK-INST-TODO: vmslt.vi v4, v8, -15, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x74]
+
+# TODO: rvv 0.7.1
 # vmsltu.vi v4, v8, 16, v0.t
+# CHECK-INST-TODO: vmsltu.vi v4, v8, 16, v0.t
+# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x70]
+
+# TODO: rvv 0.7.1
 # vmsltu.vi v4, v8, -15, v0.t
+# CHECK-INST-TODO: vmsltu.vi v4, v8, -15, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x70]
+
+# TODO: rvv 0.7.1
 # vmsge.vi v4, v8, 16, v0.t
+# CHECK-INST-TODO: vmsge.vi v4, v8, 16, v0.t
+# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x7c]
+
+# TODO: rvv 0.7.1
 # vmsge.vi v4, v8, -15, v0.t
+# CHECK-INST-TODO: vmsge.vi v4, v8, -15, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x7c]
+
+# TODO: rvv 0.7.1
 # vmsgeu.vi v4, v8, 16, v0.t
+# CHECK-INST-TODO: vmsgeu.vi v4, v8, 16, v0.t
+# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x78]
+
+# TODO: rvv 0.7.1
 # vmsgeu.vi v4, v8, -15, v0.t
+# CHECK-INST-TODO: vmsgeu.vi v4, v8, -15, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x78]
 
 # TODO: rvv 0.7.1
 # Macros
@@ -1269,553 +4936,2009 @@ vnsra.vi v4, v8, 31, v0.t
 # vmsgeu.vx v4, v8, a1, v0.t, v12
 
 vmseq.vv v4, v8, v12
+# CHECK-INST: vmseq.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x62]
+
 vmseq.vx v4, v8, a1
+# CHECK-INST: vmseq.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x62]
+
 vmseq.vi v4, v8, 15
+# CHECK-INST: vmseq.vi v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x62]
+
 vmseq.vi v4, v8, -16
+# CHECK-INST: vmseq.vi v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x62]
+
 vmseq.vv v4, v8, v12, v0.t
+# CHECK-INST: vmseq.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x60]
+
 vmseq.vx v4, v8, a1, v0.t
+# CHECK-INST: vmseq.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x60]
+
 vmseq.vi v4, v8, 15, v0.t
+# CHECK-INST: vmseq.vi v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x60]
+
 vmseq.vi v4, v8, -16, v0.t
+# CHECK-INST: vmseq.vi v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x60]
+
 vmsne.vv v4, v8, v12
+# CHECK-INST: vmsne.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x66]
+
 vmsne.vx v4, v8, a1
+# CHECK-INST: vmsne.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x66]
+
 vmsne.vi v4, v8, 15
+# CHECK-INST: vmsne.vi v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x66]
+
 vmsne.vi v4, v8, -16
+# CHECK-INST: vmsne.vi v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x66]
+
 vmsne.vv v4, v8, v12, v0.t
+# CHECK-INST: vmsne.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x64]
+
 vmsne.vx v4, v8, a1, v0.t
+# CHECK-INST: vmsne.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x64]
+
 vmsne.vi v4, v8, 15, v0.t
+# CHECK-INST: vmsne.vi v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x64]
+
 vmsne.vi v4, v8, -16, v0.t
+# CHECK-INST: vmsne.vi v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x64]
+
 vmsltu.vv v4, v8, v12
+# CHECK-INST: vmsltu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x6a]
+
 vmsltu.vx v4, v8, a1
+# CHECK-INST: vmsltu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x6a]
+
 vmsltu.vv v4, v8, v12, v0.t
+# CHECK-INST: vmsltu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x68]
+
 vmsltu.vx v4, v8, a1, v0.t
+# CHECK-INST: vmsltu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x68]
+
 vmslt.vv v4, v8, v12
+# CHECK-INST: vmslt.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x6e]
+
 vmslt.vx v4, v8, a1
+# CHECK-INST: vmslt.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x6e]
+
 vmslt.vv v4, v8, v12, v0.t
+# CHECK-INST: vmslt.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x6c]
+
 vmslt.vx v4, v8, a1, v0.t
+# CHECK-INST: vmslt.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x6c]
+
 vmsleu.vv v4, v8, v12
+# CHECK-INST: vmsleu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x72]
+
 vmsleu.vx v4, v8, a1
+# CHECK-INST: vmsleu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x72]
+
 vmsleu.vi v4, v8, 15
+# CHECK-INST: vmsleu.vi v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x72]
+
 vmsleu.vi v4, v8, -16
+# CHECK-INST: vmsleu.vi v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x72]
+
 vmsleu.vv v4, v8, v12, v0.t
+# CHECK-INST: vmsleu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x70]
+
 vmsleu.vx v4, v8, a1, v0.t
+# CHECK-INST: vmsleu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x70]
+
 vmsleu.vi v4, v8, 15, v0.t
+# CHECK-INST: vmsleu.vi v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x70]
+
 vmsleu.vi v4, v8, -16, v0.t
+# CHECK-INST: vmsleu.vi v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x70]
+
 vmsle.vv v4, v8, v12
+# CHECK-INST: vmsle.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x76]
+
 vmsle.vx v4, v8, a1
+# CHECK-INST: vmsle.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x76]
+
 vmsle.vi v4, v8, 15
+# CHECK-INST: vmsle.vi v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x76]
+
 vmsle.vi v4, v8, -16
+# CHECK-INST: vmsle.vi v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x76]
+
 vmsle.vv v4, v8, v12, v0.t
+# CHECK-INST: vmsle.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x74]
+
 vmsle.vx v4, v8, a1, v0.t
+# CHECK-INST: vmsle.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x74]
+
 vmsle.vi v4, v8, 15, v0.t
+# CHECK-INST: vmsle.vi v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x74]
+
 vmsle.vi v4, v8, -16, v0.t
+# CHECK-INST: vmsle.vi v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x74]
+
 vmsgtu.vx v4, v8, a1
+# CHECK-INST: vmsgtu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x7a]
+
 vmsgtu.vi v4, v8, 15
+# CHECK-INST: vmsgtu.vi v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x7a]
+
 vmsgtu.vi v4, v8, -16
+# CHECK-INST: vmsgtu.vi v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x7a]
+
 vmsgtu.vx v4, v8, a1, v0.t
+# CHECK-INST: vmsgtu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x78]
+
 vmsgtu.vi v4, v8, 15, v0.t
+# CHECK-INST: vmsgtu.vi v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x78]
+
 vmsgtu.vi v4, v8, -16, v0.t
+# CHECK-INST: vmsgtu.vi v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x78]
+
 vmsgt.vx v4, v8, a1
+# CHECK-INST: vmsgt.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x7e]
+
 vmsgt.vi v4, v8, 15
+# CHECK-INST: vmsgt.vi v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x7e]
+
 vmsgt.vi v4, v8, -16
+# CHECK-INST: vmsgt.vi v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x7e]
+
 vmsgt.vx v4, v8, a1, v0.t
+# CHECK-INST: vmsgt.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x7c]
+
 vmsgt.vi v4, v8, 15, v0.t
+# CHECK-INST: vmsgt.vi v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x7c]
+
 vmsgt.vi v4, v8, -16, v0.t
+# CHECK-INST: vmsgt.vi v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x7c]
 
 vminu.vv v4, v8, v12
+# CHECK-INST: vminu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x12]
+
 vminu.vx v4, v8, a1
+# CHECK-INST: vminu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x12]
+
 vminu.vv v4, v8, v12, v0.t
+# CHECK-INST: vminu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x10]
+
 vminu.vx v4, v8, a1, v0.t
+# CHECK-INST: vminu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x10]
+
 vmin.vv v4, v8, v12
+# CHECK-INST: vmin.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x16]
+
 vmin.vx v4, v8, a1
+# CHECK-INST: vmin.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x16]
+
 vmin.vv v4, v8, v12, v0.t
+# CHECK-INST: vmin.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x14]
+
 vmin.vx v4, v8, a1, v0.t
+# CHECK-INST: vmin.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x14]
+
 vmaxu.vv v4, v8, v12
+# CHECK-INST: vmaxu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x1a]
+
 vmaxu.vx v4, v8, a1
+# CHECK-INST: vmaxu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x1a]
+
 vmaxu.vv v4, v8, v12, v0.t
+# CHECK-INST: vmaxu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x18]
+
 vmaxu.vx v4, v8, a1, v0.t
+# CHECK-INST: vmaxu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x18]
+
 vmax.vv v4, v8, v12
+# CHECK-INST: vmax.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x1e]
+
 vmax.vx v4, v8, a1
+# CHECK-INST: vmax.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x1e]
+
 vmax.vv v4, v8, v12, v0.t
+# CHECK-INST: vmax.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x1c]
+
 vmax.vx v4, v8, a1, v0.t
+# CHECK-INST: vmax.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x1c]
 
 vmul.vv v4, v8, v12
+# CHECK-INST: vmul.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x96]
+
 vmul.vx v4, v8, a1
+# CHECK-INST: vmul.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x96]
+
 vmul.vv v4, v8, v12, v0.t
+# CHECK-INST: vmul.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0x94]
+
 vmul.vx v4, v8, a1, v0.t
+# CHECK-INST: vmul.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x94]
+
 vmulh.vv v4, v8, v12
+# CHECK-INST: vmulh.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x9e]
+
 vmulh.vx v4, v8, a1
+# CHECK-INST: vmulh.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x9e]
+
 vmulh.vv v4, v8, v12, v0.t
+# CHECK-INST: vmulh.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0x9c]
+
 vmulh.vx v4, v8, a1, v0.t
+# CHECK-INST: vmulh.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x9c]
+
 vmulhu.vv v4, v8, v12
+# CHECK-INST: vmulhu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x92]
+
 vmulhu.vx v4, v8, a1
+# CHECK-INST: vmulhu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x92]
+
 vmulhu.vv v4, v8, v12, v0.t
+# CHECK-INST: vmulhu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0x90]
+
 vmulhu.vx v4, v8, a1, v0.t
+# CHECK-INST: vmulhu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x90]
+
 vmulhsu.vv v4, v8, v12
+# CHECK-INST: vmulhsu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x9a]
+
 vmulhsu.vx v4, v8, a1
+# CHECK-INST: vmulhsu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x9a]
+
 vmulhsu.vv v4, v8, v12, v0.t
+# CHECK-INST: vmulhsu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0x98]
+
 vmulhsu.vx v4, v8, a1, v0.t
+# CHECK-INST: vmulhsu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x98]
 
 vwmul.vv v4, v8, v12
+# CHECK-INST: vwmul.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0xee]
+
 vwmul.vx v4, v8, a1
+# CHECK-INST: vwmul.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xee]
+
 vwmul.vv v4, v8, v12, v0.t
+# CHECK-INST: vwmul.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xec]
+
 vwmul.vx v4, v8, a1, v0.t
+# CHECK-INST: vwmul.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xec]
+
 vwmulu.vv v4, v8, v12
+# CHECK-INST: vwmulu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0xe2]
+
 vwmulu.vx v4, v8, a1
+# CHECK-INST: vwmulu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xe2]
+
 vwmulu.vv v4, v8, v12, v0.t
+# CHECK-INST: vwmulu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xe0]
+
 vwmulu.vx v4, v8, a1, v0.t
+# CHECK-INST: vwmulu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xe0]
+
 vwmulsu.vv v4, v8, v12
+# CHECK-INST: vwmulsu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0xea]
+
 vwmulsu.vx v4, v8, a1
+# CHECK-INST: vwmulsu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xea]
+
 vwmulsu.vv v4, v8, v12, v0.t
+# CHECK-INST: vwmulsu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xe8]
+
 vwmulsu.vx v4, v8, a1, v0.t
+# CHECK-INST: vwmulsu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xe8]
 
 vmacc.vv v4, v12, v8
+# CHECK-INST: vmacc.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x22,0x86,0xb6]
+
 vmacc.vx v4, a1, v8
+# CHECK-INST: vmacc.vx v4, a1, v8
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xb6]
+
 vmacc.vv v4, v12, v8, v0.t
+# CHECK-INST: vmacc.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xb4]
+
 vmacc.vx v4, a1, v8, v0.t
+# CHECK-INST: vmacc.vx v4, a1, v8, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xb4]
+
 vnmsac.vv v4, v12, v8
+# CHECK-INST: vnmsac.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x22,0x86,0xbe]
+
 vnmsac.vx v4, a1, v8
+# CHECK-INST: vnmsac.vx v4, a1, v8
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xbe]
+
 vnmsac.vv v4, v12, v8, v0.t
+# CHECK-INST: vnmsac.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xbc]
+
 vnmsac.vx v4, a1, v8, v0.t
+# CHECK-INST: vnmsac.vx v4, a1, v8, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xbc]
+
 vmadd.vv v4, v12, v8
+# CHECK-INST: vmadd.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x22,0x86,0xa6]
+
 vmadd.vx v4, a1, v8
+# CHECK-INST: vmadd.vx v4, a1, v8
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xa6]
+
 vmadd.vv v4, v12, v8, v0.t
+# CHECK-INST: vmadd.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xa4]
+
 vmadd.vx v4, a1, v8, v0.t
+# CHECK-INST: vmadd.vx v4, a1, v8, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xa4]
+
 vnmsub.vv v4, v12, v8
+# CHECK-INST: vnmsub.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x22,0x86,0xae]
+
 vnmsub.vx v4, a1, v8
+# CHECK-INST: vnmsub.vx v4, a1, v8
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xae]
+
 vnmsub.vv v4, v12, v8, v0.t
+# CHECK-INST: vnmsub.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xac]
+
 vnmsub.vx v4, a1, v8, v0.t
+# CHECK-INST: vnmsub.vx v4, a1, v8, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xac]
 
 vwmaccu.vv v4, v12, v8
+# CHECK-INST: vwmaccu.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x22,0x86,0xf2]
+
 vwmaccu.vx v4, a1, v8
+# CHECK-INST: vwmaccu.vx v4, a1, v8
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xf2]
+
 vwmaccu.vv v4, v12, v8, v0.t
+# CHECK-INST: vwmaccu.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xf0]
+
 vwmaccu.vx v4, a1, v8, v0.t
+# CHECK-INST: vwmaccu.vx v4, a1, v8, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xf0]
+
 vwmacc.vv v4, v12, v8
+# CHECK-INST: vwmacc.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x22,0x86,0xf6]
+
 vwmacc.vx v4, a1, v8
+# CHECK-INST: vwmacc.vx v4, a1, v8
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xf6]
+
 vwmacc.vv v4, v12, v8, v0.t
+# CHECK-INST: vwmacc.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xf4]
+
 vwmacc.vx v4, a1, v8, v0.t
+# CHECK-INST: vwmacc.vx v4, a1, v8, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xf4]
+
 vwmaccsu.vv v4, v12, v8
+# CHECK-INST: vwmaccsu.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x22,0x86,0xfa]
+
 vwmaccsu.vx v4, a1, v8
+# CHECK-INST: vwmaccsu.vx v4, a1, v8
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xfa]
+
 vwmaccsu.vv v4, v12, v8, v0.t
+# CHECK-INST: vwmaccsu.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0xf8]
+
 vwmaccsu.vx v4, a1, v8, v0.t
+# CHECK-INST: vwmaccsu.vx v4, a1, v8, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xf8]
+
 vwmaccus.vx v4, a1, v8
+# CHECK-INST: vwmaccus.vx v4, a1, v8
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xfe]
+
 vwmaccus.vx v4, a1, v8, v0.t
+# CHECK-INST: vwmaccus.vx v4, a1, v8, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0xfc]
 
 vdivu.vv v4, v8, v12
+# CHECK-INST: vdivu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x82]
+
 vdivu.vx v4, v8, a1
+# CHECK-INST: vdivu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x82]
+
 vdivu.vv v4, v8, v12, v0.t
+# CHECK-INST: vdivu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0x80]
+
 vdivu.vx v4, v8, a1, v0.t
+# CHECK-INST: vdivu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x80]
+
 vdiv.vv v4, v8, v12
+# CHECK-INST: vdiv.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x86]
+
 vdiv.vx v4, v8, a1
+# CHECK-INST: vdiv.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x86]
+
 vdiv.vv v4, v8, v12, v0.t
+# CHECK-INST: vdiv.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0x84]
+
 vdiv.vx v4, v8, a1, v0.t
+# CHECK-INST: vdiv.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x84]
+
 vremu.vv v4, v8, v12
+# CHECK-INST: vremu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x8a]
+
 vremu.vx v4, v8, a1
+# CHECK-INST: vremu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x8a]
+
 vremu.vv v4, v8, v12, v0.t
+# CHECK-INST: vremu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0x88]
+
 vremu.vx v4, v8, a1, v0.t
+# CHECK-INST: vremu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x88]
+
 vrem.vv v4, v8, v12
+# CHECK-INST: vrem.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x8e]
+
 vrem.vx v4, v8, a1
+# CHECK-INST: vrem.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x8e]
+
 vrem.vv v4, v8, v12, v0.t
+# CHECK-INST: vrem.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0x8c]
+
 vrem.vx v4, v8, a1, v0.t
+# CHECK-INST: vrem.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x8c]
 
 vmerge.vvm v4, v8, v12, v0
+# CHECK-INST: vmerge.vvm v4, v8, v12, v0
+# CHECK-ENCODING: [0x57,0x02,0x86,0x5c]
+
 vmerge.vxm v4, v8, a1, v0
+# CHECK-INST: vmerge.vxm v4, v8, a1, v0
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x5c]
+
 vmerge.vim v4, v8, 15, v0
+# CHECK-INST: vmerge.vim v4, v8, 15, v0
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x5c]
+
 vmerge.vim v4, v8, -16, v0
+# CHECK-INST: vmerge.vim v4, v8, -16, v0
+# CHECK-ENCODING: [0x57,0x32,0x88,0x5c]
 
 vmv.v.v v8, v12
+# CHECK-INST: vmv.v.v v8, v12
+# CHECK-ENCODING: [0x57,0x04,0x06,0x5e]
+
 vmv.v.x v8, a1
+# CHECK-INST: vmv.v.x v8, a1
+# CHECK-ENCODING: [0x57,0xc4,0x05,0x5e]
+
 vmv.v.i v8, 15
+# CHECK-INST: vmv.v.i v8, 15
+# CHECK-ENCODING: [0x57,0xb4,0x07,0x5e]
+
 vmv.v.i v8, -16
+# CHECK-INST: vmv.v.i v8, -16
+# CHECK-ENCODING: [0x57,0x34,0x08,0x5e]
 
 vsaddu.vv v4, v8, v12
+# CHECK-INST: vsaddu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x82]
+
 vsaddu.vx v4, v8, a1
+# CHECK-INST: vsaddu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x82]
+
 vsaddu.vi v4, v8, 15
+# CHECK-INST: vsaddu.vi v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x82]
+
 vsaddu.vi v4, v8, -16
+# CHECK-INST: vsaddu.vi v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x82]
+
 vsaddu.vv v4, v8, v12, v0.t
+# CHECK-INST: vsaddu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x80]
+
 vsaddu.vx v4, v8, a1, v0.t
+# CHECK-INST: vsaddu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x80]
+
 vsaddu.vi v4, v8, 15, v0.t
+# CHECK-INST: vsaddu.vi v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x80]
+
 vsaddu.vi v4, v8, -16, v0.t
+# CHECK-INST: vsaddu.vi v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x80]
+
 vsadd.vv v4, v8, v12
+# CHECK-INST: vsadd.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x86]
+
 vsadd.vx v4, v8, a1
+# CHECK-INST: vsadd.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x86]
+
 vsadd.vi v4, v8, 15
+# CHECK-INST: vsadd.vi v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x86]
+
 vsadd.vi v4, v8, -16
+# CHECK-INST: vsadd.vi v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x86]
+
 vsadd.vv v4, v8, v12, v0.t
+# CHECK-INST: vsadd.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x84]
+
 vsadd.vx v4, v8, a1, v0.t
+# CHECK-INST: vsadd.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x84]
+
 vsadd.vi v4, v8, 15, v0.t
+# CHECK-INST: vsadd.vi v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x84]
+
 vsadd.vi v4, v8, -16, v0.t
+# CHECK-INST: vsadd.vi v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x84]
+
 vssubu.vv v4, v8, v12
+# CHECK-INST: vssubu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x8a]
+
 vssubu.vx v4, v8, a1
+# CHECK-INST: vssubu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x8a]
+
 vssubu.vv v4, v8, v12, v0.t
+# CHECK-INST: vssubu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x88]
+
 vssubu.vx v4, v8, a1, v0.t
+# CHECK-INST: vssubu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x88]
+
 vssub.vv v4, v8, v12
+# CHECK-INST: vssub.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x8e]
+
 vssub.vx v4, v8, a1
+# CHECK-INST: vssub.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x8e]
+
 vssub.vv v4, v8, v12, v0.t
+# CHECK-INST: vssub.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x8c]
+
 vssub.vx v4, v8, a1, v0.t
+# CHECK-INST: vssub.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x8c]
 
 vaadd.vv v4, v8, v12
+# CHECK-INST: vaadd.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x92]
+
 vaadd.vx v4, v8, a1
+# CHECK-INST: vaadd.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x92]
+
 vaadd.vi v4, v8, 15
+# CHECK-INST: vaadd.vi v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x92]
+
 vaadd.vi v4, v8, -16
+# CHECK-INST: vaadd.vi v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x92]
+
 vaadd.vv v4, v8, v12, v0.t
+# CHECK-INST: vaadd.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x90]
+
 vaadd.vx v4, v8, a1, v0.t
+# CHECK-INST: vaadd.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x90]
+
 vaadd.vi v4, v8, 15, v0.t
+# CHECK-INST: vaadd.vi v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x90]
+
 vaadd.vi v4, v8, -16, v0.t
+# CHECK-INST: vaadd.vi v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x90]
+
 vasub.vv v4, v8, v12
+# CHECK-INST: vasub.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x9a]
+
 vasub.vx v4, v8, a1
+# CHECK-INST: vasub.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x9a]
+
 vasub.vv v4, v8, v12, v0.t
+# CHECK-INST: vasub.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x98]
+
 vasub.vx v4, v8, a1, v0.t
+# CHECK-INST: vasub.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x98]
 
 vsmul.vv v4, v8, v12
+# CHECK-INST: vsmul.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x9e]
+
 vsmul.vx v4, v8, a1
+# CHECK-INST: vsmul.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x9e]
+
 vsmul.vv v4, v8, v12, v0.t
+# CHECK-INST: vsmul.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x9c]
+
 vsmul.vx v4, v8, a1, v0.t
+# CHECK-INST: vsmul.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x9c]
 
 vwsmaccu.vv v4, v12, v8
+# CHECK-INST: vwsmaccu.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x02,0x86,0xf2]
+
 vwsmaccu.vx v4, a1, v8
+# CHECK-INST: vwsmaccu.vx v4, a1, v8
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xf2]
+
 vwsmacc.vv v4, v12, v8
+# CHECK-INST: vwsmacc.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x02,0x86,0xf6]
+
 vwsmacc.vx v4, a1, v8
+# CHECK-INST: vwsmacc.vx v4, a1, v8
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xf6]
+
 vwsmaccsu.vv v4, v12, v8
+# CHECK-INST: vwsmaccsu.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x02,0x86,0xfa]
+
 vwsmaccsu.vx v4, a1, v8
+# CHECK-INST: vwsmaccsu.vx v4, a1, v8
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xfa]
+
 vwsmaccus.vx v4, a1, v8
+# CHECK-INST: vwsmaccus.vx v4, a1, v8
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xfe]
+
 vwsmaccu.vv v4, v12, v8, v0.t
+# CHECK-INST: vwsmaccu.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0xf0]
+
 vwsmaccu.vx v4, a1, v8, v0.t
+# CHECK-INST: vwsmaccu.vx v4, a1, v8, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xf0]
+
 vwsmacc.vv v4, v12, v8, v0.t
+# CHECK-INST: vwsmacc.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0xf4]
+
 vwsmacc.vx v4, a1, v8, v0.t
+# CHECK-INST: vwsmacc.vx v4, a1, v8, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xf4]
+
 vwsmaccsu.vv v4, v12, v8, v0.t
+# CHECK-INST: vwsmaccsu.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0xf8]
+
 vwsmaccsu.vx v4, a1, v8, v0.t
+# CHECK-INST: vwsmaccsu.vx v4, a1, v8, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xf8]
+
 vwsmaccus.vx v4, a1, v8, v0.t
+# CHECK-INST: vwsmaccus.vx v4, a1, v8, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xfc]
 
 vssrl.vv v4, v8, v12
+# CHECK-INST: vssrl.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0xaa]
+
 vssrl.vx v4, v8, a1
+# CHECK-INST: vssrl.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xaa]
+
 vssrl.vi v4, v8, 1
+# CHECK-INST: vssrl.vi v4, v8, 1
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xaa]
+
 vssrl.vi v4, v8, 31
+# CHECK-INST: vssrl.vi v4, v8, 31
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xaa]
+
 vssrl.vv v4, v8, v12, v0.t
+# CHECK-INST: vssrl.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0xa8]
+
 vssrl.vx v4, v8, a1, v0.t
+# CHECK-INST: vssrl.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xa8]
+
 vssrl.vi v4, v8, 1, v0.t
+# CHECK-INST: vssrl.vi v4, v8, 1, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xa8]
+
 vssrl.vi v4, v8, 31, v0.t
+# CHECK-INST: vssrl.vi v4, v8, 31, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xa8]
+
 vssra.vv v4, v8, v12
+# CHECK-INST: vssra.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0xae]
+
 vssra.vx v4, v8, a1
+# CHECK-INST: vssra.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xae]
+
 vssra.vi v4, v8, 1
+# CHECK-INST: vssra.vi v4, v8, 1
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xae]
+
 vssra.vi v4, v8, 31
+# CHECK-INST: vssra.vi v4, v8, 31
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xae]
+
 vssra.vv v4, v8, v12, v0.t
+# CHECK-INST: vssra.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0xac]
+
 vssra.vx v4, v8, a1, v0.t
+# CHECK-INST: vssra.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xac]
+
 vssra.vi v4, v8, 1, v0.t
+# CHECK-INST: vssra.vi v4, v8, 1, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xac]
+
 vssra.vi v4, v8, 31, v0.t
+# CHECK-INST: vssra.vi v4, v8, 31, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xac]
 
 vnclipu.vv v4, v8, v12
+# CHECK-INST: vnclipu.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0xba]
+
 vnclipu.vx v4, v8, a1
+# CHECK-INST: vnclipu.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xba]
+
 vnclipu.vi v4, v8, 1
+# CHECK-INST: vnclipu.vi v4, v8, 1
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xba]
+
 vnclipu.vi v4, v8, 31
+# CHECK-INST: vnclipu.vi v4, v8, 31
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xba]
+
 vnclipu.vv v4, v8, v12, v0.t
+# CHECK-INST: vnclipu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0xb8]
+
 vnclipu.vx v4, v8, a1, v0.t
+# CHECK-INST: vnclipu.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xb8]
+
 vnclipu.vi v4, v8, 1, v0.t
+# CHECK-INST: vnclipu.vi v4, v8, 1, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xb8]
+
 vnclipu.vi v4, v8, 31, v0.t
+# CHECK-INST: vnclipu.vi v4, v8, 31, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xb8]
+
 vnclip.vv v4, v8, v12
+# CHECK-INST: vnclip.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0xbe]
+
 vnclip.vx v4, v8, a1
+# CHECK-INST: vnclip.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xbe]
+
 vnclip.vi v4, v8, 1
+# CHECK-INST: vnclip.vi v4, v8, 1
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xbe]
+
 vnclip.vi v4, v8, 31
+# CHECK-INST: vnclip.vi v4, v8, 31
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xbe]
+
 vnclip.vv v4, v8, v12, v0.t
+# CHECK-INST: vnclip.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0xbc]
+
 vnclip.vx v4, v8, a1, v0.t
+# CHECK-INST: vnclip.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0xbc]
+
 vnclip.vi v4, v8, 1, v0.t
+# CHECK-INST: vnclip.vi v4, v8, 1, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x80,0xbc]
+
 vnclip.vi v4, v8, 31, v0.t
+# CHECK-INST: vnclip.vi v4, v8, 31, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0xbc]
 
 vfadd.vv v4, v8, v12
+# CHECK-INST: vfadd.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x02]
+
 vfadd.vf v4, v8, fa2
+# CHECK-INST: vfadd.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x02]
+
 vfadd.vv v4, v8, v12, v0.t
+# CHECK-INST: vfadd.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x00]
+
 vfadd.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfadd.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x00]
+
 vfsub.vv v4, v8, v12
+# CHECK-INST: vfsub.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x0a]
+
 vfsub.vf v4, v8, fa2
+# CHECK-INST: vfsub.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x0a]
+
 vfsub.vv v4, v8, v12, v0.t
+# CHECK-INST: vfsub.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x08]
+
 vfsub.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfsub.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x08]
+
 vfrsub.vf v4, v8, fa2
+# CHECK-INST: vfrsub.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x9e]
+
 vfrsub.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfrsub.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x9c]
 
 vfwadd.vv v4, v8, v12
+# CHECK-INST: vfwadd.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0xc2]
+
 vfwadd.vf v4, v8, fa2
+# CHECK-INST: vfwadd.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0xc2]
+
 vfwadd.vv v4, v8, v12, v0.t
+# CHECK-INST: vfwadd.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xc0]
+
 vfwadd.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfwadd.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xc0]
+
 vfwsub.vv v4, v8, v12
+# CHECK-INST: vfwsub.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0xca]
+
 vfwsub.vf v4, v8, fa2
+# CHECK-INST: vfwsub.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0xca]
+
 vfwsub.vv v4, v8, v12, v0.t
+# CHECK-INST: vfwsub.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xc8]
+
 vfwsub.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfwsub.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xc8]
+
 vfwadd.wv v4, v8, v12
+# CHECK-INST: vfwadd.wv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0xd2]
+
 vfwadd.wf v4, v8, fa2
+# CHECK-INST: vfwadd.wf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0xd2]
+
 vfwadd.wv v4, v8, v12, v0.t
+# CHECK-INST: vfwadd.wv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xd0]
+
 vfwadd.wf v4, v8, fa2, v0.t
+# CHECK-INST: vfwadd.wf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xd0]
+
 vfwsub.wv v4, v8, v12
+# CHECK-INST: vfwsub.wv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0xda]
+
 vfwsub.wf v4, v8, fa2
+# CHECK-INST: vfwsub.wf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0xda]
+
 vfwsub.wv v4, v8, v12, v0.t
+# CHECK-INST: vfwsub.wv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xd8]
+
 vfwsub.wf v4, v8, fa2, v0.t
+# CHECK-INST: vfwsub.wf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xd8]
 
 vfmul.vv v4, v8, v12
+# CHECK-INST: vfmul.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x92]
+
 vfmul.vf v4, v8, fa2
+# CHECK-INST: vfmul.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x92]
+
 vfmul.vv v4, v8, v12, v0.t
+# CHECK-INST: vfmul.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x90]
+
 vfmul.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfmul.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x90]
+
 vfdiv.vv v4, v8, v12
+# CHECK-INST: vfdiv.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x82]
+
 vfdiv.vf v4, v8, fa2
+# CHECK-INST: vfdiv.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x82]
+
 vfdiv.vv v4, v8, v12, v0.t
+# CHECK-INST: vfdiv.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x80]
+
 vfdiv.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfdiv.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x80]
+
 vfrdiv.vf v4, v8, fa2
+# CHECK-INST: vfrdiv.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x86]
+
 vfrdiv.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfrdiv.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x84]
 
 vfwmul.vv v4, v8, v12
+# CHECK-INST: vfwmul.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0xe2]
+
 vfwmul.vf v4, v8, fa2
+# CHECK-INST: vfwmul.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0xe2]
+
 vfwmul.vv v4, v8, v12, v0.t
+# CHECK-INST: vfwmul.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xe0]
+
 vfwmul.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfwmul.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xe0]
 
 vfmadd.vv v4, v12, v8
+# CHECK-INST: vfmadd.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x12,0x86,0xa2]
+
 vfmadd.vf v4, fa2, v8
+# CHECK-INST: vfmadd.vf v4, fa2, v8
+# CHECK-ENCODING: [0x57,0x52,0x86,0xa2]
+
 vfnmadd.vv v4, v12, v8
+# CHECK-INST: vfnmadd.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x12,0x86,0xa6]
+
 vfnmadd.vf v4, fa2, v8
+# CHECK-INST: vfnmadd.vf v4, fa2, v8
+# CHECK-ENCODING: [0x57,0x52,0x86,0xa6]
+
 vfmsub.vv v4, v12, v8
+# CHECK-INST: vfmsub.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x12,0x86,0xaa]
+
 vfmsub.vf v4, fa2, v8
+# CHECK-INST: vfmsub.vf v4, fa2, v8
+# CHECK-ENCODING: [0x57,0x52,0x86,0xaa]
+
 vfnmsub.vv v4, v12, v8
+# CHECK-INST: vfnmsub.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x12,0x86,0xae]
+
 vfnmsub.vf v4, fa2, v8
+# CHECK-INST: vfnmsub.vf v4, fa2, v8
+# CHECK-ENCODING: [0x57,0x52,0x86,0xae]
+
 vfmadd.vv v4, v12, v8, v0.t
+# CHECK-INST: vfmadd.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xa0]
+
 vfmadd.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfmadd.vf v4, fa2, v8, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xa0]
+
 vfnmadd.vv v4, v12, v8, v0.t
+# CHECK-INST: vfnmadd.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xa4]
+
 vfnmadd.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfnmadd.vf v4, fa2, v8, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xa4]
+
 vfmsub.vv v4, v12, v8, v0.t
+# CHECK-INST: vfmsub.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xa8]
+
 vfmsub.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfmsub.vf v4, fa2, v8, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xa8]
+
 vfnmsub.vv v4, v12, v8, v0.t
+# CHECK-INST: vfnmsub.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xac]
+
 vfnmsub.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfnmsub.vf v4, fa2, v8, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xac]
+
 vfmacc.vv v4, v12, v8
+# CHECK-INST: vfmacc.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x12,0x86,0xb2]
+
 vfmacc.vf v4, fa2, v8
+# CHECK-INST: vfmacc.vf v4, fa2, v8
+# CHECK-ENCODING: [0x57,0x52,0x86,0xb2]
+
 vfnmacc.vv v4, v12, v8
+# CHECK-INST: vfnmacc.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x12,0x86,0xb6]
+
 vfnmacc.vf v4, fa2, v8
+# CHECK-INST: vfnmacc.vf v4, fa2, v8
+# CHECK-ENCODING: [0x57,0x52,0x86,0xb6]
+
 vfmsac.vv v4, v12, v8
+# CHECK-INST: vfmsac.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x12,0x86,0xba]
+
 vfmsac.vf v4, fa2, v8
+# CHECK-INST: vfmsac.vf v4, fa2, v8
+# CHECK-ENCODING: [0x57,0x52,0x86,0xba]
+
 vfnmsac.vv v4, v12, v8
+# CHECK-INST: vfnmsac.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x12,0x86,0xbe]
+
 vfnmsac.vf v4, fa2, v8
+# CHECK-INST: vfnmsac.vf v4, fa2, v8
+# CHECK-ENCODING: [0x57,0x52,0x86,0xbe]
+
 vfmacc.vv v4, v12, v8, v0.t
+# CHECK-INST: vfmacc.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xb0]
+
 vfmacc.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfmacc.vf v4, fa2, v8, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xb0]
+
 vfnmacc.vv v4, v12, v8, v0.t
+# CHECK-INST: vfnmacc.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xb4]
+
 vfnmacc.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfnmacc.vf v4, fa2, v8, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xb4]
+
 vfmsac.vv v4, v12, v8, v0.t
+# CHECK-INST: vfmsac.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xb8]
+
 vfmsac.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfmsac.vf v4, fa2, v8, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xb8]
+
 vfnmsac.vv v4, v12, v8, v0.t
+# CHECK-INST: vfnmsac.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xbc]
+
 vfnmsac.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfnmsac.vf v4, fa2, v8, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xbc]
 
 vfwmacc.vv v4, v12, v8
+# CHECK-INST: vfwmacc.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x12,0x86,0xf2]
+
 vfwmacc.vf v4, fa2, v8
+# CHECK-INST: vfwmacc.vf v4, fa2, v8
+# CHECK-ENCODING: [0x57,0x52,0x86,0xf2]
+
 vfwnmacc.vv v4, v12, v8
+# CHECK-INST: vfwnmacc.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x12,0x86,0xf6]
+
 vfwnmacc.vf v4, fa2, v8
+# CHECK-INST: vfwnmacc.vf v4, fa2, v8
+# CHECK-ENCODING: [0x57,0x52,0x86,0xf6]
+
 vfwmsac.vv v4, v12, v8
+# CHECK-INST: vfwmsac.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x12,0x86,0xfa]
+
 vfwmsac.vf v4, fa2, v8
+# CHECK-INST: vfwmsac.vf v4, fa2, v8
+# CHECK-ENCODING: [0x57,0x52,0x86,0xfa]
+
 vfwnmsac.vv v4, v12, v8
+# CHECK-INST: vfwnmsac.vv v4, v12, v8
+# CHECK-ENCODING: [0x57,0x12,0x86,0xfe]
+
 vfwnmsac.vf v4, fa2, v8
+# CHECK-INST: vfwnmsac.vf v4, fa2, v8
+# CHECK-ENCODING: [0x57,0x52,0x86,0xfe]
+
 vfwmacc.vv v4, v12, v8, v0.t
+# CHECK-INST: vfwmacc.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xf0]
+
 vfwmacc.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfwmacc.vf v4, fa2, v8, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xf0]
+
 vfwnmacc.vv v4, v12, v8, v0.t
+# CHECK-INST: vfwnmacc.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xf4]
+
 vfwnmacc.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfwnmacc.vf v4, fa2, v8, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xf4]
+
 vfwmsac.vv v4, v12, v8, v0.t
+# CHECK-INST: vfwmsac.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xf8]
+
 vfwmsac.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfwmsac.vf v4, fa2, v8, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xf8]
+
 vfwnmsac.vv v4, v12, v8, v0.t
+# CHECK-INST: vfwnmsac.vv v4, v12, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xfc]
+
 vfwnmsac.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfwnmsac.vf v4, fa2, v8, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0xfc]
 
 vfsqrt.v v4, v8
+# CHECK-INST: vfsqrt.v v4, v8
+# CHECK-ENCODING: [0x57,0x12,0x80,0x8e]
+
 vfsqrt.v v4, v8, v0.t
+# CHECK-INST: vfsqrt.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x80,0x8c]
 
 vfmin.vv v4, v8, v12
+# CHECK-INST: vfmin.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x12]
+
 vfmin.vf v4, v8, fa2
+# CHECK-INST: vfmin.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x12]
+
 vfmax.vv v4, v8, v12
+# CHECK-INST: vfmax.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x1a]
+
 vfmax.vf v4, v8, fa2
+# CHECK-INST: vfmax.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x1a]
+
 vfmin.vv v4, v8, v12, v0.t
+# CHECK-INST: vfmin.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x10]
+
 vfmin.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfmin.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x10]
+
 vfmax.vv v4, v8, v12, v0.t
+# CHECK-INST: vfmax.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x18]
+
 vfmax.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfmax.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x18]
 
 vfsgnj.vv v4, v8, v12
+# CHECK-INST: vfsgnj.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x22]
+
 vfsgnj.vf v4, v8, fa2
+# CHECK-INST: vfsgnj.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x22]
+
 vfsgnjn.vv v4, v8, v12
+# CHECK-INST: vfsgnjn.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x26]
+
 vfsgnjn.vf v4, v8, fa2
+# CHECK-INST: vfsgnjn.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x26]
+
 vfsgnjx.vv v4, v8, v12
+# CHECK-INST: vfsgnjx.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x2a]
+
 vfsgnjx.vf v4, v8, fa2
+# CHECK-INST: vfsgnjx.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x2a]
+
 vfsgnj.vv v4, v8, v12, v0.t
+# CHECK-INST: vfsgnj.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x20]
+
 vfsgnj.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfsgnj.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x20]
+
 vfsgnjn.vv v4, v8, v12, v0.t
+# CHECK-INST: vfsgnjn.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x24]
+
 vfsgnjn.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfsgnjn.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x24]
+
 vfsgnjx.vv v4, v8, v12, v0.t
+# CHECK-INST: vfsgnjx.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x28]
+
 vfsgnjx.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfsgnjx.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x28]
 
 # TODO: rvv 0.7.1
 # Aliases
 # vmfgt.vv v4, v8, v12
+# CHECK-INST-TODO: vmfgt.vv v4, v8, v12
+# CHECK-ENCODING-TODO: [0x57,0x12,0xc4,0x6e]
+
+# TODO: rvv 0.7.1
 # vmfge.vv v4, v8, v12
+# CHECK-INST-TODO: vmfge.vv v4, v8, v12
+# CHECK-ENCODING-TODO: [0x57,0x12,0xc4,0x66]
+
+# TODO: rvv 0.7.1
 # vmfgt.vv v4, v8, v12, v0.t
+# CHECK-INST-TODO: vmfgt.vv v4, v8, v12, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x12,0xc4,0x6c]
+
+# TODO: rvv 0.7.1
 # vmfge.vv v4, v8, v12, v0.t
+# CHECK-INST-TODO: vmfge.vv v4, v8, v12, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x12,0xc4,0x64]
 
 vmfeq.vv v4, v8, v12
+# CHECK-INST: vmfeq.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x62]
+
 vmfeq.vf v4, v8, fa2
+# CHECK-INST: vmfeq.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x62]
+
 vmfne.vv v4, v8, v12
+# CHECK-INST: vmfne.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x72]
+
 vmfne.vf v4, v8, fa2
+# CHECK-INST: vmfne.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x72]
+
 vmflt.vv v4, v8, v12
+# CHECK-INST: vmflt.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x6e]
+
 vmflt.vf v4, v8, fa2
+# CHECK-INST: vmflt.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x6e]
+
 vmfle.vv v4, v8, v12
+# CHECK-INST: vmfle.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x66]
+
 vmfle.vf v4, v8, fa2
+# CHECK-INST: vmfle.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x66]
+
 vmfgt.vf v4, v8, fa2
+# CHECK-INST: vmfgt.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x76]
+
 vmfge.vf v4, v8, fa2
+# CHECK-INST: vmfge.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x7e]
+
 vmfeq.vv v4, v8, v12, v0.t
+# CHECK-INST: vmfeq.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x60]
+
 vmfeq.vf v4, v8, fa2, v0.t
+# CHECK-INST: vmfeq.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x60]
+
 vmfne.vv v4, v8, v12, v0.t
+# CHECK-INST: vmfne.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x70]
+
 vmfne.vf v4, v8, fa2, v0.t
+# CHECK-INST: vmfne.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x70]
+
 vmflt.vv v4, v8, v12, v0.t
+# CHECK-INST: vmflt.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x6c]
+
 vmflt.vf v4, v8, fa2, v0.t
+# CHECK-INST: vmflt.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x6c]
+
 vmfle.vv v4, v8, v12, v0.t
+# CHECK-INST: vmfle.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x64]
+
 vmfle.vf v4, v8, fa2, v0.t
+# CHECK-INST: vmfle.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x64]
+
 vmfgt.vf v4, v8, fa2, v0.t
+# CHECK-INST: vmfgt.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x74]
+
 vmfge.vf v4, v8, fa2, v0.t
+# CHECK-INST: vmfge.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x7c]
 
 vmford.vv v4, v8, v12
+# CHECK-INST: vmford.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x6a]
+
 vmford.vf v4, v8, fa2
+# CHECK-INST: vmford.vf v4, v8, fa2
+# CHECK-ENCODING: [0x57,0x52,0x86,0x6a]
+
 vmford.vv v4, v8, v12, v0.t
+# CHECK-INST: vmford.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x68]
+
 vmford.vf v4, v8, fa2, v0.t
+# CHECK-INST: vmford.vf v4, v8, fa2, v0.t
+# CHECK-ENCODING: [0x57,0x52,0x86,0x68]
 
 vfclass.v v4, v8
+# CHECK-INST: vfclass.v v4, v8
+# CHECK-ENCODING: [0x57,0x12,0x88,0x8e]
+
 vfclass.v v4, v8, v0.t
+# CHECK-INST: vfclass.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x88,0x8c]
 
 vfmerge.vfm v4, v8, fa2, v0
+# CHECK-INST: vfmerge.vfm v4, v8, fa2, v0
+# CHECK-ENCODING: [0x57,0x52,0x86,0x5c]
+
 vfmv.v.f v4, fa1
+# CHECK-INST: vfmv.v.f v4, fa1
+# CHECK-ENCODING: [0x57,0xd2,0x05,0x5e]
 
 vfcvt.xu.f.v v4, v8
+# CHECK-INST: vfcvt.xu.f.v v4, v8
+# CHECK-ENCODING: [0x57,0x12,0x80,0x8a]
+
 vfcvt.x.f.v v4, v8
+# CHECK-INST: vfcvt.x.f.v v4, v8
+# CHECK-ENCODING: [0x57,0x92,0x80,0x8a]
+
 vfcvt.f.xu.v v4, v8
+# CHECK-INST: vfcvt.f.xu.v v4, v8
+# CHECK-ENCODING: [0x57,0x12,0x81,0x8a]
+
 vfcvt.f.x.v v4, v8
+# CHECK-INST: vfcvt.f.x.v v4, v8
+# CHECK-ENCODING: [0x57,0x92,0x81,0x8a]
+
 vfcvt.xu.f.v v4, v8, v0.t
+# CHECK-INST: vfcvt.xu.f.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x80,0x88]
+
 vfcvt.x.f.v v4, v8, v0.t
+# CHECK-INST: vfcvt.x.f.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x92,0x80,0x88]
+
 vfcvt.f.xu.v v4, v8, v0.t
+# CHECK-INST: vfcvt.f.xu.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x81,0x88]
+
 vfcvt.f.x.v v4, v8, v0.t
+# CHECK-INST: vfcvt.f.x.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x92,0x81,0x88]
 
 vfwcvt.xu.f.v v4, v8
+# CHECK-INST: vfwcvt.xu.f.v v4, v8
+# CHECK-ENCODING: [0x57,0x12,0x84,0x8a]
+
 vfwcvt.x.f.v v4, v8
+# CHECK-INST: vfwcvt.x.f.v v4, v8
+# CHECK-ENCODING: [0x57,0x92,0x84,0x8a]
+
 vfwcvt.f.xu.v v4, v8
+# CHECK-INST: vfwcvt.f.xu.v v4, v8
+# CHECK-ENCODING: [0x57,0x12,0x85,0x8a]
+
 vfwcvt.f.x.v v4, v8
+# CHECK-INST: vfwcvt.f.x.v v4, v8
+# CHECK-ENCODING: [0x57,0x92,0x85,0x8a]
+
 vfwcvt.f.f.v v4, v8
+# CHECK-INST: vfwcvt.f.f.v v4, v8
+# CHECK-ENCODING: [0x57,0x12,0x86,0x8a]
+
 vfwcvt.xu.f.v v4, v8, v0.t
+# CHECK-INST: vfwcvt.xu.f.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x84,0x88]
+
 vfwcvt.x.f.v v4, v8, v0.t
+# CHECK-INST: vfwcvt.x.f.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x92,0x84,0x88]
+
 vfwcvt.f.xu.v v4, v8, v0.t
+# CHECK-INST: vfwcvt.f.xu.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x85,0x88]
+
 vfwcvt.f.x.v v4, v8, v0.t
+# CHECK-INST: vfwcvt.f.x.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x92,0x85,0x88]
+
 vfwcvt.f.f.v v4, v8, v0.t
+# CHECK-INST: vfwcvt.f.f.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x88]
 
 vfncvt.xu.f.v v4, v8
+# CHECK-INST: vfncvt.xu.f.v v4, v8
+# CHECK-ENCODING: [0x57,0x12,0x88,0x8a]
+
 vfncvt.x.f.v v4, v8
+# CHECK-INST: vfncvt.x.f.v v4, v8
+# CHECK-ENCODING: [0x57,0x92,0x88,0x8a]
+
 vfncvt.f.xu.v v4, v8
+# CHECK-INST: vfncvt.f.xu.v v4, v8
+# CHECK-ENCODING: [0x57,0x12,0x89,0x8a]
+
 vfncvt.f.x.v v4, v8
+# CHECK-INST: vfncvt.f.x.v v4, v8
+# CHECK-ENCODING: [0x57,0x92,0x89,0x8a]
+
 vfncvt.f.f.v v4, v8
+# CHECK-INST: vfncvt.f.f.v v4, v8
+# CHECK-ENCODING: [0x57,0x12,0x8a,0x8a]
+
 vfncvt.xu.f.v v4, v8, v0.t
+# CHECK-INST: vfncvt.xu.f.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x88,0x88]
+
 vfncvt.x.f.v v4, v8, v0.t
+# CHECK-INST: vfncvt.x.f.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x92,0x88,0x88]
+
 vfncvt.f.xu.v v4, v8, v0.t
+# CHECK-INST: vfncvt.f.xu.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x89,0x88]
+
 vfncvt.f.x.v v4, v8, v0.t
+# CHECK-INST: vfncvt.f.x.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x92,0x89,0x88]
+
 vfncvt.f.f.v v4, v8, v0.t
+# CHECK-INST: vfncvt.f.f.v v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x8a,0x88]
 
 vredsum.vs v4, v8, v12
+# CHECK-INST: vredsum.vs v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x02]
+
 vredmaxu.vs v4, v8, v8
+# CHECK-INST: vredmaxu.vs v4, v8, v8
+# CHECK-ENCODING: [0x57,0x22,0x84,0x1a]
+
 vredmax.vs v4, v8, v8
+# CHECK-INST: vredmax.vs v4, v8, v8
+# CHECK-ENCODING: [0x57,0x22,0x84,0x1e]
+
 vredminu.vs v4, v8, v8
+# CHECK-INST: vredminu.vs v4, v8, v8
+# CHECK-ENCODING: [0x57,0x22,0x84,0x12]
+
 vredmin.vs v4, v8, v8
+# CHECK-INST: vredmin.vs v4, v8, v8
+# CHECK-ENCODING: [0x57,0x22,0x84,0x16]
+
 vredand.vs v4, v8, v12
+# CHECK-INST: vredand.vs v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x06]
+
 vredor.vs v4, v8, v12
+# CHECK-INST: vredor.vs v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x0a]
+
 vredxor.vs v4, v8, v12
+# CHECK-INST: vredxor.vs v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x0e]
+
 vredsum.vs v4, v8, v12, v0.t
+# CHECK-INST: vredsum.vs v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0x00]
+
 vredmaxu.vs v4, v8, v8, v0.t
+# CHECK-INST: vredmaxu.vs v4, v8, v8, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x84,0x18]
+
 vredmax.vs v4, v8, v8, v0.t
+# CHECK-INST: vredmax.vs v4, v8, v8, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x84,0x1c]
+
 vredminu.vs v4, v8, v8, v0.t
+# CHECK-INST: vredminu.vs v4, v8, v8, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x84,0x10]
+
 vredmin.vs v4, v8, v8, v0.t
+# CHECK-INST: vredmin.vs v4, v8, v8, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x84,0x14]
+
 vredand.vs v4, v8, v12, v0.t
+# CHECK-INST: vredand.vs v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0x04]
+
 vredor.vs v4, v8, v12, v0.t
+# CHECK-INST: vredor.vs v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0x08]
+
 vredxor.vs v4, v8, v12, v0.t
+# CHECK-INST: vredxor.vs v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x86,0x0c]
 
 vwredsumu.vs v4, v8, v12
+# CHECK-INST: vwredsumu.vs v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0xc2]
+
 vwredsum.vs v4, v8, v12
+# CHECK-INST: vwredsum.vs v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0xc6]
+
 vwredsumu.vs v4, v8, v12, v0.t
+# CHECK-INST: vwredsumu.vs v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0xc0]
+
 vwredsum.vs v4, v8, v12, v0.t
+# CHECK-INST: vwredsum.vs v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0xc4]
 
 vfredosum.vs v4, v8, v12
+# CHECK-INST: vfredosum.vs v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x0e]
+
 vfredsum.vs v4, v8, v12
+# CHECK-INST: vfredsum.vs v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x06]
+
 vfredmax.vs v4, v8, v12
+# CHECK-INST: vfredmax.vs v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x1e]
+
 vfredmin.vs v4, v8, v12
+# CHECK-INST: vfredmin.vs v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0x16]
+
 vfredosum.vs v4, v8, v12, v0.t
+# CHECK-INST: vfredosum.vs v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x0c]
+
 vfredsum.vs v4, v8, v12, v0.t
+# CHECK-INST: vfredsum.vs v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x04]
+
 vfredmax.vs v4, v8, v12, v0.t
+# CHECK-INST: vfredmax.vs v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x1c]
+
 vfredmin.vs v4, v8, v12, v0.t
+# CHECK-INST: vfredmin.vs v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0x14]
 
 vfwredosum.vs v4, v8, v12
+# CHECK-INST: vfwredosum.vs v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0xce]
+
 vfwredsum.vs v4, v8, v12
+# CHECK-INST: vfwredsum.vs v4, v8, v12
+# CHECK-ENCODING: [0x57,0x12,0x86,0xc6]
+
 vfwredosum.vs v4, v8, v12, v0.t
+# CHECK-INST: vfwredosum.vs v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xcc]
+
 vfwredsum.vs v4, v8, v12, v0.t
+# CHECK-INST: vfwredsum.vs v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x12,0x86,0xc4]
 
 # TODO: rvv 0.7.1
 # Aliases
 # vmcpy.m v4, v8
+# CHECK-INST-TODO: vmcpy.m v4, v8
+# CHECK-ENCODING-TODO: [0x57,0x22,0x84,0x66]
+
+# TODO: rvv 0.7.1
 # vmclr.m v4
+# CHECK-INST-TODO: vmclr.m v4
+# CHECK-ENCODING-TODO: [0x57,0x22,0x42,0x6e]
+
+# TODO: rvv 0.7.1
 # vmset.m v4
+# CHECK-INST-TODO: vmset.m v4
+# CHECK-ENCODING-TODO: [0x57,0x22,0x42,0x7e]
+
+# TODO: rvv 0.7.1
 # vmnot.m v4, v8
+# CHECK-INST-TODO: vmnot.m v4, v8
+# CHECK-ENCODING-TODO: [0x57,0x22,0x84,0x76]
 
 vmand.mm v4, v8, v12
+# CHECK-INST: vmand.mm v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x66]
+
 vmnand.mm v4, v8, v12
+# CHECK-INST: vmnand.mm v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x76]
+
 vmandnot.mm v4, v8, v12
+# CHECK-INST: vmandnot.mm v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x62]
+
 vmxor.mm v4, v8, v12
+# CHECK-INST: vmxor.mm v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x6e]
+
 vmor.mm v4, v8, v12
+# CHECK-INST: vmor.mm v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x6a]
+
 vmnor.mm v4, v8, v12
+# CHECK-INST: vmnor.mm v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x7a]
+
 vmornot.mm v4, v8, v12
+# CHECK-INST: vmornot.mm v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x72]
+
 vmxnor.mm v4, v8, v12
+# CHECK-INST: vmxnor.mm v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x7e]
 
 vmpopc.m a0, v12
+# CHECK-INST: vmpopc.m a0, v12
+# CHECK-ENCODING: [0x57,0x25,0xc0,0x52]
+
 vmfirst.m a0, v12
+# CHECK-INST: vmfirst.m a0, v12
+# CHECK-ENCODING: [0x57,0x25,0xc0,0x56]
+
 vmsbf.m v4, v8
+# CHECK-INST: vmsbf.m v4, v8
+# CHECK-ENCODING: [0x57,0xa2,0x80,0x5a]
+
 vmsif.m v4, v8
+# CHECK-INST: vmsif.m v4, v8
+# CHECK-ENCODING: [0x57,0xa2,0x81,0x5a]
+
 vmsof.m v4, v8
+# CHECK-INST: vmsof.m v4, v8
+# CHECK-ENCODING: [0x57,0x22,0x81,0x5a]
+
 viota.m v4, v8
+# CHECK-INST: viota.m v4, v8
+# CHECK-ENCODING: [0x57,0x22,0x88,0x5a]
+
 vid.v v4
+# CHECK-INST: vid.v v4
+# CHECK-ENCODING: [0x57,0xa2,0x08,0x5a]
+
 vmpopc.m a0, v12, v0.t
+# CHECK-INST: vmpopc.m a0, v12, v0.t
+# CHECK-ENCODING: [0x57,0x25,0xc0,0x50]
+
 vmfirst.m a0, v12, v0.t
+# CHECK-INST: vmfirst.m a0, v12, v0.t
+# CHECK-ENCODING: [0x57,0x25,0xc0,0x54]
+
 vmsbf.m v4, v8, v0.t
+# CHECK-INST: vmsbf.m v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0xa2,0x80,0x58]
+
 vmsif.m v4, v8, v0.t
+# CHECK-INST: vmsif.m v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0xa2,0x81,0x58]
+
 vmsof.m v4, v8, v0.t
+# CHECK-INST: vmsof.m v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x81,0x58]
+
 viota.m v4, v8, v0.t
+# CHECK-INST: viota.m v4, v8, v0.t
+# CHECK-ENCODING: [0x57,0x22,0x88,0x58]
+
 vid.v v4, v0.t
+# CHECK-INST: vid.v v4, v0.t
+# CHECK-ENCODING: [0x57,0xa2,0x08,0x58]
 
 # TODO: rvv 0.7.1
 # Alias
 # vmv.x.s a0, v12
+# CHECK-INST-TODO: vmv.x.s a0, v12
+# CHECK-ENCODING-TODO: [0x57,0x25,0xc0,0x32]
 
 vext.x.v a0, v12, a2
+# CHECK-INST: vext.x.v a0, v12, a2
+# CHECK-ENCODING: [0x57,0x25,0xc6,0x32]
+
 vmv.s.x v4, a0
+# CHECK-INST: vmv.s.x v4, a0
+# CHECK-ENCODING: [0x57,0x62,0x05,0x36]
 
 vfmv.f.s fa0, v8
+# CHECK-INST: vfmv.f.s fa0, v8
+# CHECK-ENCODING: [0x57,0x15,0x80,0x32]
+
 vfmv.s.f v4, fa1
+# CHECK-INST: vfmv.s.f v4, fa1
+# CHECK-ENCODING: [0x57,0xd2,0x05,0x36]
 
 vslideup.vx v4, v8, a1
+# CHECK-INST: vslideup.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x3a]
+
 vslideup.vi v4, v8, 0
+# CHECK-INST: vslideup.vi v4, v8, 0
+# CHECK-ENCODING: [0x57,0x32,0x80,0x3a]
+
 vslideup.vi v4, v8, 31
+# CHECK-INST: vslideup.vi v4, v8, 31
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0x3a]
+
 vslidedown.vx v4, v8, a1
+# CHECK-INST: vslidedown.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x3e]
+
 vslidedown.vi v4, v8, 0
+# CHECK-INST: vslidedown.vi v4, v8, 0
+# CHECK-ENCODING: [0x57,0x32,0x80,0x3e]
+
 vslidedown.vi v4, v8, 31
+# CHECK-INST: vslidedown.vi v4, v8, 31
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0x3e]
+
 vslideup.vx v4, v8, a1, v0.t
+# CHECK-INST: vslideup.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x38]
+
 vslideup.vi v4, v8, 0, v0.t
+# CHECK-INST: vslideup.vi v4, v8, 0, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x80,0x38]
+
 vslideup.vi v4, v8, 31, v0.t
+# CHECK-INST: vslideup.vi v4, v8, 31, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0x38]
+
 vslidedown.vx v4, v8, a1, v0.t
+# CHECK-INST: vslidedown.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x3c]
+
 vslidedown.vi v4, v8, 0, v0.t
+# CHECK-INST: vslidedown.vi v4, v8, 0, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x80,0x3c]
+
 vslidedown.vi v4, v8, 31, v0.t
+# CHECK-INST: vslidedown.vi v4, v8, 31, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0x3c]
 
 vslide1up.vx v4, v8, a1
+# CHECK-INST: vslide1up.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x3a]
+
 vslide1down.vx v4, v8, a1
+# CHECK-INST: vslide1down.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x3e]
+
 vslide1up.vx v4, v8, a1, v0.t
+# CHECK-INST: vslide1up.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x38]
+
 vslide1down.vx v4, v8, a1, v0.t
+# CHECK-INST: vslide1down.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xe2,0x85,0x3c]
 
 vrgather.vv v4, v8, v12
+# CHECK-INST: vrgather.vv v4, v8, v12
+# CHECK-ENCODING: [0x57,0x02,0x86,0x32]
+
 vrgather.vx v4, v8, a1
+# CHECK-INST: vrgather.vx v4, v8, a1
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x32]
+
 vrgather.vi v4, v8, 0
+# CHECK-INST: vrgather.vi v4, v8, 0
+# CHECK-ENCODING: [0x57,0x32,0x80,0x32]
+
 vrgather.vi v4, v8, 31
+# CHECK-INST: vrgather.vi v4, v8, 31
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0x32]
+
 vrgather.vv v4, v8, v12, v0.t
+# CHECK-INST: vrgather.vv v4, v8, v12, v0.t
+# CHECK-ENCODING: [0x57,0x02,0x86,0x30]
+
 vrgather.vx v4, v8, a1, v0.t
+# CHECK-INST: vrgather.vx v4, v8, a1, v0.t
+# CHECK-ENCODING: [0x57,0xc2,0x85,0x30]
+
 vrgather.vi v4, v8, 0, v0.t
+# CHECK-INST: vrgather.vi v4, v8, 0, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x80,0x30]
+
 vrgather.vi v4, v8, 31, v0.t
+# CHECK-INST: vrgather.vi v4, v8, 31, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x8f,0x30]
 
 vcompress.vm v4, v8, v12
+# CHECK-INST: vcompress.vm v4, v8, v12
+# CHECK-ENCODING: [0x57,0x22,0x86,0x5e]
 
 csrr a0, vstart
+# CHECK-INST: csrr a0, vstart
+# CHECK-ENCODING: [0x73,0x25,0x80,0x00]
+
 csrr a0, vxsat
+# CHECK-INST: csrr a0, vxsat
+# CHECK-ENCODING: [0x73,0x25,0x90,0x00]
+
 csrr a0, vxrm
+# CHECK-INST: csrr a0, vxrm
+# CHECK-ENCODING: [0x73,0x25,0xa0,0x00]
+
 csrr a0, vl
+# CHECK-INST: csrr a0, vl
+# CHECK-ENCODING: [0x73,0x25,0x00,0xc2]
+
 csrr a0, vtype
+# CHECK-INST: csrr a0, vtype
+# CHECK-ENCODING: [0x73,0x25,0x10,0xc2]

--- a/llvm/test/MC/RISCV/rvv0p71/vector-insns.s
+++ b/llvm/test/MC/RISCV/rvv0p71/vector-insns.s
@@ -6,3907 +6,3907 @@
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 vsetvl a0, a1, a2
-# CHECK-INST: vsetvl a0, a1, a2
+# CHECK-INST: vsetvl	a0, a1, a2
 # CHECK-ENCODING: [0x57,0xf5,0xc5,0x80]
 
 vsetvli a0, a1, 0
-# CHECK-INST: vsetvli a0, a1, 0
+# CHECK-INST: vsetvli	a0, a1, e8, m1, d1
 # CHECK-ENCODING: [0x57,0xf5,0x05,0x00]
 
 vsetvli a0, a1, 0x7ff
-# CHECK-INST: vsetvli a0, a1, 0x7ff
+# CHECK-INST: vsetvli	a0, a1, 2047
 # CHECK-ENCODING: [0x57,0xf5,0xf5,0x7f]
 
 vsetvli a0, a1, e16,m2,d4
-# CHECK-INST: vsetvli a0, a1, e16,m2,d4
+# CHECK-INST: vsetvli	a0, a1, e16, m2, d4
 # CHECK-ENCODING: [0x57,0xf5,0x55,0x04]
 
 vlb.v v4, (a0)
-# CHECK-INST: vlb.v v4, (a0)
+# CHECK-INST: vlb.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x12]
 
 vlb.v v4, 0(a0)
-# CHECK-INST: vlb.v v4, 0(a0)
+# CHECK-INST: vlb.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x12]
 
 vlb.v v4, (a0), v0.t
-# CHECK-INST: vlb.v v4, (a0), v0.t
+# CHECK-INST: vlb.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x10]
 
 vlh.v v4, (a0)
-# CHECK-INST: vlh.v v4, (a0)
+# CHECK-INST: vlh.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x12]
 
 vlh.v v4, 0(a0)
-# CHECK-INST: vlh.v v4, 0(a0)
+# CHECK-INST: vlh.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x12]
 
 vlh.v v4, (a0), v0.t
-# CHECK-INST: vlh.v v4, (a0), v0.t
+# CHECK-INST: vlh.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x10]
 
 vlw.v v4, (a0)
-# CHECK-INST: vlw.v v4, (a0)
+# CHECK-INST: vlw.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x12]
 
 vlw.v v4, 0(a0)
-# CHECK-INST: vlw.v v4, 0(a0)
+# CHECK-INST: vlw.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x12]
 
 vlw.v v4, (a0), v0.t
-# CHECK-INST: vlw.v v4, (a0), v0.t
+# CHECK-INST: vlw.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x10]
 
 vlbu.v v4, (a0)
-# CHECK-INST: vlbu.v v4, (a0)
+# CHECK-INST: vlbu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x02]
 
 vlbu.v v4, 0(a0)
-# CHECK-INST: vlbu.v v4, 0(a0)
+# CHECK-INST: vlbu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x02]
 
 vlbu.v v4, (a0), v0.t
-# CHECK-INST: vlbu.v v4, (a0), v0.t
+# CHECK-INST: vlbu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x00]
 
 vlhu.v v4, (a0)
-# CHECK-INST: vlhu.v v4, (a0)
+# CHECK-INST: vlhu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x02]
 
 vlhu.v v4, 0(a0)
-# CHECK-INST: vlhu.v v4, 0(a0)
+# CHECK-INST: vlhu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x02]
 
 vlhu.v v4, (a0), v0.t
-# CHECK-INST: vlhu.v v4, (a0), v0.t
+# CHECK-INST: vlhu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x00]
 
 vlwu.v v4, (a0)
-# CHECK-INST: vlwu.v v4, (a0)
+# CHECK-INST: vlwu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x02]
 
 vlwu.v v4, 0(a0)
-# CHECK-INST: vlwu.v v4, 0(a0)
+# CHECK-INST: vlwu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x02]
 
 vlwu.v v4, (a0), v0.t
-# CHECK-INST: vlwu.v v4, (a0), v0.t
+# CHECK-INST: vlwu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x00]
 
 vle.v v4, (a0)
-# CHECK-INST: vle.v v4, (a0)
+# CHECK-INST: vle.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x02]
 
 vle.v v4, 0(a0)
-# CHECK-INST: vle.v v4, 0(a0)
+# CHECK-INST: vle.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x02]
 
 vle.v v4, (a0), v0.t
-# CHECK-INST: vle.v v4, (a0), v0.t
+# CHECK-INST: vle.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0x00]
 
 vsb.v v4, (a0)
-# CHECK-INST: vsb.v v4, (a0)
+# CHECK-INST: vsb.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0x02]
 
 vsb.v v4, 0(a0)
-# CHECK-INST: vsb.v v4, 0(a0)
+# CHECK-INST: vsb.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0x02]
 
 vsb.v v4, (a0), v0.t
-# CHECK-INST: vsb.v v4, (a0), v0.t
+# CHECK-INST: vsb.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x02,0x05,0x00]
 
 vsh.v v4, (a0)
-# CHECK-INST: vsh.v v4, (a0)
+# CHECK-INST: vsh.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0x02]
 
 vsh.v v4, 0(a0)
-# CHECK-INST: vsh.v v4, 0(a0)
+# CHECK-INST: vsh.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0x02]
 
 vsh.v v4, (a0), v0.t
-# CHECK-INST: vsh.v v4, (a0), v0.t
+# CHECK-INST: vsh.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x52,0x05,0x00]
 
 vsw.v v4, (a0)
-# CHECK-INST: vsw.v v4, (a0)
+# CHECK-INST: vsw.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0x02]
 
 vsw.v v4, 0(a0)
-# CHECK-INST: vsw.v v4, 0(a0)
+# CHECK-INST: vsw.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0x02]
 
 vsw.v v4, (a0), v0.t
-# CHECK-INST: vsw.v v4, (a0), v0.t
+# CHECK-INST: vsw.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x62,0x05,0x00]
 
 vse.v v4, (a0)
-# CHECK-INST: vse.v v4, (a0)
+# CHECK-INST: vse.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0x02]
 
 vse.v v4, 0(a0)
-# CHECK-INST: vse.v v4, 0(a0)
+# CHECK-INST: vse.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0x02]
 
 vse.v v4, (a0), v0.t
-# CHECK-INST: vse.v v4, (a0), v0.t
+# CHECK-INST: vse.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x72,0x05,0x00]
 
 vlsb.v v4, (a0), a1
-# CHECK-INST: vlsb.v v4, (a0), a1
+# CHECK-INST: vlsb.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x1a]
 
 vlsb.v v4, 0(a0), a1
-# CHECK-INST: vlsb.v v4, 0(a0), a1
+# CHECK-INST: vlsb.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x1a]
 
 vlsb.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsb.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsb.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x18]
 
 vlsh.v v4, (a0), a1
-# CHECK-INST: vlsh.v v4, (a0), a1
+# CHECK-INST: vlsh.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x1a]
 
 vlsh.v v4, 0(a0), a1
-# CHECK-INST: vlsh.v v4, 0(a0), a1
+# CHECK-INST: vlsh.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x1a]
 
 vlsh.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsh.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsh.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x18]
 
 vlsw.v v4, (a0), a1
-# CHECK-INST: vlsw.v v4, (a0), a1
+# CHECK-INST: vlsw.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x1a]
 
 vlsw.v v4, 0(a0), a1
-# CHECK-INST: vlsw.v v4, 0(a0), a1
+# CHECK-INST: vlsw.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x1a]
 
 vlsw.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsw.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsw.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x18]
 
 vlsbu.v v4, (a0), a1
-# CHECK-INST: vlsbu.v v4, (a0), a1
+# CHECK-INST: vlsbu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x0a]
 
 vlsbu.v v4, 0(a0), a1
-# CHECK-INST: vlsbu.v v4, 0(a0), a1
+# CHECK-INST: vlsbu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x0a]
 
 vlsbu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsbu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsbu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x08]
 
 vlshu.v v4, (a0), a1
-# CHECK-INST: vlshu.v v4, (a0), a1
+# CHECK-INST: vlshu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x0a]
 
 vlshu.v v4, 0(a0), a1
-# CHECK-INST: vlshu.v v4, 0(a0), a1
+# CHECK-INST: vlshu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x0a]
 
 vlshu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlshu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlshu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x08]
 
 vlswu.v v4, (a0), a1
-# CHECK-INST: vlswu.v v4, (a0), a1
+# CHECK-INST: vlswu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x0a]
 
 vlswu.v v4, 0(a0), a1
-# CHECK-INST: vlswu.v v4, 0(a0), a1
+# CHECK-INST: vlswu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x0a]
 
 vlswu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlswu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlswu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x08]
 
 vlse.v v4, (a0), a1
-# CHECK-INST: vlse.v v4, (a0), a1
+# CHECK-INST: vlse.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x0a]
 
 vlse.v v4, 0(a0), a1
-# CHECK-INST: vlse.v v4, 0(a0), a1
+# CHECK-INST: vlse.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x0a]
 
 vlse.v v4, (a0), a1, v0.t
-# CHECK-INST: vlse.v v4, (a0), a1, v0.t
+# CHECK-INST: vlse.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x08]
 
 vssb.v v4, (a0), a1
-# CHECK-INST: vssb.v v4, (a0), a1
+# CHECK-INST: vssb.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x0a]
 
 vssb.v v4, 0(a0), a1
-# CHECK-INST: vssb.v v4, 0(a0), a1
+# CHECK-INST: vssb.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x0a]
 
 vssb.v v4, (a0), a1, v0.t
-# CHECK-INST: vssb.v v4, (a0), a1, v0.t
+# CHECK-INST: vssb.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x08]
 
 vssh.v v4, (a0), a1
-# CHECK-INST: vssh.v v4, (a0), a1
+# CHECK-INST: vssh.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x0a]
 
 vssh.v v4, 0(a0), a1
-# CHECK-INST: vssh.v v4, 0(a0), a1
+# CHECK-INST: vssh.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x0a]
 
 vssh.v v4, (a0), a1, v0.t
-# CHECK-INST: vssh.v v4, (a0), a1, v0.t
+# CHECK-INST: vssh.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x08]
 
 vssw.v v4, (a0), a1
-# CHECK-INST: vssw.v v4, (a0), a1
+# CHECK-INST: vssw.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x0a]
 
 vssw.v v4, 0(a0), a1
-# CHECK-INST: vssw.v v4, 0(a0), a1
+# CHECK-INST: vssw.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x0a]
 
 vssw.v v4, (a0), a1, v0.t
-# CHECK-INST: vssw.v v4, (a0), a1, v0.t
+# CHECK-INST: vssw.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x08]
 
 vsse.v v4, (a0), a1
-# CHECK-INST: vsse.v v4, (a0), a1
+# CHECK-INST: vsse.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x0a]
 
 vsse.v v4, 0(a0), a1
-# CHECK-INST: vsse.v v4, 0(a0), a1
+# CHECK-INST: vsse.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x0a]
 
 vsse.v v4, (a0), a1, v0.t
-# CHECK-INST: vsse.v v4, (a0), a1, v0.t
+# CHECK-INST: vsse.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x08]
 
 vlxb.v v4, (a0), v12
-# CHECK-INST: vlxb.v v4, (a0), v12
+# CHECK-INST: vlxb.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x1e]
 
 vlxb.v v4, 0(a0), v12
-# CHECK-INST: vlxb.v v4, 0(a0), v12
+# CHECK-INST: vlxb.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x1e]
 
 vlxb.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxb.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxb.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x1c]
 
 vlxh.v v4, (a0), v12
-# CHECK-INST: vlxh.v v4, (a0), v12
+# CHECK-INST: vlxh.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x1e]
 
 vlxh.v v4, 0(a0), v12
-# CHECK-INST: vlxh.v v4, 0(a0), v12
+# CHECK-INST: vlxh.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x1e]
 
 vlxh.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxh.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxh.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x1c]
 
 vlxw.v v4, (a0), v12
-# CHECK-INST: vlxw.v v4, (a0), v12
+# CHECK-INST: vlxw.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x1e]
 
 vlxw.v v4, 0(a0), v12
-# CHECK-INST: vlxw.v v4, 0(a0), v12
+# CHECK-INST: vlxw.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x1e]
 
 vlxw.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxw.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxw.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x1c]
 
 vlxbu.v v4, (a0), v12
-# CHECK-INST: vlxbu.v v4, (a0), v12
+# CHECK-INST: vlxbu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x0e]
 
 vlxbu.v v4, 0(a0), v12
-# CHECK-INST: vlxbu.v v4, 0(a0), v12
+# CHECK-INST: vlxbu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x0e]
 
 vlxbu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxbu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxbu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x0c]
 
 vlxhu.v v4, (a0), v12
-# CHECK-INST: vlxhu.v v4, (a0), v12
+# CHECK-INST: vlxhu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x0e]
 
 vlxhu.v v4, 0(a0), v12
-# CHECK-INST: vlxhu.v v4, 0(a0), v12
+# CHECK-INST: vlxhu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x0e]
 
 vlxhu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxhu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxhu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x0c]
 
 vlxwu.v v4, (a0), v12
-# CHECK-INST: vlxwu.v v4, (a0), v12
+# CHECK-INST: vlxwu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x0e]
 
 vlxwu.v v4, 0(a0), v12
-# CHECK-INST: vlxwu.v v4, 0(a0), v12
+# CHECK-INST: vlxwu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x0e]
 
 vlxwu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxwu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxwu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x0c]
 
 vlxe.v v4, (a0), v12
-# CHECK-INST: vlxe.v v4, (a0), v12
+# CHECK-INST: vlxe.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x0e]
 
 vlxe.v v4, 0(a0), v12
-# CHECK-INST: vlxe.v v4, 0(a0), v12
+# CHECK-INST: vlxe.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x0e]
 
 vlxe.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxe.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxe.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x0c]
 
 vsxb.v v4, (a0), v12
-# CHECK-INST: vsxb.v v4, (a0), v12
+# CHECK-INST: vsxb.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x0e]
 
 vsxb.v v4, 0(a0), v12
-# CHECK-INST: vsxb.v v4, 0(a0), v12
+# CHECK-INST: vsxb.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x0e]
 
 vsxb.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxb.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxb.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x0c]
 
 vsxh.v v4, (a0), v12
-# CHECK-INST: vsxh.v v4, (a0), v12
+# CHECK-INST: vsxh.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x0e]
 
 vsxh.v v4, 0(a0), v12
-# CHECK-INST: vsxh.v v4, 0(a0), v12
+# CHECK-INST: vsxh.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x0e]
 
 vsxh.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxh.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxh.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x0c]
 
 vsxw.v v4, (a0), v12
-# CHECK-INST: vsxw.v v4, (a0), v12
+# CHECK-INST: vsxw.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x0e]
 
 vsxw.v v4, 0(a0), v12
-# CHECK-INST: vsxw.v v4, 0(a0), v12
+# CHECK-INST: vsxw.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x0e]
 
 vsxw.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxw.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxw.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x0c]
 
 vsxe.v v4, (a0), v12
-# CHECK-INST: vsxe.v v4, (a0), v12
+# CHECK-INST: vsxe.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x0e]
 
 vsxe.v v4, 0(a0), v12
-# CHECK-INST: vsxe.v v4, 0(a0), v12
+# CHECK-INST: vsxe.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x0e]
 
 vsxe.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxe.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxe.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x0c]
 
 vsuxb.v v4, (a0), v12
-# CHECK-INST: vsuxb.v v4, (a0), v12
+# CHECK-INST: vsuxb.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x1e]
 
 vsuxb.v v4, 0(a0), v12
-# CHECK-INST: vsuxb.v v4, 0(a0), v12
+# CHECK-INST: vsuxb.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x1e]
 
 vsuxb.v v4, (a0), v12, v0.t
-# CHECK-INST: vsuxb.v v4, (a0), v12, v0.t
+# CHECK-INST: vsuxb.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x1c]
 
 vsuxh.v v4, (a0), v12
-# CHECK-INST: vsuxh.v v4, (a0), v12
+# CHECK-INST: vsuxh.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x1e]
 
 vsuxh.v v4, 0(a0), v12
-# CHECK-INST: vsuxh.v v4, 0(a0), v12
+# CHECK-INST: vsuxh.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x1e]
 
 vsuxh.v v4, (a0), v12, v0.t
-# CHECK-INST: vsuxh.v v4, (a0), v12, v0.t
+# CHECK-INST: vsuxh.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x1c]
 
 vsuxw.v v4, (a0), v12
-# CHECK-INST: vsuxw.v v4, (a0), v12
+# CHECK-INST: vsuxw.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x1e]
 
 vsuxw.v v4, 0(a0), v12
-# CHECK-INST: vsuxw.v v4, 0(a0), v12
+# CHECK-INST: vsuxw.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x1e]
 
 vsuxw.v v4, (a0), v12, v0.t
-# CHECK-INST: vsuxw.v v4, (a0), v12, v0.t
+# CHECK-INST: vsuxw.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x1c]
 
 vsuxe.v v4, (a0), v12
-# CHECK-INST: vsuxe.v v4, (a0), v12
+# CHECK-INST: vsuxe.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x1e]
 
 vsuxe.v v4, 0(a0), v12
-# CHECK-INST: vsuxe.v v4, 0(a0), v12
+# CHECK-INST: vsuxe.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x1e]
 
 vsuxe.v v4, (a0), v12, v0.t
-# CHECK-INST: vsuxe.v v4, (a0), v12, v0.t
+# CHECK-INST: vsuxe.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x1c]
 
 vlbff.v v4, (a0)
-# CHECK-INST: vlbff.v v4, (a0)
+# CHECK-INST: vlbff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x13]
 
 vlbff.v v4, 0(a0)
-# CHECK-INST: vlbff.v v4, 0(a0)
+# CHECK-INST: vlbff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x13]
 
 vlbff.v v4, (a0), v0.t
-# CHECK-INST: vlbff.v v4, (a0), v0.t
+# CHECK-INST: vlbff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x11]
 
 vlhff.v v4, (a0)
-# CHECK-INST: vlhff.v v4, (a0)
+# CHECK-INST: vlhff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x13]
 
 vlhff.v v4, 0(a0)
-# CHECK-INST: vlhff.v v4, 0(a0)
+# CHECK-INST: vlhff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x13]
 
 vlhff.v v4, (a0), v0.t
-# CHECK-INST: vlhff.v v4, (a0), v0.t
+# CHECK-INST: vlhff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x11]
 
 vlwff.v v4, (a0)
-# CHECK-INST: vlwff.v v4, (a0)
+# CHECK-INST: vlwff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x13]
 
 vlwff.v v4, 0(a0)
-# CHECK-INST: vlwff.v v4, 0(a0)
+# CHECK-INST: vlwff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x13]
 
 vlwff.v v4, (a0), v0.t
-# CHECK-INST: vlwff.v v4, (a0), v0.t
+# CHECK-INST: vlwff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x11]
 
 vlbuff.v v4, (a0)
-# CHECK-INST: vlbuff.v v4, (a0)
+# CHECK-INST: vlbuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x03]
 
 vlbuff.v v4, 0(a0)
-# CHECK-INST: vlbuff.v v4, 0(a0)
+# CHECK-INST: vlbuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x03]
 
 vlbuff.v v4, (a0), v0.t
-# CHECK-INST: vlbuff.v v4, (a0), v0.t
+# CHECK-INST: vlbuff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x01]
 
 vlhuff.v v4, (a0)
-# CHECK-INST: vlhuff.v v4, (a0)
+# CHECK-INST: vlhuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x03]
 
 vlhuff.v v4, 0(a0)
-# CHECK-INST: vlhuff.v v4, 0(a0)
+# CHECK-INST: vlhuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x03]
 
 vlhuff.v v4, (a0), v0.t
-# CHECK-INST: vlhuff.v v4, (a0), v0.t
+# CHECK-INST: vlhuff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x01]
 
 vlwuff.v v4, (a0)
-# CHECK-INST: vlwuff.v v4, (a0)
+# CHECK-INST: vlwuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x03]
 
 vlwuff.v v4, 0(a0)
-# CHECK-INST: vlwuff.v v4, 0(a0)
+# CHECK-INST: vlwuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x03]
 
 vlwuff.v v4, (a0), v0.t
-# CHECK-INST: vlwuff.v v4, (a0), v0.t
+# CHECK-INST: vlwuff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x01]
 
 vleff.v v4, (a0)
-# CHECK-INST: vleff.v v4, (a0)
+# CHECK-INST: vleff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x03]
 
 vleff.v v4, 0(a0)
-# CHECK-INST: vleff.v v4, 0(a0)
+# CHECK-INST: vleff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x03]
 
 vleff.v v4, (a0), v0.t
-# CHECK-INST: vleff.v v4, (a0), v0.t
+# CHECK-INST: vleff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0x01]
 
 vlseg2b.v v4, (a0)
-# CHECK-INST: vlseg2b.v v4, (a0)
+# CHECK-INST: vlseg2b.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x32]
 
 vlseg2b.v v4, 0(a0)
-# CHECK-INST: vlseg2b.v v4, 0(a0)
+# CHECK-INST: vlseg2b.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x32]
 
 vlseg2b.v v4, (a0), v0.t
-# CHECK-INST: vlseg2b.v v4, (a0), v0.t
+# CHECK-INST: vlseg2b.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x30]
 
 vlseg2h.v v4, (a0)
-# CHECK-INST: vlseg2h.v v4, (a0)
+# CHECK-INST: vlseg2h.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x32]
 
 vlseg2h.v v4, 0(a0)
-# CHECK-INST: vlseg2h.v v4, 0(a0)
+# CHECK-INST: vlseg2h.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x32]
 
 vlseg2h.v v4, (a0), v0.t
-# CHECK-INST: vlseg2h.v v4, (a0), v0.t
+# CHECK-INST: vlseg2h.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x30]
 
 vlseg2w.v v4, (a0)
-# CHECK-INST: vlseg2w.v v4, (a0)
+# CHECK-INST: vlseg2w.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x32]
 
 vlseg2w.v v4, 0(a0)
-# CHECK-INST: vlseg2w.v v4, 0(a0)
+# CHECK-INST: vlseg2w.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x32]
 
 vlseg2w.v v4, (a0), v0.t
-# CHECK-INST: vlseg2w.v v4, (a0), v0.t
+# CHECK-INST: vlseg2w.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x30]
 
 vlseg2bu.v v4, (a0)
-# CHECK-INST: vlseg2bu.v v4, (a0)
+# CHECK-INST: vlseg2bu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x22]
 
 vlseg2bu.v v4, 0(a0)
-# CHECK-INST: vlseg2bu.v v4, 0(a0)
+# CHECK-INST: vlseg2bu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x22]
 
 vlseg2bu.v v4, (a0), v0.t
-# CHECK-INST: vlseg2bu.v v4, (a0), v0.t
+# CHECK-INST: vlseg2bu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x20]
 
 vlseg2hu.v v4, (a0)
-# CHECK-INST: vlseg2hu.v v4, (a0)
+# CHECK-INST: vlseg2hu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x22]
 
 vlseg2hu.v v4, 0(a0)
-# CHECK-INST: vlseg2hu.v v4, 0(a0)
+# CHECK-INST: vlseg2hu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x22]
 
 vlseg2hu.v v4, (a0), v0.t
-# CHECK-INST: vlseg2hu.v v4, (a0), v0.t
+# CHECK-INST: vlseg2hu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x20]
 
 vlseg2wu.v v4, (a0)
-# CHECK-INST: vlseg2wu.v v4, (a0)
+# CHECK-INST: vlseg2wu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x22]
 
 vlseg2wu.v v4, 0(a0)
-# CHECK-INST: vlseg2wu.v v4, 0(a0)
+# CHECK-INST: vlseg2wu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x22]
 
 vlseg2wu.v v4, (a0), v0.t
-# CHECK-INST: vlseg2wu.v v4, (a0), v0.t
+# CHECK-INST: vlseg2wu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x20]
 
 vlseg2e.v v4, (a0)
-# CHECK-INST: vlseg2e.v v4, (a0)
+# CHECK-INST: vlseg2e.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x22]
 
 vlseg2e.v v4, 0(a0)
-# CHECK-INST: vlseg2e.v v4, 0(a0)
+# CHECK-INST: vlseg2e.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x22]
 
 vlseg2e.v v4, (a0), v0.t
-# CHECK-INST: vlseg2e.v v4, (a0), v0.t
+# CHECK-INST: vlseg2e.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0x20]
 
 vsseg2b.v v4, (a0)
-# CHECK-INST: vsseg2b.v v4, (a0)
+# CHECK-INST: vsseg2b.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0x22]
 
 vsseg2b.v v4, 0(a0)
-# CHECK-INST: vsseg2b.v v4, 0(a0)
+# CHECK-INST: vsseg2b.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0x22]
 
 vsseg2b.v v4, (a0), v0.t
-# CHECK-INST: vsseg2b.v v4, (a0), v0.t
+# CHECK-INST: vsseg2b.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x02,0x05,0x20]
 
 vsseg2h.v v4, (a0)
-# CHECK-INST: vsseg2h.v v4, (a0)
+# CHECK-INST: vsseg2h.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0x22]
 
 vsseg2h.v v4, 0(a0)
-# CHECK-INST: vsseg2h.v v4, 0(a0)
+# CHECK-INST: vsseg2h.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0x22]
 
 vsseg2h.v v4, (a0), v0.t
-# CHECK-INST: vsseg2h.v v4, (a0), v0.t
+# CHECK-INST: vsseg2h.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x52,0x05,0x20]
 
 vsseg2w.v v4, (a0)
-# CHECK-INST: vsseg2w.v v4, (a0)
+# CHECK-INST: vsseg2w.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0x22]
 
 vsseg2w.v v4, 0(a0)
-# CHECK-INST: vsseg2w.v v4, 0(a0)
+# CHECK-INST: vsseg2w.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0x22]
 
 vsseg2w.v v4, (a0), v0.t
-# CHECK-INST: vsseg2w.v v4, (a0), v0.t
+# CHECK-INST: vsseg2w.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x62,0x05,0x20]
 
 vsseg2e.v v4, (a0)
-# CHECK-INST: vsseg2e.v v4, (a0)
+# CHECK-INST: vsseg2e.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0x22]
 
 vsseg2e.v v4, 0(a0)
-# CHECK-INST: vsseg2e.v v4, 0(a0)
+# CHECK-INST: vsseg2e.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0x22]
 
 vsseg2e.v v4, (a0), v0.t
-# CHECK-INST: vsseg2e.v v4, (a0), v0.t
+# CHECK-INST: vsseg2e.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x72,0x05,0x20]
 
 vlseg3b.v v4, (a0)
-# CHECK-INST: vlseg3b.v v4, (a0)
+# CHECK-INST: vlseg3b.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x52]
 
 vlseg3b.v v4, 0(a0)
-# CHECK-INST: vlseg3b.v v4, 0(a0)
+# CHECK-INST: vlseg3b.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x52]
 
 vlseg3b.v v4, (a0), v0.t
-# CHECK-INST: vlseg3b.v v4, (a0), v0.t
+# CHECK-INST: vlseg3b.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x50]
 
 vlseg3h.v v4, (a0)
-# CHECK-INST: vlseg3h.v v4, (a0)
+# CHECK-INST: vlseg3h.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x52]
 
 vlseg3h.v v4, 0(a0)
-# CHECK-INST: vlseg3h.v v4, 0(a0)
+# CHECK-INST: vlseg3h.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x52]
 
 vlseg3h.v v4, (a0), v0.t
-# CHECK-INST: vlseg3h.v v4, (a0), v0.t
+# CHECK-INST: vlseg3h.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x50]
 
 vlseg3w.v v4, (a0)
-# CHECK-INST: vlseg3w.v v4, (a0)
+# CHECK-INST: vlseg3w.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x52]
 
 vlseg3w.v v4, 0(a0)
-# CHECK-INST: vlseg3w.v v4, 0(a0)
+# CHECK-INST: vlseg3w.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x52]
 
 vlseg3w.v v4, (a0), v0.t
-# CHECK-INST: vlseg3w.v v4, (a0), v0.t
+# CHECK-INST: vlseg3w.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x50]
 
 vlseg3bu.v v4, (a0)
-# CHECK-INST: vlseg3bu.v v4, (a0)
+# CHECK-INST: vlseg3bu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x42]
 
 vlseg3bu.v v4, 0(a0)
-# CHECK-INST: vlseg3bu.v v4, 0(a0)
+# CHECK-INST: vlseg3bu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x42]
 
 vlseg3bu.v v4, (a0), v0.t
-# CHECK-INST: vlseg3bu.v v4, (a0), v0.t
+# CHECK-INST: vlseg3bu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x40]
 
 vlseg3hu.v v4, (a0)
-# CHECK-INST: vlseg3hu.v v4, (a0)
+# CHECK-INST: vlseg3hu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x42]
 
 vlseg3hu.v v4, 0(a0)
-# CHECK-INST: vlseg3hu.v v4, 0(a0)
+# CHECK-INST: vlseg3hu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x42]
 
 vlseg3hu.v v4, (a0), v0.t
-# CHECK-INST: vlseg3hu.v v4, (a0), v0.t
+# CHECK-INST: vlseg3hu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x40]
 
 vlseg3wu.v v4, (a0)
-# CHECK-INST: vlseg3wu.v v4, (a0)
+# CHECK-INST: vlseg3wu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x42]
 
 vlseg3wu.v v4, 0(a0)
-# CHECK-INST: vlseg3wu.v v4, 0(a0)
+# CHECK-INST: vlseg3wu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x42]
 
 vlseg3wu.v v4, (a0), v0.t
-# CHECK-INST: vlseg3wu.v v4, (a0), v0.t
+# CHECK-INST: vlseg3wu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x40]
 
 vlseg3e.v v4, (a0)
-# CHECK-INST: vlseg3e.v v4, (a0)
+# CHECK-INST: vlseg3e.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x42]
 
 vlseg3e.v v4, 0(a0)
-# CHECK-INST: vlseg3e.v v4, 0(a0)
+# CHECK-INST: vlseg3e.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x42]
 
 vlseg3e.v v4, (a0), v0.t
-# CHECK-INST: vlseg3e.v v4, (a0), v0.t
+# CHECK-INST: vlseg3e.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0x40]
 
 vsseg3b.v v4, (a0)
-# CHECK-INST: vsseg3b.v v4, (a0)
+# CHECK-INST: vsseg3b.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0x42]
 
 vsseg3b.v v4, 0(a0)
-# CHECK-INST: vsseg3b.v v4, 0(a0)
+# CHECK-INST: vsseg3b.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0x42]
 
 vsseg3b.v v4, (a0), v0.t
-# CHECK-INST: vsseg3b.v v4, (a0), v0.t
+# CHECK-INST: vsseg3b.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x02,0x05,0x40]
 
 vsseg3h.v v4, (a0)
-# CHECK-INST: vsseg3h.v v4, (a0)
+# CHECK-INST: vsseg3h.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0x42]
 
 vsseg3h.v v4, 0(a0)
-# CHECK-INST: vsseg3h.v v4, 0(a0)
+# CHECK-INST: vsseg3h.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0x42]
 
 vsseg3h.v v4, (a0), v0.t
-# CHECK-INST: vsseg3h.v v4, (a0), v0.t
+# CHECK-INST: vsseg3h.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x52,0x05,0x40]
 
 vsseg3w.v v4, (a0)
-# CHECK-INST: vsseg3w.v v4, (a0)
+# CHECK-INST: vsseg3w.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0x42]
 
 vsseg3w.v v4, 0(a0)
-# CHECK-INST: vsseg3w.v v4, 0(a0)
+# CHECK-INST: vsseg3w.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0x42]
 
 vsseg3w.v v4, (a0), v0.t
-# CHECK-INST: vsseg3w.v v4, (a0), v0.t
+# CHECK-INST: vsseg3w.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x62,0x05,0x40]
 
 vsseg3e.v v4, (a0)
-# CHECK-INST: vsseg3e.v v4, (a0)
+# CHECK-INST: vsseg3e.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0x42]
 
 vsseg3e.v v4, 0(a0)
-# CHECK-INST: vsseg3e.v v4, 0(a0)
+# CHECK-INST: vsseg3e.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0x42]
 
 vsseg3e.v v4, (a0), v0.t
-# CHECK-INST: vsseg3e.v v4, (a0), v0.t
+# CHECK-INST: vsseg3e.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x72,0x05,0x40]
 
 vlseg4b.v v4, (a0)
-# CHECK-INST: vlseg4b.v v4, (a0)
+# CHECK-INST: vlseg4b.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x72]
 
 vlseg4b.v v4, 0(a0)
-# CHECK-INST: vlseg4b.v v4, 0(a0)
+# CHECK-INST: vlseg4b.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x72]
 
 vlseg4b.v v4, (a0), v0.t
-# CHECK-INST: vlseg4b.v v4, (a0), v0.t
+# CHECK-INST: vlseg4b.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x70]
 
 vlseg4h.v v4, (a0)
-# CHECK-INST: vlseg4h.v v4, (a0)
+# CHECK-INST: vlseg4h.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x72]
 
 vlseg4h.v v4, 0(a0)
-# CHECK-INST: vlseg4h.v v4, 0(a0)
+# CHECK-INST: vlseg4h.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x72]
 
 vlseg4h.v v4, (a0), v0.t
-# CHECK-INST: vlseg4h.v v4, (a0), v0.t
+# CHECK-INST: vlseg4h.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x70]
 
 vlseg4w.v v4, (a0)
-# CHECK-INST: vlseg4w.v v4, (a0)
+# CHECK-INST: vlseg4w.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x72]
 
 vlseg4w.v v4, 0(a0)
-# CHECK-INST: vlseg4w.v v4, 0(a0)
+# CHECK-INST: vlseg4w.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x72]
 
 vlseg4w.v v4, (a0), v0.t
-# CHECK-INST: vlseg4w.v v4, (a0), v0.t
+# CHECK-INST: vlseg4w.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x70]
 
 vlseg4bu.v v4, (a0)
-# CHECK-INST: vlseg4bu.v v4, (a0)
+# CHECK-INST: vlseg4bu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x62]
 
 vlseg4bu.v v4, 0(a0)
-# CHECK-INST: vlseg4bu.v v4, 0(a0)
+# CHECK-INST: vlseg4bu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x62]
 
 vlseg4bu.v v4, (a0), v0.t
-# CHECK-INST: vlseg4bu.v v4, (a0), v0.t
+# CHECK-INST: vlseg4bu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x60]
 
 vlseg4hu.v v4, (a0)
-# CHECK-INST: vlseg4hu.v v4, (a0)
+# CHECK-INST: vlseg4hu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x62]
 
 vlseg4hu.v v4, 0(a0)
-# CHECK-INST: vlseg4hu.v v4, 0(a0)
+# CHECK-INST: vlseg4hu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x62]
 
 vlseg4hu.v v4, (a0), v0.t
-# CHECK-INST: vlseg4hu.v v4, (a0), v0.t
+# CHECK-INST: vlseg4hu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x60]
 
 vlseg4wu.v v4, (a0)
-# CHECK-INST: vlseg4wu.v v4, (a0)
+# CHECK-INST: vlseg4wu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x62]
 
 vlseg4wu.v v4, 0(a0)
-# CHECK-INST: vlseg4wu.v v4, 0(a0)
+# CHECK-INST: vlseg4wu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x62]
 
 vlseg4wu.v v4, (a0), v0.t
-# CHECK-INST: vlseg4wu.v v4, (a0), v0.t
+# CHECK-INST: vlseg4wu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x60]
 
 vlseg4e.v v4, (a0)
-# CHECK-INST: vlseg4e.v v4, (a0)
+# CHECK-INST: vlseg4e.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x62]
 
 vlseg4e.v v4, 0(a0)
-# CHECK-INST: vlseg4e.v v4, 0(a0)
+# CHECK-INST: vlseg4e.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x62]
 
 vlseg4e.v v4, (a0), v0.t
-# CHECK-INST: vlseg4e.v v4, (a0), v0.t
+# CHECK-INST: vlseg4e.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0x60]
 
 vsseg4b.v v4, (a0)
-# CHECK-INST: vsseg4b.v v4, (a0)
+# CHECK-INST: vsseg4b.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0x62]
 
 vsseg4b.v v4, 0(a0)
-# CHECK-INST: vsseg4b.v v4, 0(a0)
+# CHECK-INST: vsseg4b.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0x62]
 
 vsseg4b.v v4, (a0), v0.t
-# CHECK-INST: vsseg4b.v v4, (a0), v0.t
+# CHECK-INST: vsseg4b.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x02,0x05,0x60]
 
 vsseg4h.v v4, (a0)
-# CHECK-INST: vsseg4h.v v4, (a0)
+# CHECK-INST: vsseg4h.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0x62]
 
 vsseg4h.v v4, 0(a0)
-# CHECK-INST: vsseg4h.v v4, 0(a0)
+# CHECK-INST: vsseg4h.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0x62]
 
 vsseg4h.v v4, (a0), v0.t
-# CHECK-INST: vsseg4h.v v4, (a0), v0.t
+# CHECK-INST: vsseg4h.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x52,0x05,0x60]
 
 vsseg4w.v v4, (a0)
-# CHECK-INST: vsseg4w.v v4, (a0)
+# CHECK-INST: vsseg4w.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0x62]
 
 vsseg4w.v v4, 0(a0)
-# CHECK-INST: vsseg4w.v v4, 0(a0)
+# CHECK-INST: vsseg4w.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0x62]
 
 vsseg4w.v v4, (a0), v0.t
-# CHECK-INST: vsseg4w.v v4, (a0), v0.t
+# CHECK-INST: vsseg4w.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x62,0x05,0x60]
 
 vsseg4e.v v4, (a0)
-# CHECK-INST: vsseg4e.v v4, (a0)
+# CHECK-INST: vsseg4e.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0x62]
 
 vsseg4e.v v4, 0(a0)
-# CHECK-INST: vsseg4e.v v4, 0(a0)
+# CHECK-INST: vsseg4e.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0x62]
 
 vsseg4e.v v4, (a0), v0.t
-# CHECK-INST: vsseg4e.v v4, (a0), v0.t
+# CHECK-INST: vsseg4e.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x72,0x05,0x60]
 
 vlseg5b.v v4, (a0)
-# CHECK-INST: vlseg5b.v v4, (a0)
+# CHECK-INST: vlseg5b.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x92]
 
 vlseg5b.v v4, 0(a0)
-# CHECK-INST: vlseg5b.v v4, 0(a0)
+# CHECK-INST: vlseg5b.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x92]
 
 vlseg5b.v v4, (a0), v0.t
-# CHECK-INST: vlseg5b.v v4, (a0), v0.t
+# CHECK-INST: vlseg5b.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x90]
 
 vlseg5h.v v4, (a0)
-# CHECK-INST: vlseg5h.v v4, (a0)
+# CHECK-INST: vlseg5h.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x92]
 
 vlseg5h.v v4, 0(a0)
-# CHECK-INST: vlseg5h.v v4, 0(a0)
+# CHECK-INST: vlseg5h.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x92]
 
 vlseg5h.v v4, (a0), v0.t
-# CHECK-INST: vlseg5h.v v4, (a0), v0.t
+# CHECK-INST: vlseg5h.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x90]
 
 vlseg5w.v v4, (a0)
-# CHECK-INST: vlseg5w.v v4, (a0)
+# CHECK-INST: vlseg5w.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x92]
 
 vlseg5w.v v4, 0(a0)
-# CHECK-INST: vlseg5w.v v4, 0(a0)
+# CHECK-INST: vlseg5w.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x92]
 
 vlseg5w.v v4, (a0), v0.t
-# CHECK-INST: vlseg5w.v v4, (a0), v0.t
+# CHECK-INST: vlseg5w.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x90]
 
 vlseg5bu.v v4, (a0)
-# CHECK-INST: vlseg5bu.v v4, (a0)
+# CHECK-INST: vlseg5bu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x82]
 
 vlseg5bu.v v4, 0(a0)
-# CHECK-INST: vlseg5bu.v v4, 0(a0)
+# CHECK-INST: vlseg5bu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x82]
 
 vlseg5bu.v v4, (a0), v0.t
-# CHECK-INST: vlseg5bu.v v4, (a0), v0.t
+# CHECK-INST: vlseg5bu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x80]
 
 vlseg5hu.v v4, (a0)
-# CHECK-INST: vlseg5hu.v v4, (a0)
+# CHECK-INST: vlseg5hu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x82]
 
 vlseg5hu.v v4, 0(a0)
-# CHECK-INST: vlseg5hu.v v4, 0(a0)
+# CHECK-INST: vlseg5hu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x82]
 
 vlseg5hu.v v4, (a0), v0.t
-# CHECK-INST: vlseg5hu.v v4, (a0), v0.t
+# CHECK-INST: vlseg5hu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x80]
 
 vlseg5wu.v v4, (a0)
-# CHECK-INST: vlseg5wu.v v4, (a0)
+# CHECK-INST: vlseg5wu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x82]
 
 vlseg5wu.v v4, 0(a0)
-# CHECK-INST: vlseg5wu.v v4, 0(a0)
+# CHECK-INST: vlseg5wu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x82]
 
 vlseg5wu.v v4, (a0), v0.t
-# CHECK-INST: vlseg5wu.v v4, (a0), v0.t
+# CHECK-INST: vlseg5wu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x80]
 
 vlseg5e.v v4, (a0)
-# CHECK-INST: vlseg5e.v v4, (a0)
+# CHECK-INST: vlseg5e.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x82]
 
 vlseg5e.v v4, 0(a0)
-# CHECK-INST: vlseg5e.v v4, 0(a0)
+# CHECK-INST: vlseg5e.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x82]
 
 vlseg5e.v v4, (a0), v0.t
-# CHECK-INST: vlseg5e.v v4, (a0), v0.t
+# CHECK-INST: vlseg5e.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0x80]
 
 vsseg5b.v v4, (a0)
-# CHECK-INST: vsseg5b.v v4, (a0)
+# CHECK-INST: vsseg5b.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0x82]
 
 vsseg5b.v v4, 0(a0)
-# CHECK-INST: vsseg5b.v v4, 0(a0)
+# CHECK-INST: vsseg5b.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0x82]
 
 vsseg5b.v v4, (a0), v0.t
-# CHECK-INST: vsseg5b.v v4, (a0), v0.t
+# CHECK-INST: vsseg5b.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x02,0x05,0x80]
 
 vsseg5h.v v4, (a0)
-# CHECK-INST: vsseg5h.v v4, (a0)
+# CHECK-INST: vsseg5h.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0x82]
 
 vsseg5h.v v4, 0(a0)
-# CHECK-INST: vsseg5h.v v4, 0(a0)
+# CHECK-INST: vsseg5h.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0x82]
 
 vsseg5h.v v4, (a0), v0.t
-# CHECK-INST: vsseg5h.v v4, (a0), v0.t
+# CHECK-INST: vsseg5h.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x52,0x05,0x80]
 
 vsseg5w.v v4, (a0)
-# CHECK-INST: vsseg5w.v v4, (a0)
+# CHECK-INST: vsseg5w.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0x82]
 
 vsseg5w.v v4, 0(a0)
-# CHECK-INST: vsseg5w.v v4, 0(a0)
+# CHECK-INST: vsseg5w.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0x82]
 
 vsseg5w.v v4, (a0), v0.t
-# CHECK-INST: vsseg5w.v v4, (a0), v0.t
+# CHECK-INST: vsseg5w.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x62,0x05,0x80]
 
 vsseg5e.v v4, (a0)
-# CHECK-INST: vsseg5e.v v4, (a0)
+# CHECK-INST: vsseg5e.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0x82]
 
 vsseg5e.v v4, 0(a0)
-# CHECK-INST: vsseg5e.v v4, 0(a0)
+# CHECK-INST: vsseg5e.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0x82]
 
 vsseg5e.v v4, (a0), v0.t
-# CHECK-INST: vsseg5e.v v4, (a0), v0.t
+# CHECK-INST: vsseg5e.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x72,0x05,0x80]
 
 vlseg6b.v v4, (a0)
-# CHECK-INST: vlseg6b.v v4, (a0)
+# CHECK-INST: vlseg6b.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xb2]
 
 vlseg6b.v v4, 0(a0)
-# CHECK-INST: vlseg6b.v v4, 0(a0)
+# CHECK-INST: vlseg6b.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xb2]
 
 vlseg6b.v v4, (a0), v0.t
-# CHECK-INST: vlseg6b.v v4, (a0), v0.t
+# CHECK-INST: vlseg6b.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0xb0]
 
 vlseg6h.v v4, (a0)
-# CHECK-INST: vlseg6h.v v4, (a0)
+# CHECK-INST: vlseg6h.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xb2]
 
 vlseg6h.v v4, 0(a0)
-# CHECK-INST: vlseg6h.v v4, 0(a0)
+# CHECK-INST: vlseg6h.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xb2]
 
 vlseg6h.v v4, (a0), v0.t
-# CHECK-INST: vlseg6h.v v4, (a0), v0.t
+# CHECK-INST: vlseg6h.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0xb0]
 
 vlseg6w.v v4, (a0)
-# CHECK-INST: vlseg6w.v v4, (a0)
+# CHECK-INST: vlseg6w.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xb2]
 
 vlseg6w.v v4, 0(a0)
-# CHECK-INST: vlseg6w.v v4, 0(a0)
+# CHECK-INST: vlseg6w.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xb2]
 
 vlseg6w.v v4, (a0), v0.t
-# CHECK-INST: vlseg6w.v v4, (a0), v0.t
+# CHECK-INST: vlseg6w.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0xb0]
 
 vlseg6bu.v v4, (a0)
-# CHECK-INST: vlseg6bu.v v4, (a0)
+# CHECK-INST: vlseg6bu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xa2]
 
 vlseg6bu.v v4, 0(a0)
-# CHECK-INST: vlseg6bu.v v4, 0(a0)
+# CHECK-INST: vlseg6bu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xa2]
 
 vlseg6bu.v v4, (a0), v0.t
-# CHECK-INST: vlseg6bu.v v4, (a0), v0.t
+# CHECK-INST: vlseg6bu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0xa0]
 
 vlseg6hu.v v4, (a0)
-# CHECK-INST: vlseg6hu.v v4, (a0)
+# CHECK-INST: vlseg6hu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xa2]
 
 vlseg6hu.v v4, 0(a0)
-# CHECK-INST: vlseg6hu.v v4, 0(a0)
+# CHECK-INST: vlseg6hu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xa2]
 
 vlseg6hu.v v4, (a0), v0.t
-# CHECK-INST: vlseg6hu.v v4, (a0), v0.t
+# CHECK-INST: vlseg6hu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0xa0]
 
 vlseg6wu.v v4, (a0)
-# CHECK-INST: vlseg6wu.v v4, (a0)
+# CHECK-INST: vlseg6wu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xa2]
 
 vlseg6wu.v v4, 0(a0)
-# CHECK-INST: vlseg6wu.v v4, 0(a0)
+# CHECK-INST: vlseg6wu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xa2]
 
 vlseg6wu.v v4, (a0), v0.t
-# CHECK-INST: vlseg6wu.v v4, (a0), v0.t
+# CHECK-INST: vlseg6wu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0xa0]
 
 vlseg6e.v v4, (a0)
-# CHECK-INST: vlseg6e.v v4, (a0)
+# CHECK-INST: vlseg6e.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0xa2]
 
 vlseg6e.v v4, 0(a0)
-# CHECK-INST: vlseg6e.v v4, 0(a0)
+# CHECK-INST: vlseg6e.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0xa2]
 
 vlseg6e.v v4, (a0), v0.t
-# CHECK-INST: vlseg6e.v v4, (a0), v0.t
+# CHECK-INST: vlseg6e.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0xa0]
 
 vsseg6b.v v4, (a0)
-# CHECK-INST: vsseg6b.v v4, (a0)
+# CHECK-INST: vsseg6b.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0xa2]
 
 vsseg6b.v v4, 0(a0)
-# CHECK-INST: vsseg6b.v v4, 0(a0)
+# CHECK-INST: vsseg6b.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0xa2]
 
 vsseg6b.v v4, (a0), v0.t
-# CHECK-INST: vsseg6b.v v4, (a0), v0.t
+# CHECK-INST: vsseg6b.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x02,0x05,0xa0]
 
 vsseg6h.v v4, (a0)
-# CHECK-INST: vsseg6h.v v4, (a0)
+# CHECK-INST: vsseg6h.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0xa2]
 
 vsseg6h.v v4, 0(a0)
-# CHECK-INST: vsseg6h.v v4, 0(a0)
+# CHECK-INST: vsseg6h.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0xa2]
 
 vsseg6h.v v4, (a0), v0.t
-# CHECK-INST: vsseg6h.v v4, (a0), v0.t
+# CHECK-INST: vsseg6h.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x52,0x05,0xa0]
 
 vsseg6w.v v4, (a0)
-# CHECK-INST: vsseg6w.v v4, (a0)
+# CHECK-INST: vsseg6w.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0xa2]
 
 vsseg6w.v v4, 0(a0)
-# CHECK-INST: vsseg6w.v v4, 0(a0)
+# CHECK-INST: vsseg6w.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0xa2]
 
 vsseg6w.v v4, (a0), v0.t
-# CHECK-INST: vsseg6w.v v4, (a0), v0.t
+# CHECK-INST: vsseg6w.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x62,0x05,0xa0]
 
 vsseg6e.v v4, (a0)
-# CHECK-INST: vsseg6e.v v4, (a0)
+# CHECK-INST: vsseg6e.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0xa2]
 
 vsseg6e.v v4, 0(a0)
-# CHECK-INST: vsseg6e.v v4, 0(a0)
+# CHECK-INST: vsseg6e.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0xa2]
 
 vsseg6e.v v4, (a0), v0.t
-# CHECK-INST: vsseg6e.v v4, (a0), v0.t
+# CHECK-INST: vsseg6e.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x72,0x05,0xa0]
 
 vlseg7b.v v4, (a0)
-# CHECK-INST: vlseg7b.v v4, (a0)
+# CHECK-INST: vlseg7b.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xd2]
 
 vlseg7b.v v4, 0(a0)
-# CHECK-INST: vlseg7b.v v4, 0(a0)
+# CHECK-INST: vlseg7b.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xd2]
 
 vlseg7b.v v4, (a0), v0.t
-# CHECK-INST: vlseg7b.v v4, (a0), v0.t
+# CHECK-INST: vlseg7b.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0xd0]
 
 vlseg7h.v v4, (a0)
-# CHECK-INST: vlseg7h.v v4, (a0)
+# CHECK-INST: vlseg7h.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xd2]
 
 vlseg7h.v v4, 0(a0)
-# CHECK-INST: vlseg7h.v v4, 0(a0)
+# CHECK-INST: vlseg7h.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xd2]
 
 vlseg7h.v v4, (a0), v0.t
-# CHECK-INST: vlseg7h.v v4, (a0), v0.t
+# CHECK-INST: vlseg7h.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0xd0]
 
 vlseg7w.v v4, (a0)
-# CHECK-INST: vlseg7w.v v4, (a0)
+# CHECK-INST: vlseg7w.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xd2]
 
 vlseg7w.v v4, 0(a0)
-# CHECK-INST: vlseg7w.v v4, 0(a0)
+# CHECK-INST: vlseg7w.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xd2]
 
 vlseg7w.v v4, (a0), v0.t
-# CHECK-INST: vlseg7w.v v4, (a0), v0.t
+# CHECK-INST: vlseg7w.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0xd0]
 
 vlseg7bu.v v4, (a0)
-# CHECK-INST: vlseg7bu.v v4, (a0)
+# CHECK-INST: vlseg7bu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xc2]
 
 vlseg7bu.v v4, 0(a0)
-# CHECK-INST: vlseg7bu.v v4, 0(a0)
+# CHECK-INST: vlseg7bu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xc2]
 
 vlseg7bu.v v4, (a0), v0.t
-# CHECK-INST: vlseg7bu.v v4, (a0), v0.t
+# CHECK-INST: vlseg7bu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0xc0]
 
 vlseg7hu.v v4, (a0)
-# CHECK-INST: vlseg7hu.v v4, (a0)
+# CHECK-INST: vlseg7hu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xc2]
 
 vlseg7hu.v v4, 0(a0)
-# CHECK-INST: vlseg7hu.v v4, 0(a0)
+# CHECK-INST: vlseg7hu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xc2]
 
 vlseg7hu.v v4, (a0), v0.t
-# CHECK-INST: vlseg7hu.v v4, (a0), v0.t
+# CHECK-INST: vlseg7hu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0xc0]
 
 vlseg7wu.v v4, (a0)
-# CHECK-INST: vlseg7wu.v v4, (a0)
+# CHECK-INST: vlseg7wu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xc2]
 
 vlseg7wu.v v4, 0(a0)
-# CHECK-INST: vlseg7wu.v v4, 0(a0)
+# CHECK-INST: vlseg7wu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xc2]
 
 vlseg7wu.v v4, (a0), v0.t
-# CHECK-INST: vlseg7wu.v v4, (a0), v0.t
+# CHECK-INST: vlseg7wu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0xc0]
 
 vlseg7e.v v4, (a0)
-# CHECK-INST: vlseg7e.v v4, (a0)
+# CHECK-INST: vlseg7e.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0xc2]
 
 vlseg7e.v v4, 0(a0)
-# CHECK-INST: vlseg7e.v v4, 0(a0)
+# CHECK-INST: vlseg7e.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0xc2]
 
 vlseg7e.v v4, (a0), v0.t
-# CHECK-INST: vlseg7e.v v4, (a0), v0.t
+# CHECK-INST: vlseg7e.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0xc0]
 
 vsseg7b.v v4, (a0)
-# CHECK-INST: vsseg7b.v v4, (a0)
+# CHECK-INST: vsseg7b.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0xc2]
 
 vsseg7b.v v4, 0(a0)
-# CHECK-INST: vsseg7b.v v4, 0(a0)
+# CHECK-INST: vsseg7b.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0xc2]
 
 vsseg7b.v v4, (a0), v0.t
-# CHECK-INST: vsseg7b.v v4, (a0), v0.t
+# CHECK-INST: vsseg7b.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x02,0x05,0xc0]
 
 vsseg7h.v v4, (a0)
-# CHECK-INST: vsseg7h.v v4, (a0)
+# CHECK-INST: vsseg7h.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0xc2]
 
 vsseg7h.v v4, 0(a0)
-# CHECK-INST: vsseg7h.v v4, 0(a0)
+# CHECK-INST: vsseg7h.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0xc2]
 
 vsseg7h.v v4, (a0), v0.t
-# CHECK-INST: vsseg7h.v v4, (a0), v0.t
+# CHECK-INST: vsseg7h.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x52,0x05,0xc0]
 
 vsseg7w.v v4, (a0)
-# CHECK-INST: vsseg7w.v v4, (a0)
+# CHECK-INST: vsseg7w.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0xc2]
 
 vsseg7w.v v4, 0(a0)
-# CHECK-INST: vsseg7w.v v4, 0(a0)
+# CHECK-INST: vsseg7w.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0xc2]
 
 vsseg7w.v v4, (a0), v0.t
-# CHECK-INST: vsseg7w.v v4, (a0), v0.t
+# CHECK-INST: vsseg7w.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x62,0x05,0xc0]
 
 vsseg7e.v v4, (a0)
-# CHECK-INST: vsseg7e.v v4, (a0)
+# CHECK-INST: vsseg7e.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0xc2]
 
 vsseg7e.v v4, 0(a0)
-# CHECK-INST: vsseg7e.v v4, 0(a0)
+# CHECK-INST: vsseg7e.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0xc2]
 
 vsseg7e.v v4, (a0), v0.t
-# CHECK-INST: vsseg7e.v v4, (a0), v0.t
+# CHECK-INST: vsseg7e.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x72,0x05,0xc0]
 
 vlseg8b.v v4, (a0)
-# CHECK-INST: vlseg8b.v v4, (a0)
+# CHECK-INST: vlseg8b.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xf2]
 
 vlseg8b.v v4, 0(a0)
-# CHECK-INST: vlseg8b.v v4, 0(a0)
+# CHECK-INST: vlseg8b.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xf2]
 
 vlseg8b.v v4, (a0), v0.t
-# CHECK-INST: vlseg8b.v v4, (a0), v0.t
+# CHECK-INST: vlseg8b.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0xf0]
 
 vlseg8h.v v4, (a0)
-# CHECK-INST: vlseg8h.v v4, (a0)
+# CHECK-INST: vlseg8h.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xf2]
 
 vlseg8h.v v4, 0(a0)
-# CHECK-INST: vlseg8h.v v4, 0(a0)
+# CHECK-INST: vlseg8h.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xf2]
 
 vlseg8h.v v4, (a0), v0.t
-# CHECK-INST: vlseg8h.v v4, (a0), v0.t
+# CHECK-INST: vlseg8h.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0xf0]
 
 vlseg8w.v v4, (a0)
-# CHECK-INST: vlseg8w.v v4, (a0)
+# CHECK-INST: vlseg8w.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xf2]
 
 vlseg8w.v v4, 0(a0)
-# CHECK-INST: vlseg8w.v v4, 0(a0)
+# CHECK-INST: vlseg8w.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xf2]
 
 vlseg8w.v v4, (a0), v0.t
-# CHECK-INST: vlseg8w.v v4, (a0), v0.t
+# CHECK-INST: vlseg8w.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0xf0]
 
 vlseg8bu.v v4, (a0)
-# CHECK-INST: vlseg8bu.v v4, (a0)
+# CHECK-INST: vlseg8bu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xe2]
 
 vlseg8bu.v v4, 0(a0)
-# CHECK-INST: vlseg8bu.v v4, 0(a0)
+# CHECK-INST: vlseg8bu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xe2]
 
 vlseg8bu.v v4, (a0), v0.t
-# CHECK-INST: vlseg8bu.v v4, (a0), v0.t
+# CHECK-INST: vlseg8bu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0xe0]
 
 vlseg8hu.v v4, (a0)
-# CHECK-INST: vlseg8hu.v v4, (a0)
+# CHECK-INST: vlseg8hu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xe2]
 
 vlseg8hu.v v4, 0(a0)
-# CHECK-INST: vlseg8hu.v v4, 0(a0)
+# CHECK-INST: vlseg8hu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xe2]
 
 vlseg8hu.v v4, (a0), v0.t
-# CHECK-INST: vlseg8hu.v v4, (a0), v0.t
+# CHECK-INST: vlseg8hu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0xe0]
 
 vlseg8wu.v v4, (a0)
-# CHECK-INST: vlseg8wu.v v4, (a0)
+# CHECK-INST: vlseg8wu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xe2]
 
 vlseg8wu.v v4, 0(a0)
-# CHECK-INST: vlseg8wu.v v4, 0(a0)
+# CHECK-INST: vlseg8wu.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xe2]
 
 vlseg8wu.v v4, (a0), v0.t
-# CHECK-INST: vlseg8wu.v v4, (a0), v0.t
+# CHECK-INST: vlseg8wu.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0xe0]
 
 vlseg8e.v v4, (a0)
-# CHECK-INST: vlseg8e.v v4, (a0)
+# CHECK-INST: vlseg8e.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0xe2]
 
 vlseg8e.v v4, 0(a0)
-# CHECK-INST: vlseg8e.v v4, 0(a0)
+# CHECK-INST: vlseg8e.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0xe2]
 
 vlseg8e.v v4, (a0), v0.t
-# CHECK-INST: vlseg8e.v v4, (a0), v0.t
+# CHECK-INST: vlseg8e.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0xe0]
 
 vsseg8b.v v4, (a0)
-# CHECK-INST: vsseg8b.v v4, (a0)
+# CHECK-INST: vsseg8b.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0xe2]
 
 vsseg8b.v v4, 0(a0)
-# CHECK-INST: vsseg8b.v v4, 0(a0)
+# CHECK-INST: vsseg8b.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x02,0x05,0xe2]
 
 vsseg8b.v v4, (a0), v0.t
-# CHECK-INST: vsseg8b.v v4, (a0), v0.t
+# CHECK-INST: vsseg8b.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x02,0x05,0xe0]
 
 vsseg8h.v v4, (a0)
-# CHECK-INST: vsseg8h.v v4, (a0)
+# CHECK-INST: vsseg8h.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0xe2]
 
 vsseg8h.v v4, 0(a0)
-# CHECK-INST: vsseg8h.v v4, 0(a0)
+# CHECK-INST: vsseg8h.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x52,0x05,0xe2]
 
 vsseg8h.v v4, (a0), v0.t
-# CHECK-INST: vsseg8h.v v4, (a0), v0.t
+# CHECK-INST: vsseg8h.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x52,0x05,0xe0]
 
 vsseg8w.v v4, (a0)
-# CHECK-INST: vsseg8w.v v4, (a0)
+# CHECK-INST: vsseg8w.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0xe2]
 
 vsseg8w.v v4, 0(a0)
-# CHECK-INST: vsseg8w.v v4, 0(a0)
+# CHECK-INST: vsseg8w.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x62,0x05,0xe2]
 
 vsseg8w.v v4, (a0), v0.t
-# CHECK-INST: vsseg8w.v v4, (a0), v0.t
+# CHECK-INST: vsseg8w.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x62,0x05,0xe0]
 
 vsseg8e.v v4, (a0)
-# CHECK-INST: vsseg8e.v v4, (a0)
+# CHECK-INST: vsseg8e.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0xe2]
 
 vsseg8e.v v4, 0(a0)
-# CHECK-INST: vsseg8e.v v4, 0(a0)
+# CHECK-INST: vsseg8e.v	v4, (a0)
 # CHECK-ENCODING: [0x27,0x72,0x05,0xe2]
 
 vsseg8e.v v4, (a0), v0.t
-# CHECK-INST: vsseg8e.v v4, (a0), v0.t
+# CHECK-INST: vsseg8e.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x27,0x72,0x05,0xe0]
 
 vlsseg2b.v v4, (a0), a1
-# CHECK-INST: vlsseg2b.v v4, (a0), a1
+# CHECK-INST: vlsseg2b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x3a]
 
 vlsseg2b.v v4, 0(a0), a1
-# CHECK-INST: vlsseg2b.v v4, 0(a0), a1
+# CHECK-INST: vlsseg2b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x3a]
 
 vlsseg2b.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg2b.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg2b.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x38]
 
 vlsseg2h.v v4, (a0), a1
-# CHECK-INST: vlsseg2h.v v4, (a0), a1
+# CHECK-INST: vlsseg2h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x3a]
 
 vlsseg2h.v v4, 0(a0), a1
-# CHECK-INST: vlsseg2h.v v4, 0(a0), a1
+# CHECK-INST: vlsseg2h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x3a]
 
 vlsseg2h.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg2h.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg2h.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x38]
 
 vlsseg2w.v v4, (a0), a1
-# CHECK-INST: vlsseg2w.v v4, (a0), a1
+# CHECK-INST: vlsseg2w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x3a]
 
 vlsseg2w.v v4, 0(a0), a1
-# CHECK-INST: vlsseg2w.v v4, 0(a0), a1
+# CHECK-INST: vlsseg2w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x3a]
 
 vlsseg2w.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg2w.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg2w.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x38]
 
 vlsseg2bu.v v4, (a0), a1
-# CHECK-INST: vlsseg2bu.v v4, (a0), a1
+# CHECK-INST: vlsseg2bu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x2a]
 
 vlsseg2bu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg2bu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg2bu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x2a]
 
 vlsseg2bu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg2bu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg2bu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x28]
 
 vlsseg2hu.v v4, (a0), a1
-# CHECK-INST: vlsseg2hu.v v4, (a0), a1
+# CHECK-INST: vlsseg2hu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x2a]
 
 vlsseg2hu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg2hu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg2hu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x2a]
 
 vlsseg2hu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg2hu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg2hu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x28]
 
 vlsseg2wu.v v4, (a0), a1
-# CHECK-INST: vlsseg2wu.v v4, (a0), a1
+# CHECK-INST: vlsseg2wu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x2a]
 
 vlsseg2wu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg2wu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg2wu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x2a]
 
 vlsseg2wu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg2wu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg2wu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x28]
 
 vlsseg2e.v v4, (a0), a1
-# CHECK-INST: vlsseg2e.v v4, (a0), a1
+# CHECK-INST: vlsseg2e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x2a]
 
 vlsseg2e.v v4, 0(a0), a1
-# CHECK-INST: vlsseg2e.v v4, 0(a0), a1
+# CHECK-INST: vlsseg2e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x2a]
 
 vlsseg2e.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg2e.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg2e.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x28]
 
 vssseg2b.v v4, (a0), a1
-# CHECK-INST: vssseg2b.v v4, (a0), a1
+# CHECK-INST: vssseg2b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x2a]
 
 vssseg2b.v v4, 0(a0), a1
-# CHECK-INST: vssseg2b.v v4, 0(a0), a1
+# CHECK-INST: vssseg2b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x2a]
 
 vssseg2b.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg2b.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg2b.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x28]
 
 vssseg2h.v v4, (a0), a1
-# CHECK-INST: vssseg2h.v v4, (a0), a1
+# CHECK-INST: vssseg2h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x2a]
 
 vssseg2h.v v4, 0(a0), a1
-# CHECK-INST: vssseg2h.v v4, 0(a0), a1
+# CHECK-INST: vssseg2h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x2a]
 
 vssseg2h.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg2h.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg2h.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x28]
 
 vssseg2w.v v4, (a0), a1
-# CHECK-INST: vssseg2w.v v4, (a0), a1
+# CHECK-INST: vssseg2w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x2a]
 
 vssseg2w.v v4, 0(a0), a1
-# CHECK-INST: vssseg2w.v v4, 0(a0), a1
+# CHECK-INST: vssseg2w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x2a]
 
 vssseg2w.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg2w.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg2w.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x28]
 
 vssseg2e.v v4, (a0), a1
-# CHECK-INST: vssseg2e.v v4, (a0), a1
+# CHECK-INST: vssseg2e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x2a]
 
 vssseg2e.v v4, 0(a0), a1
-# CHECK-INST: vssseg2e.v v4, 0(a0), a1
+# CHECK-INST: vssseg2e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x2a]
 
 vssseg2e.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg2e.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg2e.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x28]
 
 vlsseg3b.v v4, (a0), a1
-# CHECK-INST: vlsseg3b.v v4, (a0), a1
+# CHECK-INST: vlsseg3b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x5a]
 
 vlsseg3b.v v4, 0(a0), a1
-# CHECK-INST: vlsseg3b.v v4, 0(a0), a1
+# CHECK-INST: vlsseg3b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x5a]
 
 vlsseg3b.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg3b.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg3b.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x58]
 
 vlsseg3h.v v4, (a0), a1
-# CHECK-INST: vlsseg3h.v v4, (a0), a1
+# CHECK-INST: vlsseg3h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x5a]
 
 vlsseg3h.v v4, 0(a0), a1
-# CHECK-INST: vlsseg3h.v v4, 0(a0), a1
+# CHECK-INST: vlsseg3h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x5a]
 
 vlsseg3h.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg3h.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg3h.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x58]
 
 vlsseg3w.v v4, (a0), a1
-# CHECK-INST: vlsseg3w.v v4, (a0), a1
+# CHECK-INST: vlsseg3w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x5a]
 
 vlsseg3w.v v4, 0(a0), a1
-# CHECK-INST: vlsseg3w.v v4, 0(a0), a1
+# CHECK-INST: vlsseg3w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x5a]
 
 vlsseg3w.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg3w.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg3w.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x58]
 
 vlsseg3bu.v v4, (a0), a1
-# CHECK-INST: vlsseg3bu.v v4, (a0), a1
+# CHECK-INST: vlsseg3bu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x4a]
 
 vlsseg3bu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg3bu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg3bu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x4a]
 
 vlsseg3bu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg3bu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg3bu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x48]
 
 vlsseg3hu.v v4, (a0), a1
-# CHECK-INST: vlsseg3hu.v v4, (a0), a1
+# CHECK-INST: vlsseg3hu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x4a]
 
 vlsseg3hu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg3hu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg3hu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x4a]
 
 vlsseg3hu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg3hu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg3hu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x48]
 
 vlsseg3wu.v v4, (a0), a1
-# CHECK-INST: vlsseg3wu.v v4, (a0), a1
+# CHECK-INST: vlsseg3wu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x4a]
 
 vlsseg3wu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg3wu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg3wu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x4a]
 
 vlsseg3wu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg3wu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg3wu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x48]
 
 vlsseg3e.v v4, (a0), a1
-# CHECK-INST: vlsseg3e.v v4, (a0), a1
+# CHECK-INST: vlsseg3e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x4a]
 
 vlsseg3e.v v4, 0(a0), a1
-# CHECK-INST: vlsseg3e.v v4, 0(a0), a1
+# CHECK-INST: vlsseg3e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x4a]
 
 vlsseg3e.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg3e.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg3e.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x48]
 
 vssseg3b.v v4, (a0), a1
-# CHECK-INST: vssseg3b.v v4, (a0), a1
+# CHECK-INST: vssseg3b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x4a]
 
 vssseg3b.v v4, 0(a0), a1
-# CHECK-INST: vssseg3b.v v4, 0(a0), a1
+# CHECK-INST: vssseg3b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x4a]
 
 vssseg3b.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg3b.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg3b.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x48]
 
 vssseg3h.v v4, (a0), a1
-# CHECK-INST: vssseg3h.v v4, (a0), a1
+# CHECK-INST: vssseg3h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x4a]
 
 vssseg3h.v v4, 0(a0), a1
-# CHECK-INST: vssseg3h.v v4, 0(a0), a1
+# CHECK-INST: vssseg3h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x4a]
 
 vssseg3h.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg3h.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg3h.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x48]
 
 vssseg3w.v v4, (a0), a1
-# CHECK-INST: vssseg3w.v v4, (a0), a1
+# CHECK-INST: vssseg3w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x4a]
 
 vssseg3w.v v4, 0(a0), a1
-# CHECK-INST: vssseg3w.v v4, 0(a0), a1
+# CHECK-INST: vssseg3w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x4a]
 
 vssseg3w.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg3w.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg3w.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x48]
 
 vssseg3e.v v4, (a0), a1
-# CHECK-INST: vssseg3e.v v4, (a0), a1
+# CHECK-INST: vssseg3e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x4a]
 
 vssseg3e.v v4, 0(a0), a1
-# CHECK-INST: vssseg3e.v v4, 0(a0), a1
+# CHECK-INST: vssseg3e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x4a]
 
 vssseg3e.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg3e.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg3e.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x48]
 
 vlsseg4b.v v4, (a0), a1
-# CHECK-INST: vlsseg4b.v v4, (a0), a1
+# CHECK-INST: vlsseg4b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x7a]
 
 vlsseg4b.v v4, 0(a0), a1
-# CHECK-INST: vlsseg4b.v v4, 0(a0), a1
+# CHECK-INST: vlsseg4b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x7a]
 
 vlsseg4b.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg4b.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg4b.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x78]
 
 vlsseg4h.v v4, (a0), a1
-# CHECK-INST: vlsseg4h.v v4, (a0), a1
+# CHECK-INST: vlsseg4h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x7a]
 
 vlsseg4h.v v4, 0(a0), a1
-# CHECK-INST: vlsseg4h.v v4, 0(a0), a1
+# CHECK-INST: vlsseg4h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x7a]
 
 vlsseg4h.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg4h.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg4h.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x78]
 
 vlsseg4w.v v4, (a0), a1
-# CHECK-INST: vlsseg4w.v v4, (a0), a1
+# CHECK-INST: vlsseg4w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x7a]
 
 vlsseg4w.v v4, 0(a0), a1
-# CHECK-INST: vlsseg4w.v v4, 0(a0), a1
+# CHECK-INST: vlsseg4w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x7a]
 
 vlsseg4w.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg4w.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg4w.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x78]
 
 vlsseg4bu.v v4, (a0), a1
-# CHECK-INST: vlsseg4bu.v v4, (a0), a1
+# CHECK-INST: vlsseg4bu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x6a]
 
 vlsseg4bu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg4bu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg4bu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x6a]
 
 vlsseg4bu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg4bu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg4bu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x68]
 
 vlsseg4hu.v v4, (a0), a1
-# CHECK-INST: vlsseg4hu.v v4, (a0), a1
+# CHECK-INST: vlsseg4hu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x6a]
 
 vlsseg4hu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg4hu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg4hu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x6a]
 
 vlsseg4hu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg4hu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg4hu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x68]
 
 vlsseg4wu.v v4, (a0), a1
-# CHECK-INST: vlsseg4wu.v v4, (a0), a1
+# CHECK-INST: vlsseg4wu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x6a]
 
 vlsseg4wu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg4wu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg4wu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x6a]
 
 vlsseg4wu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg4wu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg4wu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x68]
 
 vlsseg4e.v v4, (a0), a1
-# CHECK-INST: vlsseg4e.v v4, (a0), a1
+# CHECK-INST: vlsseg4e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x6a]
 
 vlsseg4e.v v4, 0(a0), a1
-# CHECK-INST: vlsseg4e.v v4, 0(a0), a1
+# CHECK-INST: vlsseg4e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x6a]
 
 vlsseg4e.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg4e.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg4e.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x68]
 
 vssseg4b.v v4, (a0), a1
-# CHECK-INST: vssseg4b.v v4, (a0), a1
+# CHECK-INST: vssseg4b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x6a]
 
 vssseg4b.v v4, 0(a0), a1
-# CHECK-INST: vssseg4b.v v4, 0(a0), a1
+# CHECK-INST: vssseg4b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x6a]
 
 vssseg4b.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg4b.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg4b.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x68]
 
 vssseg4h.v v4, (a0), a1
-# CHECK-INST: vssseg4h.v v4, (a0), a1
+# CHECK-INST: vssseg4h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x6a]
 
 vssseg4h.v v4, 0(a0), a1
-# CHECK-INST: vssseg4h.v v4, 0(a0), a1
+# CHECK-INST: vssseg4h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x6a]
 
 vssseg4h.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg4h.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg4h.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x68]
 
 vssseg4w.v v4, (a0), a1
-# CHECK-INST: vssseg4w.v v4, (a0), a1
+# CHECK-INST: vssseg4w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x6a]
 
 vssseg4w.v v4, 0(a0), a1
-# CHECK-INST: vssseg4w.v v4, 0(a0), a1
+# CHECK-INST: vssseg4w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x6a]
 
 vssseg4w.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg4w.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg4w.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x68]
 
 vssseg4e.v v4, (a0), a1
-# CHECK-INST: vssseg4e.v v4, (a0), a1
+# CHECK-INST: vssseg4e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x6a]
 
 vssseg4e.v v4, 0(a0), a1
-# CHECK-INST: vssseg4e.v v4, 0(a0), a1
+# CHECK-INST: vssseg4e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x6a]
 
 vssseg4e.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg4e.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg4e.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x68]
 
 vlsseg5b.v v4, (a0), a1
-# CHECK-INST: vlsseg5b.v v4, (a0), a1
+# CHECK-INST: vlsseg5b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x9a]
 
 vlsseg5b.v v4, 0(a0), a1
-# CHECK-INST: vlsseg5b.v v4, 0(a0), a1
+# CHECK-INST: vlsseg5b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x9a]
 
 vlsseg5b.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg5b.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg5b.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x98]
 
 vlsseg5h.v v4, (a0), a1
-# CHECK-INST: vlsseg5h.v v4, (a0), a1
+# CHECK-INST: vlsseg5h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x9a]
 
 vlsseg5h.v v4, 0(a0), a1
-# CHECK-INST: vlsseg5h.v v4, 0(a0), a1
+# CHECK-INST: vlsseg5h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x9a]
 
 vlsseg5h.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg5h.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg5h.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x98]
 
 vlsseg5w.v v4, (a0), a1
-# CHECK-INST: vlsseg5w.v v4, (a0), a1
+# CHECK-INST: vlsseg5w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x9a]
 
 vlsseg5w.v v4, 0(a0), a1
-# CHECK-INST: vlsseg5w.v v4, 0(a0), a1
+# CHECK-INST: vlsseg5w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x9a]
 
 vlsseg5w.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg5w.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg5w.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x98]
 
 vlsseg5bu.v v4, (a0), a1
-# CHECK-INST: vlsseg5bu.v v4, (a0), a1
+# CHECK-INST: vlsseg5bu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x8a]
 
 vlsseg5bu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg5bu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg5bu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x8a]
 
 vlsseg5bu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg5bu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg5bu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0x88]
 
 vlsseg5hu.v v4, (a0), a1
-# CHECK-INST: vlsseg5hu.v v4, (a0), a1
+# CHECK-INST: vlsseg5hu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x8a]
 
 vlsseg5hu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg5hu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg5hu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x8a]
 
 vlsseg5hu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg5hu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg5hu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0x88]
 
 vlsseg5wu.v v4, (a0), a1
-# CHECK-INST: vlsseg5wu.v v4, (a0), a1
+# CHECK-INST: vlsseg5wu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x8a]
 
 vlsseg5wu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg5wu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg5wu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x8a]
 
 vlsseg5wu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg5wu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg5wu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0x88]
 
 vlsseg5e.v v4, (a0), a1
-# CHECK-INST: vlsseg5e.v v4, (a0), a1
+# CHECK-INST: vlsseg5e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x8a]
 
 vlsseg5e.v v4, 0(a0), a1
-# CHECK-INST: vlsseg5e.v v4, 0(a0), a1
+# CHECK-INST: vlsseg5e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x8a]
 
 vlsseg5e.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg5e.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg5e.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xb5,0x88]
 
 vssseg5b.v v4, (a0), a1
-# CHECK-INST: vssseg5b.v v4, (a0), a1
+# CHECK-INST: vssseg5b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x8a]
 
 vssseg5b.v v4, 0(a0), a1
-# CHECK-INST: vssseg5b.v v4, 0(a0), a1
+# CHECK-INST: vssseg5b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x8a]
 
 vssseg5b.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg5b.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg5b.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xb5,0x88]
 
 vssseg5h.v v4, (a0), a1
-# CHECK-INST: vssseg5h.v v4, (a0), a1
+# CHECK-INST: vssseg5h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x8a]
 
 vssseg5h.v v4, 0(a0), a1
-# CHECK-INST: vssseg5h.v v4, 0(a0), a1
+# CHECK-INST: vssseg5h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x8a]
 
 vssseg5h.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg5h.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg5h.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xb5,0x88]
 
 vssseg5w.v v4, (a0), a1
-# CHECK-INST: vssseg5w.v v4, (a0), a1
+# CHECK-INST: vssseg5w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x8a]
 
 vssseg5w.v v4, 0(a0), a1
-# CHECK-INST: vssseg5w.v v4, 0(a0), a1
+# CHECK-INST: vssseg5w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x8a]
 
 vssseg5w.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg5w.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg5w.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xb5,0x88]
 
 vssseg5e.v v4, (a0), a1
-# CHECK-INST: vssseg5e.v v4, (a0), a1
+# CHECK-INST: vssseg5e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x8a]
 
 vssseg5e.v v4, 0(a0), a1
-# CHECK-INST: vssseg5e.v v4, 0(a0), a1
+# CHECK-INST: vssseg5e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x8a]
 
 vssseg5e.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg5e.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg5e.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xb5,0x88]
 
 vlsseg6b.v v4, (a0), a1
-# CHECK-INST: vlsseg6b.v v4, (a0), a1
+# CHECK-INST: vlsseg6b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xba]
 
 vlsseg6b.v v4, 0(a0), a1
-# CHECK-INST: vlsseg6b.v v4, 0(a0), a1
+# CHECK-INST: vlsseg6b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xba]
 
 vlsseg6b.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg6b.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg6b.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xb8]
 
 vlsseg6h.v v4, (a0), a1
-# CHECK-INST: vlsseg6h.v v4, (a0), a1
+# CHECK-INST: vlsseg6h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xba]
 
 vlsseg6h.v v4, 0(a0), a1
-# CHECK-INST: vlsseg6h.v v4, 0(a0), a1
+# CHECK-INST: vlsseg6h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xba]
 
 vlsseg6h.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg6h.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg6h.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xb8]
 
 vlsseg6w.v v4, (a0), a1
-# CHECK-INST: vlsseg6w.v v4, (a0), a1
+# CHECK-INST: vlsseg6w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xba]
 
 vlsseg6w.v v4, 0(a0), a1
-# CHECK-INST: vlsseg6w.v v4, 0(a0), a1
+# CHECK-INST: vlsseg6w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xba]
 
 vlsseg6w.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg6w.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg6w.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xb8]
 
 vlsseg6bu.v v4, (a0), a1
-# CHECK-INST: vlsseg6bu.v v4, (a0), a1
+# CHECK-INST: vlsseg6bu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xaa]
 
 vlsseg6bu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg6bu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg6bu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xaa]
 
 vlsseg6bu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg6bu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg6bu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xa8]
 
 vlsseg6hu.v v4, (a0), a1
-# CHECK-INST: vlsseg6hu.v v4, (a0), a1
+# CHECK-INST: vlsseg6hu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xaa]
 
 vlsseg6hu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg6hu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg6hu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xaa]
 
 vlsseg6hu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg6hu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg6hu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xa8]
 
 vlsseg6wu.v v4, (a0), a1
-# CHECK-INST: vlsseg6wu.v v4, (a0), a1
+# CHECK-INST: vlsseg6wu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xaa]
 
 vlsseg6wu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg6wu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg6wu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xaa]
 
 vlsseg6wu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg6wu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg6wu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xa8]
 
 vlsseg6e.v v4, (a0), a1
-# CHECK-INST: vlsseg6e.v v4, (a0), a1
+# CHECK-INST: vlsseg6e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0xaa]
 
 vlsseg6e.v v4, 0(a0), a1
-# CHECK-INST: vlsseg6e.v v4, 0(a0), a1
+# CHECK-INST: vlsseg6e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0xaa]
 
 vlsseg6e.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg6e.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg6e.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xb5,0xa8]
 
 vssseg6b.v v4, (a0), a1
-# CHECK-INST: vssseg6b.v v4, (a0), a1
+# CHECK-INST: vssseg6b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0xaa]
 
 vssseg6b.v v4, 0(a0), a1
-# CHECK-INST: vssseg6b.v v4, 0(a0), a1
+# CHECK-INST: vssseg6b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0xaa]
 
 vssseg6b.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg6b.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg6b.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xb5,0xa8]
 
 vssseg6h.v v4, (a0), a1
-# CHECK-INST: vssseg6h.v v4, (a0), a1
+# CHECK-INST: vssseg6h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0xaa]
 
 vssseg6h.v v4, 0(a0), a1
-# CHECK-INST: vssseg6h.v v4, 0(a0), a1
+# CHECK-INST: vssseg6h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0xaa]
 
 vssseg6h.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg6h.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg6h.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xb5,0xa8]
 
 vssseg6w.v v4, (a0), a1
-# CHECK-INST: vssseg6w.v v4, (a0), a1
+# CHECK-INST: vssseg6w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0xaa]
 
 vssseg6w.v v4, 0(a0), a1
-# CHECK-INST: vssseg6w.v v4, 0(a0), a1
+# CHECK-INST: vssseg6w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0xaa]
 
 vssseg6w.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg6w.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg6w.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xb5,0xa8]
 
 vssseg6e.v v4, (a0), a1
-# CHECK-INST: vssseg6e.v v4, (a0), a1
+# CHECK-INST: vssseg6e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0xaa]
 
 vssseg6e.v v4, 0(a0), a1
-# CHECK-INST: vssseg6e.v v4, 0(a0), a1
+# CHECK-INST: vssseg6e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0xaa]
 
 vssseg6e.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg6e.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg6e.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xb5,0xa8]
 
 vlsseg7b.v v4, (a0), a1
-# CHECK-INST: vlsseg7b.v v4, (a0), a1
+# CHECK-INST: vlsseg7b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xda]
 
 vlsseg7b.v v4, 0(a0), a1
-# CHECK-INST: vlsseg7b.v v4, 0(a0), a1
+# CHECK-INST: vlsseg7b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xda]
 
 vlsseg7b.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg7b.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg7b.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xd8]
 
 vlsseg7h.v v4, (a0), a1
-# CHECK-INST: vlsseg7h.v v4, (a0), a1
+# CHECK-INST: vlsseg7h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xda]
 
 vlsseg7h.v v4, 0(a0), a1
-# CHECK-INST: vlsseg7h.v v4, 0(a0), a1
+# CHECK-INST: vlsseg7h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xda]
 
 vlsseg7h.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg7h.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg7h.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xd8]
 
 vlsseg7w.v v4, (a0), a1
-# CHECK-INST: vlsseg7w.v v4, (a0), a1
+# CHECK-INST: vlsseg7w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xda]
 
 vlsseg7w.v v4, 0(a0), a1
-# CHECK-INST: vlsseg7w.v v4, 0(a0), a1
+# CHECK-INST: vlsseg7w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xda]
 
 vlsseg7w.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg7w.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg7w.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xd8]
 
 vlsseg7bu.v v4, (a0), a1
-# CHECK-INST: vlsseg7bu.v v4, (a0), a1
+# CHECK-INST: vlsseg7bu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xca]
 
 vlsseg7bu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg7bu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg7bu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xca]
 
 vlsseg7bu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg7bu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg7bu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xc8]
 
 vlsseg7hu.v v4, (a0), a1
-# CHECK-INST: vlsseg7hu.v v4, (a0), a1
+# CHECK-INST: vlsseg7hu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xca]
 
 vlsseg7hu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg7hu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg7hu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xca]
 
 vlsseg7hu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg7hu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg7hu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xc8]
 
 vlsseg7wu.v v4, (a0), a1
-# CHECK-INST: vlsseg7wu.v v4, (a0), a1
+# CHECK-INST: vlsseg7wu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xca]
 
 vlsseg7wu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg7wu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg7wu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xca]
 
 vlsseg7wu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg7wu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg7wu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xc8]
 
 vlsseg7e.v v4, (a0), a1
-# CHECK-INST: vlsseg7e.v v4, (a0), a1
+# CHECK-INST: vlsseg7e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0xca]
 
 vlsseg7e.v v4, 0(a0), a1
-# CHECK-INST: vlsseg7e.v v4, 0(a0), a1
+# CHECK-INST: vlsseg7e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0xca]
 
 vlsseg7e.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg7e.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg7e.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xb5,0xc8]
 
 vssseg7b.v v4, (a0), a1
-# CHECK-INST: vssseg7b.v v4, (a0), a1
+# CHECK-INST: vssseg7b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0xca]
 
 vssseg7b.v v4, 0(a0), a1
-# CHECK-INST: vssseg7b.v v4, 0(a0), a1
+# CHECK-INST: vssseg7b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0xca]
 
 vssseg7b.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg7b.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg7b.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xb5,0xc8]
 
 vssseg7h.v v4, (a0), a1
-# CHECK-INST: vssseg7h.v v4, (a0), a1
+# CHECK-INST: vssseg7h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0xca]
 
 vssseg7h.v v4, 0(a0), a1
-# CHECK-INST: vssseg7h.v v4, 0(a0), a1
+# CHECK-INST: vssseg7h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0xca]
 
 vssseg7h.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg7h.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg7h.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xb5,0xc8]
 
 vssseg7w.v v4, (a0), a1
-# CHECK-INST: vssseg7w.v v4, (a0), a1
+# CHECK-INST: vssseg7w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0xca]
 
 vssseg7w.v v4, 0(a0), a1
-# CHECK-INST: vssseg7w.v v4, 0(a0), a1
+# CHECK-INST: vssseg7w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0xca]
 
 vssseg7w.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg7w.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg7w.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xb5,0xc8]
 
 vssseg7e.v v4, (a0), a1
-# CHECK-INST: vssseg7e.v v4, (a0), a1
+# CHECK-INST: vssseg7e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0xca]
 
 vssseg7e.v v4, 0(a0), a1
-# CHECK-INST: vssseg7e.v v4, 0(a0), a1
+# CHECK-INST: vssseg7e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0xca]
 
 vssseg7e.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg7e.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg7e.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xb5,0xc8]
 
 vlsseg8b.v v4, (a0), a1
-# CHECK-INST: vlsseg8b.v v4, (a0), a1
+# CHECK-INST: vlsseg8b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xfa]
 
 vlsseg8b.v v4, 0(a0), a1
-# CHECK-INST: vlsseg8b.v v4, 0(a0), a1
+# CHECK-INST: vlsseg8b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xfa]
 
 vlsseg8b.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg8b.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg8b.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xf8]
 
 vlsseg8h.v v4, (a0), a1
-# CHECK-INST: vlsseg8h.v v4, (a0), a1
+# CHECK-INST: vlsseg8h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xfa]
 
 vlsseg8h.v v4, 0(a0), a1
-# CHECK-INST: vlsseg8h.v v4, 0(a0), a1
+# CHECK-INST: vlsseg8h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xfa]
 
 vlsseg8h.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg8h.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg8h.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xf8]
 
 vlsseg8w.v v4, (a0), a1
-# CHECK-INST: vlsseg8w.v v4, (a0), a1
+# CHECK-INST: vlsseg8w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xfa]
 
 vlsseg8w.v v4, 0(a0), a1
-# CHECK-INST: vlsseg8w.v v4, 0(a0), a1
+# CHECK-INST: vlsseg8w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xfa]
 
 vlsseg8w.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg8w.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg8w.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xf8]
 
 vlsseg8bu.v v4, (a0), a1
-# CHECK-INST: vlsseg8bu.v v4, (a0), a1
+# CHECK-INST: vlsseg8bu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xea]
 
 vlsseg8bu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg8bu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg8bu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xea]
 
 vlsseg8bu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg8bu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg8bu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xb5,0xe8]
 
 vlsseg8hu.v v4, (a0), a1
-# CHECK-INST: vlsseg8hu.v v4, (a0), a1
+# CHECK-INST: vlsseg8hu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xea]
 
 vlsseg8hu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg8hu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg8hu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xea]
 
 vlsseg8hu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg8hu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg8hu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xb5,0xe8]
 
 vlsseg8wu.v v4, (a0), a1
-# CHECK-INST: vlsseg8wu.v v4, (a0), a1
+# CHECK-INST: vlsseg8wu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xea]
 
 vlsseg8wu.v v4, 0(a0), a1
-# CHECK-INST: vlsseg8wu.v v4, 0(a0), a1
+# CHECK-INST: vlsseg8wu.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xea]
 
 vlsseg8wu.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg8wu.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg8wu.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xb5,0xe8]
 
 vlsseg8e.v v4, (a0), a1
-# CHECK-INST: vlsseg8e.v v4, (a0), a1
+# CHECK-INST: vlsseg8e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0xea]
 
 vlsseg8e.v v4, 0(a0), a1
-# CHECK-INST: vlsseg8e.v v4, 0(a0), a1
+# CHECK-INST: vlsseg8e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x07,0x72,0xb5,0xea]
 
 vlsseg8e.v v4, (a0), a1, v0.t
-# CHECK-INST: vlsseg8e.v v4, (a0), a1, v0.t
+# CHECK-INST: vlsseg8e.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xb5,0xe8]
 
 vssseg8b.v v4, (a0), a1
-# CHECK-INST: vssseg8b.v v4, (a0), a1
+# CHECK-INST: vssseg8b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0xea]
 
 vssseg8b.v v4, 0(a0), a1
-# CHECK-INST: vssseg8b.v v4, 0(a0), a1
+# CHECK-INST: vssseg8b.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x02,0xb5,0xea]
 
 vssseg8b.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg8b.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg8b.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xb5,0xe8]
 
 vssseg8h.v v4, (a0), a1
-# CHECK-INST: vssseg8h.v v4, (a0), a1
+# CHECK-INST: vssseg8h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0xea]
 
 vssseg8h.v v4, 0(a0), a1
-# CHECK-INST: vssseg8h.v v4, 0(a0), a1
+# CHECK-INST: vssseg8h.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x52,0xb5,0xea]
 
 vssseg8h.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg8h.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg8h.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xb5,0xe8]
 
 vssseg8w.v v4, (a0), a1
-# CHECK-INST: vssseg8w.v v4, (a0), a1
+# CHECK-INST: vssseg8w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0xea]
 
 vssseg8w.v v4, 0(a0), a1
-# CHECK-INST: vssseg8w.v v4, 0(a0), a1
+# CHECK-INST: vssseg8w.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x62,0xb5,0xea]
 
 vssseg8w.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg8w.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg8w.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xb5,0xe8]
 
 vssseg8e.v v4, (a0), a1
-# CHECK-INST: vssseg8e.v v4, (a0), a1
+# CHECK-INST: vssseg8e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0xea]
 
 vssseg8e.v v4, 0(a0), a1
-# CHECK-INST: vssseg8e.v v4, 0(a0), a1
+# CHECK-INST: vssseg8e.v	v4, (a0), a1
 # CHECK-ENCODING: [0x27,0x72,0xb5,0xea]
 
 vssseg8e.v v4, (a0), a1, v0.t
-# CHECK-INST: vssseg8e.v v4, (a0), a1, v0.t
+# CHECK-INST: vssseg8e.v	v4, (a0), a1, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xb5,0xe8]
 
 vlxseg2b.v v4, (a0), v12
-# CHECK-INST: vlxseg2b.v v4, (a0), v12
+# CHECK-INST: vlxseg2b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x3e]
 
 vlxseg2b.v v4, 0(a0), v12
-# CHECK-INST: vlxseg2b.v v4, 0(a0), v12
+# CHECK-INST: vlxseg2b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x3e]
 
 vlxseg2b.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg2b.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg2b.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x3c]
 
 vlxseg2h.v v4, (a0), v12
-# CHECK-INST: vlxseg2h.v v4, (a0), v12
+# CHECK-INST: vlxseg2h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x3e]
 
 vlxseg2h.v v4, 0(a0), v12
-# CHECK-INST: vlxseg2h.v v4, 0(a0), v12
+# CHECK-INST: vlxseg2h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x3e]
 
 vlxseg2h.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg2h.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg2h.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x3c]
 
 vlxseg2w.v v4, (a0), v12
-# CHECK-INST: vlxseg2w.v v4, (a0), v12
+# CHECK-INST: vlxseg2w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x3e]
 
 vlxseg2w.v v4, 0(a0), v12
-# CHECK-INST: vlxseg2w.v v4, 0(a0), v12
+# CHECK-INST: vlxseg2w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x3e]
 
 vlxseg2w.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg2w.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg2w.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x3c]
 
 vlxseg2bu.v v4, (a0), v12
-# CHECK-INST: vlxseg2bu.v v4, (a0), v12
+# CHECK-INST: vlxseg2bu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x2e]
 
 vlxseg2bu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg2bu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg2bu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x2e]
 
 vlxseg2bu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg2bu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg2bu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x2c]
 
 vlxseg2hu.v v4, (a0), v12
-# CHECK-INST: vlxseg2hu.v v4, (a0), v12
+# CHECK-INST: vlxseg2hu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x2e]
 
 vlxseg2hu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg2hu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg2hu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x2e]
 
 vlxseg2hu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg2hu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg2hu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x2c]
 
 vlxseg2wu.v v4, (a0), v12
-# CHECK-INST: vlxseg2wu.v v4, (a0), v12
+# CHECK-INST: vlxseg2wu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x2e]
 
 vlxseg2wu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg2wu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg2wu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x2e]
 
 vlxseg2wu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg2wu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg2wu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x2c]
 
 vlxseg2e.v v4, (a0), v12
-# CHECK-INST: vlxseg2e.v v4, (a0), v12
+# CHECK-INST: vlxseg2e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x2e]
 
 vlxseg2e.v v4, 0(a0), v12
-# CHECK-INST: vlxseg2e.v v4, 0(a0), v12
+# CHECK-INST: vlxseg2e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x2e]
 
 vlxseg2e.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg2e.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg2e.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x2c]
 
 vsxseg2b.v v4, (a0), v12
-# CHECK-INST: vsxseg2b.v v4, (a0), v12
+# CHECK-INST: vsxseg2b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x2e]
 
 vsxseg2b.v v4, 0(a0), v12
-# CHECK-INST: vsxseg2b.v v4, 0(a0), v12
+# CHECK-INST: vsxseg2b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x2e]
 
 vsxseg2b.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg2b.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg2b.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x2c]
 
 vsxseg2h.v v4, (a0), v12
-# CHECK-INST: vsxseg2h.v v4, (a0), v12
+# CHECK-INST: vsxseg2h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x2e]
 
 vsxseg2h.v v4, 0(a0), v12
-# CHECK-INST: vsxseg2h.v v4, 0(a0), v12
+# CHECK-INST: vsxseg2h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x2e]
 
 vsxseg2h.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg2h.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg2h.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x2c]
 
 vsxseg2w.v v4, (a0), v12
-# CHECK-INST: vsxseg2w.v v4, (a0), v12
+# CHECK-INST: vsxseg2w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x2e]
 
 vsxseg2w.v v4, 0(a0), v12
-# CHECK-INST: vsxseg2w.v v4, 0(a0), v12
+# CHECK-INST: vsxseg2w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x2e]
 
 vsxseg2w.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg2w.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg2w.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x2c]
 
 vsxseg2e.v v4, (a0), v12
-# CHECK-INST: vsxseg2e.v v4, (a0), v12
+# CHECK-INST: vsxseg2e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x2e]
 
 vsxseg2e.v v4, 0(a0), v12
-# CHECK-INST: vsxseg2e.v v4, 0(a0), v12
+# CHECK-INST: vsxseg2e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x2e]
 
 vsxseg2e.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg2e.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg2e.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x2c]
 
 vlxseg3b.v v4, (a0), v12
-# CHECK-INST: vlxseg3b.v v4, (a0), v12
+# CHECK-INST: vlxseg3b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x5e]
 
 vlxseg3b.v v4, 0(a0), v12
-# CHECK-INST: vlxseg3b.v v4, 0(a0), v12
+# CHECK-INST: vlxseg3b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x5e]
 
 vlxseg3b.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg3b.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg3b.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x5c]
 
 vlxseg3h.v v4, (a0), v12
-# CHECK-INST: vlxseg3h.v v4, (a0), v12
+# CHECK-INST: vlxseg3h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x5e]
 
 vlxseg3h.v v4, 0(a0), v12
-# CHECK-INST: vlxseg3h.v v4, 0(a0), v12
+# CHECK-INST: vlxseg3h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x5e]
 
 vlxseg3h.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg3h.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg3h.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x5c]
 
 vlxseg3w.v v4, (a0), v12
-# CHECK-INST: vlxseg3w.v v4, (a0), v12
+# CHECK-INST: vlxseg3w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x5e]
 
 vlxseg3w.v v4, 0(a0), v12
-# CHECK-INST: vlxseg3w.v v4, 0(a0), v12
+# CHECK-INST: vlxseg3w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x5e]
 
 vlxseg3w.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg3w.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg3w.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x5c]
 
 vlxseg3bu.v v4, (a0), v12
-# CHECK-INST: vlxseg3bu.v v4, (a0), v12
+# CHECK-INST: vlxseg3bu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x4e]
 
 vlxseg3bu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg3bu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg3bu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x4e]
 
 vlxseg3bu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg3bu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg3bu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x4c]
 
 vlxseg3hu.v v4, (a0), v12
-# CHECK-INST: vlxseg3hu.v v4, (a0), v12
+# CHECK-INST: vlxseg3hu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x4e]
 
 vlxseg3hu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg3hu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg3hu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x4e]
 
 vlxseg3hu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg3hu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg3hu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x4c]
 
 vlxseg3wu.v v4, (a0), v12
-# CHECK-INST: vlxseg3wu.v v4, (a0), v12
+# CHECK-INST: vlxseg3wu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x4e]
 
 vlxseg3wu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg3wu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg3wu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x4e]
 
 vlxseg3wu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg3wu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg3wu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x4c]
 
 vlxseg3e.v v4, (a0), v12
-# CHECK-INST: vlxseg3e.v v4, (a0), v12
+# CHECK-INST: vlxseg3e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x4e]
 
 vlxseg3e.v v4, 0(a0), v12
-# CHECK-INST: vlxseg3e.v v4, 0(a0), v12
+# CHECK-INST: vlxseg3e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x4e]
 
 vlxseg3e.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg3e.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg3e.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x4c]
 
 vsxseg3b.v v4, (a0), v12
-# CHECK-INST: vsxseg3b.v v4, (a0), v12
+# CHECK-INST: vsxseg3b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x4e]
 
 vsxseg3b.v v4, 0(a0), v12
-# CHECK-INST: vsxseg3b.v v4, 0(a0), v12
+# CHECK-INST: vsxseg3b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x4e]
 
 vsxseg3b.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg3b.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg3b.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x4c]
 
 vsxseg3h.v v4, (a0), v12
-# CHECK-INST: vsxseg3h.v v4, (a0), v12
+# CHECK-INST: vsxseg3h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x4e]
 
 vsxseg3h.v v4, 0(a0), v12
-# CHECK-INST: vsxseg3h.v v4, 0(a0), v12
+# CHECK-INST: vsxseg3h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x4e]
 
 vsxseg3h.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg3h.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg3h.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x4c]
 
 vsxseg3w.v v4, (a0), v12
-# CHECK-INST: vsxseg3w.v v4, (a0), v12
+# CHECK-INST: vsxseg3w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x4e]
 
 vsxseg3w.v v4, 0(a0), v12
-# CHECK-INST: vsxseg3w.v v4, 0(a0), v12
+# CHECK-INST: vsxseg3w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x4e]
 
 vsxseg3w.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg3w.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg3w.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x4c]
 
 vsxseg3e.v v4, (a0), v12
-# CHECK-INST: vsxseg3e.v v4, (a0), v12
+# CHECK-INST: vsxseg3e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x4e]
 
 vsxseg3e.v v4, 0(a0), v12
-# CHECK-INST: vsxseg3e.v v4, 0(a0), v12
+# CHECK-INST: vsxseg3e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x4e]
 
 vsxseg3e.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg3e.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg3e.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x4c]
 
 vlxseg4b.v v4, (a0), v12
-# CHECK-INST: vlxseg4b.v v4, (a0), v12
+# CHECK-INST: vlxseg4b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x7e]
 
 vlxseg4b.v v4, 0(a0), v12
-# CHECK-INST: vlxseg4b.v v4, 0(a0), v12
+# CHECK-INST: vlxseg4b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x7e]
 
 vlxseg4b.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg4b.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg4b.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x7c]
 
 vlxseg4h.v v4, (a0), v12
-# CHECK-INST: vlxseg4h.v v4, (a0), v12
+# CHECK-INST: vlxseg4h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x7e]
 
 vlxseg4h.v v4, 0(a0), v12
-# CHECK-INST: vlxseg4h.v v4, 0(a0), v12
+# CHECK-INST: vlxseg4h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x7e]
 
 vlxseg4h.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg4h.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg4h.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x7c]
 
 vlxseg4w.v v4, (a0), v12
-# CHECK-INST: vlxseg4w.v v4, (a0), v12
+# CHECK-INST: vlxseg4w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x7e]
 
 vlxseg4w.v v4, 0(a0), v12
-# CHECK-INST: vlxseg4w.v v4, 0(a0), v12
+# CHECK-INST: vlxseg4w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x7e]
 
 vlxseg4w.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg4w.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg4w.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x7c]
 
 vlxseg4bu.v v4, (a0), v12
-# CHECK-INST: vlxseg4bu.v v4, (a0), v12
+# CHECK-INST: vlxseg4bu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x6e]
 
 vlxseg4bu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg4bu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg4bu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x6e]
 
 vlxseg4bu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg4bu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg4bu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x6c]
 
 vlxseg4hu.v v4, (a0), v12
-# CHECK-INST: vlxseg4hu.v v4, (a0), v12
+# CHECK-INST: vlxseg4hu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x6e]
 
 vlxseg4hu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg4hu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg4hu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x6e]
 
 vlxseg4hu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg4hu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg4hu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x6c]
 
 vlxseg4wu.v v4, (a0), v12
-# CHECK-INST: vlxseg4wu.v v4, (a0), v12
+# CHECK-INST: vlxseg4wu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x6e]
 
 vlxseg4wu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg4wu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg4wu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x6e]
 
 vlxseg4wu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg4wu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg4wu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x6c]
 
 vlxseg4e.v v4, (a0), v12
-# CHECK-INST: vlxseg4e.v v4, (a0), v12
+# CHECK-INST: vlxseg4e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x6e]
 
 vlxseg4e.v v4, 0(a0), v12
-# CHECK-INST: vlxseg4e.v v4, 0(a0), v12
+# CHECK-INST: vlxseg4e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x6e]
 
 vlxseg4e.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg4e.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg4e.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x6c]
 
 vsxseg4b.v v4, (a0), v12
-# CHECK-INST: vsxseg4b.v v4, (a0), v12
+# CHECK-INST: vsxseg4b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x6e]
 
 vsxseg4b.v v4, 0(a0), v12
-# CHECK-INST: vsxseg4b.v v4, 0(a0), v12
+# CHECK-INST: vsxseg4b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x6e]
 
 vsxseg4b.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg4b.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg4b.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x6c]
 
 vsxseg4h.v v4, (a0), v12
-# CHECK-INST: vsxseg4h.v v4, (a0), v12
+# CHECK-INST: vsxseg4h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x6e]
 
 vsxseg4h.v v4, 0(a0), v12
-# CHECK-INST: vsxseg4h.v v4, 0(a0), v12
+# CHECK-INST: vsxseg4h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x6e]
 
 vsxseg4h.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg4h.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg4h.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x6c]
 
 vsxseg4w.v v4, (a0), v12
-# CHECK-INST: vsxseg4w.v v4, (a0), v12
+# CHECK-INST: vsxseg4w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x6e]
 
 vsxseg4w.v v4, 0(a0), v12
-# CHECK-INST: vsxseg4w.v v4, 0(a0), v12
+# CHECK-INST: vsxseg4w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x6e]
 
 vsxseg4w.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg4w.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg4w.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x6c]
 
 vsxseg4e.v v4, (a0), v12
-# CHECK-INST: vsxseg4e.v v4, (a0), v12
+# CHECK-INST: vsxseg4e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x6e]
 
 vsxseg4e.v v4, 0(a0), v12
-# CHECK-INST: vsxseg4e.v v4, 0(a0), v12
+# CHECK-INST: vsxseg4e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x6e]
 
 vsxseg4e.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg4e.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg4e.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x6c]
 
 vlxseg5b.v v4, (a0), v12
-# CHECK-INST: vlxseg5b.v v4, (a0), v12
+# CHECK-INST: vlxseg5b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x9e]
 
 vlxseg5b.v v4, 0(a0), v12
-# CHECK-INST: vlxseg5b.v v4, 0(a0), v12
+# CHECK-INST: vlxseg5b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x9e]
 
 vlxseg5b.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg5b.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg5b.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x9c]
 
 vlxseg5h.v v4, (a0), v12
-# CHECK-INST: vlxseg5h.v v4, (a0), v12
+# CHECK-INST: vlxseg5h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x9e]
 
 vlxseg5h.v v4, 0(a0), v12
-# CHECK-INST: vlxseg5h.v v4, 0(a0), v12
+# CHECK-INST: vlxseg5h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x9e]
 
 vlxseg5h.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg5h.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg5h.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x9c]
 
 vlxseg5w.v v4, (a0), v12
-# CHECK-INST: vlxseg5w.v v4, (a0), v12
+# CHECK-INST: vlxseg5w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x9e]
 
 vlxseg5w.v v4, 0(a0), v12
-# CHECK-INST: vlxseg5w.v v4, 0(a0), v12
+# CHECK-INST: vlxseg5w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x9e]
 
 vlxseg5w.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg5w.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg5w.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x9c]
 
 vlxseg5bu.v v4, (a0), v12
-# CHECK-INST: vlxseg5bu.v v4, (a0), v12
+# CHECK-INST: vlxseg5bu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x8e]
 
 vlxseg5bu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg5bu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg5bu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x8e]
 
 vlxseg5bu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg5bu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg5bu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0x8c]
 
 vlxseg5hu.v v4, (a0), v12
-# CHECK-INST: vlxseg5hu.v v4, (a0), v12
+# CHECK-INST: vlxseg5hu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x8e]
 
 vlxseg5hu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg5hu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg5hu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x8e]
 
 vlxseg5hu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg5hu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg5hu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0x8c]
 
 vlxseg5wu.v v4, (a0), v12
-# CHECK-INST: vlxseg5wu.v v4, (a0), v12
+# CHECK-INST: vlxseg5wu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x8e]
 
 vlxseg5wu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg5wu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg5wu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x8e]
 
 vlxseg5wu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg5wu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg5wu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0x8c]
 
 vlxseg5e.v v4, (a0), v12
-# CHECK-INST: vlxseg5e.v v4, (a0), v12
+# CHECK-INST: vlxseg5e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x8e]
 
 vlxseg5e.v v4, 0(a0), v12
-# CHECK-INST: vlxseg5e.v v4, 0(a0), v12
+# CHECK-INST: vlxseg5e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x8e]
 
 vlxseg5e.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg5e.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg5e.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xc5,0x8c]
 
 vsxseg5b.v v4, (a0), v12
-# CHECK-INST: vsxseg5b.v v4, (a0), v12
+# CHECK-INST: vsxseg5b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x8e]
 
 vsxseg5b.v v4, 0(a0), v12
-# CHECK-INST: vsxseg5b.v v4, 0(a0), v12
+# CHECK-INST: vsxseg5b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x8e]
 
 vsxseg5b.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg5b.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg5b.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xc5,0x8c]
 
 vsxseg5h.v v4, (a0), v12
-# CHECK-INST: vsxseg5h.v v4, (a0), v12
+# CHECK-INST: vsxseg5h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x8e]
 
 vsxseg5h.v v4, 0(a0), v12
-# CHECK-INST: vsxseg5h.v v4, 0(a0), v12
+# CHECK-INST: vsxseg5h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x8e]
 
 vsxseg5h.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg5h.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg5h.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xc5,0x8c]
 
 vsxseg5w.v v4, (a0), v12
-# CHECK-INST: vsxseg5w.v v4, (a0), v12
+# CHECK-INST: vsxseg5w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x8e]
 
 vsxseg5w.v v4, 0(a0), v12
-# CHECK-INST: vsxseg5w.v v4, 0(a0), v12
+# CHECK-INST: vsxseg5w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x8e]
 
 vsxseg5w.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg5w.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg5w.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xc5,0x8c]
 
 vsxseg5e.v v4, (a0), v12
-# CHECK-INST: vsxseg5e.v v4, (a0), v12
+# CHECK-INST: vsxseg5e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x8e]
 
 vsxseg5e.v v4, 0(a0), v12
-# CHECK-INST: vsxseg5e.v v4, 0(a0), v12
+# CHECK-INST: vsxseg5e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x8e]
 
 vsxseg5e.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg5e.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg5e.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xc5,0x8c]
 
 vlxseg6b.v v4, (a0), v12
-# CHECK-INST: vlxseg6b.v v4, (a0), v12
+# CHECK-INST: vlxseg6b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xbe]
 
 vlxseg6b.v v4, 0(a0), v12
-# CHECK-INST: vlxseg6b.v v4, 0(a0), v12
+# CHECK-INST: vlxseg6b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xbe]
 
 vlxseg6b.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg6b.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg6b.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xbc]
 
 vlxseg6h.v v4, (a0), v12
-# CHECK-INST: vlxseg6h.v v4, (a0), v12
+# CHECK-INST: vlxseg6h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xbe]
 
 vlxseg6h.v v4, 0(a0), v12
-# CHECK-INST: vlxseg6h.v v4, 0(a0), v12
+# CHECK-INST: vlxseg6h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xbe]
 
 vlxseg6h.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg6h.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg6h.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xbc]
 
 vlxseg6w.v v4, (a0), v12
-# CHECK-INST: vlxseg6w.v v4, (a0), v12
+# CHECK-INST: vlxseg6w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xbe]
 
 vlxseg6w.v v4, 0(a0), v12
-# CHECK-INST: vlxseg6w.v v4, 0(a0), v12
+# CHECK-INST: vlxseg6w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xbe]
 
 vlxseg6w.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg6w.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg6w.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xbc]
 
 vlxseg6bu.v v4, (a0), v12
-# CHECK-INST: vlxseg6bu.v v4, (a0), v12
+# CHECK-INST: vlxseg6bu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xae]
 
 vlxseg6bu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg6bu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg6bu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xae]
 
 vlxseg6bu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg6bu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg6bu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xac]
 
 vlxseg6hu.v v4, (a0), v12
-# CHECK-INST: vlxseg6hu.v v4, (a0), v12
+# CHECK-INST: vlxseg6hu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xae]
 
 vlxseg6hu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg6hu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg6hu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xae]
 
 vlxseg6hu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg6hu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg6hu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xac]
 
 vlxseg6wu.v v4, (a0), v12
-# CHECK-INST: vlxseg6wu.v v4, (a0), v12
+# CHECK-INST: vlxseg6wu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xae]
 
 vlxseg6wu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg6wu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg6wu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xae]
 
 vlxseg6wu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg6wu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg6wu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xac]
 
 vlxseg6e.v v4, (a0), v12
-# CHECK-INST: vlxseg6e.v v4, (a0), v12
+# CHECK-INST: vlxseg6e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0xae]
 
 vlxseg6e.v v4, 0(a0), v12
-# CHECK-INST: vlxseg6e.v v4, 0(a0), v12
+# CHECK-INST: vlxseg6e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0xae]
 
 vlxseg6e.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg6e.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg6e.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xc5,0xac]
 
 vsxseg6b.v v4, (a0), v12
-# CHECK-INST: vsxseg6b.v v4, (a0), v12
+# CHECK-INST: vsxseg6b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0xae]
 
 vsxseg6b.v v4, 0(a0), v12
-# CHECK-INST: vsxseg6b.v v4, 0(a0), v12
+# CHECK-INST: vsxseg6b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0xae]
 
 vsxseg6b.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg6b.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg6b.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xc5,0xac]
 
 vsxseg6h.v v4, (a0), v12
-# CHECK-INST: vsxseg6h.v v4, (a0), v12
+# CHECK-INST: vsxseg6h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0xae]
 
 vsxseg6h.v v4, 0(a0), v12
-# CHECK-INST: vsxseg6h.v v4, 0(a0), v12
+# CHECK-INST: vsxseg6h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0xae]
 
 vsxseg6h.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg6h.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg6h.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xc5,0xac]
 
 vsxseg6w.v v4, (a0), v12
-# CHECK-INST: vsxseg6w.v v4, (a0), v12
+# CHECK-INST: vsxseg6w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0xae]
 
 vsxseg6w.v v4, 0(a0), v12
-# CHECK-INST: vsxseg6w.v v4, 0(a0), v12
+# CHECK-INST: vsxseg6w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0xae]
 
 vsxseg6w.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg6w.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg6w.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xc5,0xac]
 
 vsxseg6e.v v4, (a0), v12
-# CHECK-INST: vsxseg6e.v v4, (a0), v12
+# CHECK-INST: vsxseg6e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0xae]
 
 vsxseg6e.v v4, 0(a0), v12
-# CHECK-INST: vsxseg6e.v v4, 0(a0), v12
+# CHECK-INST: vsxseg6e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0xae]
 
 vsxseg6e.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg6e.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg6e.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xc5,0xac]
 
 vlxseg7b.v v4, (a0), v12
-# CHECK-INST: vlxseg7b.v v4, (a0), v12
+# CHECK-INST: vlxseg7b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xde]
 
 vlxseg7b.v v4, 0(a0), v12
-# CHECK-INST: vlxseg7b.v v4, 0(a0), v12
+# CHECK-INST: vlxseg7b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xde]
 
 vlxseg7b.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg7b.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg7b.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xdc]
 
 vlxseg7h.v v4, (a0), v12
-# CHECK-INST: vlxseg7h.v v4, (a0), v12
+# CHECK-INST: vlxseg7h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xde]
 
 vlxseg7h.v v4, 0(a0), v12
-# CHECK-INST: vlxseg7h.v v4, 0(a0), v12
+# CHECK-INST: vlxseg7h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xde]
 
 vlxseg7h.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg7h.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg7h.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xdc]
 
 vlxseg7w.v v4, (a0), v12
-# CHECK-INST: vlxseg7w.v v4, (a0), v12
+# CHECK-INST: vlxseg7w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xde]
 
 vlxseg7w.v v4, 0(a0), v12
-# CHECK-INST: vlxseg7w.v v4, 0(a0), v12
+# CHECK-INST: vlxseg7w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xde]
 
 vlxseg7w.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg7w.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg7w.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xdc]
 
 vlxseg7bu.v v4, (a0), v12
-# CHECK-INST: vlxseg7bu.v v4, (a0), v12
+# CHECK-INST: vlxseg7bu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xce]
 
 vlxseg7bu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg7bu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg7bu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xce]
 
 vlxseg7bu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg7bu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg7bu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xcc]
 
 vlxseg7hu.v v4, (a0), v12
-# CHECK-INST: vlxseg7hu.v v4, (a0), v12
+# CHECK-INST: vlxseg7hu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xce]
 
 vlxseg7hu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg7hu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg7hu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xce]
 
 vlxseg7hu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg7hu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg7hu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xcc]
 
 vlxseg7wu.v v4, (a0), v12
-# CHECK-INST: vlxseg7wu.v v4, (a0), v12
+# CHECK-INST: vlxseg7wu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xce]
 
 vlxseg7wu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg7wu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg7wu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xce]
 
 vlxseg7wu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg7wu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg7wu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xcc]
 
 vlxseg7e.v v4, (a0), v12
-# CHECK-INST: vlxseg7e.v v4, (a0), v12
+# CHECK-INST: vlxseg7e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0xce]
 
 vlxseg7e.v v4, 0(a0), v12
-# CHECK-INST: vlxseg7e.v v4, 0(a0), v12
+# CHECK-INST: vlxseg7e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0xce]
 
 vlxseg7e.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg7e.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg7e.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xc5,0xcc]
 
 vsxseg7b.v v4, (a0), v12
-# CHECK-INST: vsxseg7b.v v4, (a0), v12
+# CHECK-INST: vsxseg7b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0xce]
 
 vsxseg7b.v v4, 0(a0), v12
-# CHECK-INST: vsxseg7b.v v4, 0(a0), v12
+# CHECK-INST: vsxseg7b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0xce]
 
 vsxseg7b.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg7b.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg7b.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xc5,0xcc]
 
 vsxseg7h.v v4, (a0), v12
-# CHECK-INST: vsxseg7h.v v4, (a0), v12
+# CHECK-INST: vsxseg7h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0xce]
 
 vsxseg7h.v v4, 0(a0), v12
-# CHECK-INST: vsxseg7h.v v4, 0(a0), v12
+# CHECK-INST: vsxseg7h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0xce]
 
 vsxseg7h.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg7h.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg7h.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xc5,0xcc]
 
 vsxseg7w.v v4, (a0), v12
-# CHECK-INST: vsxseg7w.v v4, (a0), v12
+# CHECK-INST: vsxseg7w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0xce]
 
 vsxseg7w.v v4, 0(a0), v12
-# CHECK-INST: vsxseg7w.v v4, 0(a0), v12
+# CHECK-INST: vsxseg7w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0xce]
 
 vsxseg7w.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg7w.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg7w.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xc5,0xcc]
 
 vsxseg7e.v v4, (a0), v12
-# CHECK-INST: vsxseg7e.v v4, (a0), v12
+# CHECK-INST: vsxseg7e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0xce]
 
 vsxseg7e.v v4, 0(a0), v12
-# CHECK-INST: vsxseg7e.v v4, 0(a0), v12
+# CHECK-INST: vsxseg7e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0xce]
 
 vsxseg7e.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg7e.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg7e.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xc5,0xcc]
 
 vlxseg8b.v v4, (a0), v12
-# CHECK-INST: vlxseg8b.v v4, (a0), v12
+# CHECK-INST: vlxseg8b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xfe]
 
 vlxseg8b.v v4, 0(a0), v12
-# CHECK-INST: vlxseg8b.v v4, 0(a0), v12
+# CHECK-INST: vlxseg8b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xfe]
 
 vlxseg8b.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg8b.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg8b.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xfc]
 
 vlxseg8h.v v4, (a0), v12
-# CHECK-INST: vlxseg8h.v v4, (a0), v12
+# CHECK-INST: vlxseg8h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xfe]
 
 vlxseg8h.v v4, 0(a0), v12
-# CHECK-INST: vlxseg8h.v v4, 0(a0), v12
+# CHECK-INST: vlxseg8h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xfe]
 
 vlxseg8h.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg8h.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg8h.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xfc]
 
 vlxseg8w.v v4, (a0), v12
-# CHECK-INST: vlxseg8w.v v4, (a0), v12
+# CHECK-INST: vlxseg8w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xfe]
 
 vlxseg8w.v v4, 0(a0), v12
-# CHECK-INST: vlxseg8w.v v4, 0(a0), v12
+# CHECK-INST: vlxseg8w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xfe]
 
 vlxseg8w.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg8w.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg8w.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xfc]
 
 vlxseg8bu.v v4, (a0), v12
-# CHECK-INST: vlxseg8bu.v v4, (a0), v12
+# CHECK-INST: vlxseg8bu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xee]
 
 vlxseg8bu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg8bu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg8bu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xee]
 
 vlxseg8bu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg8bu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg8bu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x02,0xc5,0xec]
 
 vlxseg8hu.v v4, (a0), v12
-# CHECK-INST: vlxseg8hu.v v4, (a0), v12
+# CHECK-INST: vlxseg8hu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xee]
 
 vlxseg8hu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg8hu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg8hu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xee]
 
 vlxseg8hu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg8hu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg8hu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x52,0xc5,0xec]
 
 vlxseg8wu.v v4, (a0), v12
-# CHECK-INST: vlxseg8wu.v v4, (a0), v12
+# CHECK-INST: vlxseg8wu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xee]
 
 vlxseg8wu.v v4, 0(a0), v12
-# CHECK-INST: vlxseg8wu.v v4, 0(a0), v12
+# CHECK-INST: vlxseg8wu.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xee]
 
 vlxseg8wu.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg8wu.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg8wu.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x62,0xc5,0xec]
 
 vlxseg8e.v v4, (a0), v12
-# CHECK-INST: vlxseg8e.v v4, (a0), v12
+# CHECK-INST: vlxseg8e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0xee]
 
 vlxseg8e.v v4, 0(a0), v12
-# CHECK-INST: vlxseg8e.v v4, 0(a0), v12
+# CHECK-INST: vlxseg8e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x07,0x72,0xc5,0xee]
 
 vlxseg8e.v v4, (a0), v12, v0.t
-# CHECK-INST: vlxseg8e.v v4, (a0), v12, v0.t
+# CHECK-INST: vlxseg8e.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x07,0x72,0xc5,0xec]
 
 vsxseg8b.v v4, (a0), v12
-# CHECK-INST: vsxseg8b.v v4, (a0), v12
+# CHECK-INST: vsxseg8b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0xee]
 
 vsxseg8b.v v4, 0(a0), v12
-# CHECK-INST: vsxseg8b.v v4, 0(a0), v12
+# CHECK-INST: vsxseg8b.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x02,0xc5,0xee]
 
 vsxseg8b.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg8b.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg8b.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x02,0xc5,0xec]
 
 vsxseg8h.v v4, (a0), v12
-# CHECK-INST: vsxseg8h.v v4, (a0), v12
+# CHECK-INST: vsxseg8h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0xee]
 
 vsxseg8h.v v4, 0(a0), v12
-# CHECK-INST: vsxseg8h.v v4, 0(a0), v12
+# CHECK-INST: vsxseg8h.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x52,0xc5,0xee]
 
 vsxseg8h.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg8h.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg8h.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x52,0xc5,0xec]
 
 vsxseg8w.v v4, (a0), v12
-# CHECK-INST: vsxseg8w.v v4, (a0), v12
+# CHECK-INST: vsxseg8w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0xee]
 
 vsxseg8w.v v4, 0(a0), v12
-# CHECK-INST: vsxseg8w.v v4, 0(a0), v12
+# CHECK-INST: vsxseg8w.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x62,0xc5,0xee]
 
 vsxseg8w.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg8w.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg8w.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x62,0xc5,0xec]
 
 vsxseg8e.v v4, (a0), v12
-# CHECK-INST: vsxseg8e.v v4, (a0), v12
+# CHECK-INST: vsxseg8e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0xee]
 
 vsxseg8e.v v4, 0(a0), v12
-# CHECK-INST: vsxseg8e.v v4, 0(a0), v12
+# CHECK-INST: vsxseg8e.v	v4, (a0), v12
 # CHECK-ENCODING: [0x27,0x72,0xc5,0xee]
 
 vsxseg8e.v v4, (a0), v12, v0.t
-# CHECK-INST: vsxseg8e.v v4, (a0), v12, v0.t
+# CHECK-INST: vsxseg8e.v	v4, (a0), v12, v0.t
 # CHECK-ENCODING: [0x27,0x72,0xc5,0xec]
 
 vlseg2bff.v v4, (a0)
-# CHECK-INST: vlseg2bff.v v4, (a0)
+# CHECK-INST: vlseg2bff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x33]
 
 vlseg2bff.v v4, 0(a0)
-# CHECK-INST: vlseg2bff.v v4, 0(a0)
+# CHECK-INST: vlseg2bff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x33]
 
 vlseg2bff.v v4, (a0), v0.t
-# CHECK-INST: vlseg2bff.v v4, (a0), v0.t
+# CHECK-INST: vlseg2bff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x31]
 
 vlseg2hff.v v4, (a0)
-# CHECK-INST: vlseg2hff.v v4, (a0)
+# CHECK-INST: vlseg2hff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x33]
 
 vlseg2hff.v v4, 0(a0)
-# CHECK-INST: vlseg2hff.v v4, 0(a0)
+# CHECK-INST: vlseg2hff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x33]
 
 vlseg2hff.v v4, (a0), v0.t
-# CHECK-INST: vlseg2hff.v v4, (a0), v0.t
+# CHECK-INST: vlseg2hff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x31]
 
 vlseg2wff.v v4, (a0)
-# CHECK-INST: vlseg2wff.v v4, (a0)
+# CHECK-INST: vlseg2wff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x33]
 
 vlseg2wff.v v4, 0(a0)
-# CHECK-INST: vlseg2wff.v v4, 0(a0)
+# CHECK-INST: vlseg2wff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x33]
 
 vlseg2wff.v v4, (a0), v0.t
-# CHECK-INST: vlseg2wff.v v4, (a0), v0.t
+# CHECK-INST: vlseg2wff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x31]
 
 vlseg2buff.v v4, (a0)
-# CHECK-INST: vlseg2buff.v v4, (a0)
+# CHECK-INST: vlseg2buff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x23]
 
 vlseg2buff.v v4, 0(a0)
-# CHECK-INST: vlseg2buff.v v4, 0(a0)
+# CHECK-INST: vlseg2buff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x23]
 
 vlseg2buff.v v4, (a0), v0.t
-# CHECK-INST: vlseg2buff.v v4, (a0), v0.t
+# CHECK-INST: vlseg2buff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x21]
 
 vlseg2huff.v v4, (a0)
-# CHECK-INST: vlseg2huff.v v4, (a0)
+# CHECK-INST: vlseg2huff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x23]
 
 vlseg2huff.v v4, 0(a0)
-# CHECK-INST: vlseg2huff.v v4, 0(a0)
+# CHECK-INST: vlseg2huff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x23]
 
 vlseg2huff.v v4, (a0), v0.t
-# CHECK-INST: vlseg2huff.v v4, (a0), v0.t
+# CHECK-INST: vlseg2huff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x21]
 
 vlseg2wuff.v v4, (a0)
-# CHECK-INST: vlseg2wuff.v v4, (a0)
+# CHECK-INST: vlseg2wuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x23]
 
 vlseg2wuff.v v4, 0(a0)
-# CHECK-INST: vlseg2wuff.v v4, 0(a0)
+# CHECK-INST: vlseg2wuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x23]
 
 vlseg2wuff.v v4, (a0), v0.t
-# CHECK-INST: vlseg2wuff.v v4, (a0), v0.t
+# CHECK-INST: vlseg2wuff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x21]
 
 vlseg2eff.v v4, (a0)
-# CHECK-INST: vlseg2eff.v v4, (a0)
+# CHECK-INST: vlseg2eff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x23]
 
 vlseg2eff.v v4, 0(a0)
-# CHECK-INST: vlseg2eff.v v4, 0(a0)
+# CHECK-INST: vlseg2eff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x23]
 
 vlseg2eff.v v4, (a0), v0.t
-# CHECK-INST: vlseg2eff.v v4, (a0), v0.t
+# CHECK-INST: vlseg2eff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0x21]
 
 vlseg3bff.v v4, (a0)
-# CHECK-INST: vlseg3bff.v v4, (a0)
+# CHECK-INST: vlseg3bff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x53]
 
 vlseg3bff.v v4, 0(a0)
-# CHECK-INST: vlseg3bff.v v4, 0(a0)
+# CHECK-INST: vlseg3bff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x53]
 
 vlseg3bff.v v4, (a0), v0.t
-# CHECK-INST: vlseg3bff.v v4, (a0), v0.t
+# CHECK-INST: vlseg3bff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x51]
 
 vlseg3hff.v v4, (a0)
-# CHECK-INST: vlseg3hff.v v4, (a0)
+# CHECK-INST: vlseg3hff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x53]
 
 vlseg3hff.v v4, 0(a0)
-# CHECK-INST: vlseg3hff.v v4, 0(a0)
+# CHECK-INST: vlseg3hff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x53]
 
 vlseg3hff.v v4, (a0), v0.t
-# CHECK-INST: vlseg3hff.v v4, (a0), v0.t
+# CHECK-INST: vlseg3hff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x51]
 
 vlseg3wff.v v4, (a0)
-# CHECK-INST: vlseg3wff.v v4, (a0)
+# CHECK-INST: vlseg3wff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x53]
 
 vlseg3wff.v v4, 0(a0)
-# CHECK-INST: vlseg3wff.v v4, 0(a0)
+# CHECK-INST: vlseg3wff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x53]
 
 vlseg3wff.v v4, (a0), v0.t
-# CHECK-INST: vlseg3wff.v v4, (a0), v0.t
+# CHECK-INST: vlseg3wff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x51]
 
 vlseg3buff.v v4, (a0)
-# CHECK-INST: vlseg3buff.v v4, (a0)
+# CHECK-INST: vlseg3buff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x43]
 
 vlseg3buff.v v4, 0(a0)
-# CHECK-INST: vlseg3buff.v v4, 0(a0)
+# CHECK-INST: vlseg3buff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x43]
 
 vlseg3buff.v v4, (a0), v0.t
-# CHECK-INST: vlseg3buff.v v4, (a0), v0.t
+# CHECK-INST: vlseg3buff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x41]
 
 vlseg3huff.v v4, (a0)
-# CHECK-INST: vlseg3huff.v v4, (a0)
+# CHECK-INST: vlseg3huff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x43]
 
 vlseg3huff.v v4, 0(a0)
-# CHECK-INST: vlseg3huff.v v4, 0(a0)
+# CHECK-INST: vlseg3huff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x43]
 
 vlseg3huff.v v4, (a0), v0.t
-# CHECK-INST: vlseg3huff.v v4, (a0), v0.t
+# CHECK-INST: vlseg3huff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x41]
 
 vlseg3wuff.v v4, (a0)
-# CHECK-INST: vlseg3wuff.v v4, (a0)
+# CHECK-INST: vlseg3wuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x43]
 
 vlseg3wuff.v v4, 0(a0)
-# CHECK-INST: vlseg3wuff.v v4, 0(a0)
+# CHECK-INST: vlseg3wuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x43]
 
 vlseg3wuff.v v4, (a0), v0.t
-# CHECK-INST: vlseg3wuff.v v4, (a0), v0.t
+# CHECK-INST: vlseg3wuff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x41]
 
 vlseg3eff.v v4, (a0)
-# CHECK-INST: vlseg3eff.v v4, (a0)
+# CHECK-INST: vlseg3eff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x43]
 
 vlseg3eff.v v4, 0(a0)
-# CHECK-INST: vlseg3eff.v v4, 0(a0)
+# CHECK-INST: vlseg3eff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x43]
 
 vlseg3eff.v v4, (a0), v0.t
-# CHECK-INST: vlseg3eff.v v4, (a0), v0.t
+# CHECK-INST: vlseg3eff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0x41]
 
 vlseg4bff.v v4, (a0)
-# CHECK-INST: vlseg4bff.v v4, (a0)
+# CHECK-INST: vlseg4bff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x73]
 
 vlseg4bff.v v4, 0(a0)
-# CHECK-INST: vlseg4bff.v v4, 0(a0)
+# CHECK-INST: vlseg4bff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x73]
 
 vlseg4bff.v v4, (a0), v0.t
-# CHECK-INST: vlseg4bff.v v4, (a0), v0.t
+# CHECK-INST: vlseg4bff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x71]
 
 vlseg4hff.v v4, (a0)
-# CHECK-INST: vlseg4hff.v v4, (a0)
+# CHECK-INST: vlseg4hff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x73]
 
 vlseg4hff.v v4, 0(a0)
-# CHECK-INST: vlseg4hff.v v4, 0(a0)
+# CHECK-INST: vlseg4hff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x73]
 
 vlseg4hff.v v4, (a0), v0.t
-# CHECK-INST: vlseg4hff.v v4, (a0), v0.t
+# CHECK-INST: vlseg4hff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x71]
 
 vlseg4wff.v v4, (a0)
-# CHECK-INST: vlseg4wff.v v4, (a0)
+# CHECK-INST: vlseg4wff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x73]
 
 vlseg4wff.v v4, 0(a0)
-# CHECK-INST: vlseg4wff.v v4, 0(a0)
+# CHECK-INST: vlseg4wff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x73]
 
 vlseg4wff.v v4, (a0), v0.t
-# CHECK-INST: vlseg4wff.v v4, (a0), v0.t
+# CHECK-INST: vlseg4wff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x71]
 
 vlseg4buff.v v4, (a0)
-# CHECK-INST: vlseg4buff.v v4, (a0)
+# CHECK-INST: vlseg4buff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x63]
 
 vlseg4buff.v v4, 0(a0)
-# CHECK-INST: vlseg4buff.v v4, 0(a0)
+# CHECK-INST: vlseg4buff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x63]
 
 vlseg4buff.v v4, (a0), v0.t
-# CHECK-INST: vlseg4buff.v v4, (a0), v0.t
+# CHECK-INST: vlseg4buff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x61]
 
 vlseg4huff.v v4, (a0)
-# CHECK-INST: vlseg4huff.v v4, (a0)
+# CHECK-INST: vlseg4huff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x63]
 
 vlseg4huff.v v4, 0(a0)
-# CHECK-INST: vlseg4huff.v v4, 0(a0)
+# CHECK-INST: vlseg4huff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x63]
 
 vlseg4huff.v v4, (a0), v0.t
-# CHECK-INST: vlseg4huff.v v4, (a0), v0.t
+# CHECK-INST: vlseg4huff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x61]
 
 vlseg4wuff.v v4, (a0)
-# CHECK-INST: vlseg4wuff.v v4, (a0)
+# CHECK-INST: vlseg4wuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x63]
 
 vlseg4wuff.v v4, 0(a0)
-# CHECK-INST: vlseg4wuff.v v4, 0(a0)
+# CHECK-INST: vlseg4wuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x63]
 
 vlseg4wuff.v v4, (a0), v0.t
-# CHECK-INST: vlseg4wuff.v v4, (a0), v0.t
+# CHECK-INST: vlseg4wuff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x61]
 
 vlseg4eff.v v4, (a0)
-# CHECK-INST: vlseg4eff.v v4, (a0)
+# CHECK-INST: vlseg4eff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x63]
 
 vlseg4eff.v v4, 0(a0)
-# CHECK-INST: vlseg4eff.v v4, 0(a0)
+# CHECK-INST: vlseg4eff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x63]
 
 vlseg4eff.v v4, (a0), v0.t
-# CHECK-INST: vlseg4eff.v v4, (a0), v0.t
+# CHECK-INST: vlseg4eff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0x61]
 
 vlseg5bff.v v4, (a0)
-# CHECK-INST: vlseg5bff.v v4, (a0)
+# CHECK-INST: vlseg5bff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x93]
 
 vlseg5bff.v v4, 0(a0)
-# CHECK-INST: vlseg5bff.v v4, 0(a0)
+# CHECK-INST: vlseg5bff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x93]
 
 vlseg5bff.v v4, (a0), v0.t
-# CHECK-INST: vlseg5bff.v v4, (a0), v0.t
+# CHECK-INST: vlseg5bff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x91]
 
 vlseg5hff.v v4, (a0)
-# CHECK-INST: vlseg5hff.v v4, (a0)
+# CHECK-INST: vlseg5hff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x93]
 
 vlseg5hff.v v4, 0(a0)
-# CHECK-INST: vlseg5hff.v v4, 0(a0)
+# CHECK-INST: vlseg5hff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x93]
 
 vlseg5hff.v v4, (a0), v0.t
-# CHECK-INST: vlseg5hff.v v4, (a0), v0.t
+# CHECK-INST: vlseg5hff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x91]
 
 vlseg5wff.v v4, (a0)
-# CHECK-INST: vlseg5wff.v v4, (a0)
+# CHECK-INST: vlseg5wff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x93]
 
 vlseg5wff.v v4, 0(a0)
-# CHECK-INST: vlseg5wff.v v4, 0(a0)
+# CHECK-INST: vlseg5wff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x93]
 
 vlseg5wff.v v4, (a0), v0.t
-# CHECK-INST: vlseg5wff.v v4, (a0), v0.t
+# CHECK-INST: vlseg5wff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x91]
 
 vlseg5buff.v v4, (a0)
-# CHECK-INST: vlseg5buff.v v4, (a0)
+# CHECK-INST: vlseg5buff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x83]
 
 vlseg5buff.v v4, 0(a0)
-# CHECK-INST: vlseg5buff.v v4, 0(a0)
+# CHECK-INST: vlseg5buff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0x83]
 
 vlseg5buff.v v4, (a0), v0.t
-# CHECK-INST: vlseg5buff.v v4, (a0), v0.t
+# CHECK-INST: vlseg5buff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0x81]
 
 vlseg5huff.v v4, (a0)
-# CHECK-INST: vlseg5huff.v v4, (a0)
+# CHECK-INST: vlseg5huff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x83]
 
 vlseg5huff.v v4, 0(a0)
-# CHECK-INST: vlseg5huff.v v4, 0(a0)
+# CHECK-INST: vlseg5huff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0x83]
 
 vlseg5huff.v v4, (a0), v0.t
-# CHECK-INST: vlseg5huff.v v4, (a0), v0.t
+# CHECK-INST: vlseg5huff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0x81]
 
 vlseg5wuff.v v4, (a0)
-# CHECK-INST: vlseg5wuff.v v4, (a0)
+# CHECK-INST: vlseg5wuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x83]
 
 vlseg5wuff.v v4, 0(a0)
-# CHECK-INST: vlseg5wuff.v v4, 0(a0)
+# CHECK-INST: vlseg5wuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0x83]
 
 vlseg5wuff.v v4, (a0), v0.t
-# CHECK-INST: vlseg5wuff.v v4, (a0), v0.t
+# CHECK-INST: vlseg5wuff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0x81]
 
 vlseg5eff.v v4, (a0)
-# CHECK-INST: vlseg5eff.v v4, (a0)
+# CHECK-INST: vlseg5eff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x83]
 
 vlseg5eff.v v4, 0(a0)
-# CHECK-INST: vlseg5eff.v v4, 0(a0)
+# CHECK-INST: vlseg5eff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0x83]
 
 vlseg5eff.v v4, (a0), v0.t
-# CHECK-INST: vlseg5eff.v v4, (a0), v0.t
+# CHECK-INST: vlseg5eff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0x81]
 
 vlseg6bff.v v4, (a0)
-# CHECK-INST: vlseg6bff.v v4, (a0)
+# CHECK-INST: vlseg6bff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xb3]
 
 vlseg6bff.v v4, 0(a0)
-# CHECK-INST: vlseg6bff.v v4, 0(a0)
+# CHECK-INST: vlseg6bff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xb3]
 
 vlseg6bff.v v4, (a0), v0.t
-# CHECK-INST: vlseg6bff.v v4, (a0), v0.t
+# CHECK-INST: vlseg6bff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0xb1]
 
 vlseg6hff.v v4, (a0)
-# CHECK-INST: vlseg6hff.v v4, (a0)
+# CHECK-INST: vlseg6hff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xb3]
 
 vlseg6hff.v v4, 0(a0)
-# CHECK-INST: vlseg6hff.v v4, 0(a0)
+# CHECK-INST: vlseg6hff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xb3]
 
 vlseg6hff.v v4, (a0), v0.t
-# CHECK-INST: vlseg6hff.v v4, (a0), v0.t
+# CHECK-INST: vlseg6hff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0xb1]
 
 vlseg6wff.v v4, (a0)
-# CHECK-INST: vlseg6wff.v v4, (a0)
+# CHECK-INST: vlseg6wff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xb3]
 
 vlseg6wff.v v4, 0(a0)
-# CHECK-INST: vlseg6wff.v v4, 0(a0)
+# CHECK-INST: vlseg6wff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xb3]
 
 vlseg6wff.v v4, (a0), v0.t
-# CHECK-INST: vlseg6wff.v v4, (a0), v0.t
+# CHECK-INST: vlseg6wff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0xb1]
 
 vlseg6buff.v v4, (a0)
-# CHECK-INST: vlseg6buff.v v4, (a0)
+# CHECK-INST: vlseg6buff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xa3]
 
 vlseg6buff.v v4, 0(a0)
-# CHECK-INST: vlseg6buff.v v4, 0(a0)
+# CHECK-INST: vlseg6buff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xa3]
 
 vlseg6buff.v v4, (a0), v0.t
-# CHECK-INST: vlseg6buff.v v4, (a0), v0.t
+# CHECK-INST: vlseg6buff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0xa1]
 
 vlseg6huff.v v4, (a0)
-# CHECK-INST: vlseg6huff.v v4, (a0)
+# CHECK-INST: vlseg6huff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xa3]
 
 vlseg6huff.v v4, 0(a0)
-# CHECK-INST: vlseg6huff.v v4, 0(a0)
+# CHECK-INST: vlseg6huff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xa3]
 
 vlseg6huff.v v4, (a0), v0.t
-# CHECK-INST: vlseg6huff.v v4, (a0), v0.t
+# CHECK-INST: vlseg6huff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0xa1]
 
 vlseg6wuff.v v4, (a0)
-# CHECK-INST: vlseg6wuff.v v4, (a0)
+# CHECK-INST: vlseg6wuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xa3]
 
 vlseg6wuff.v v4, 0(a0)
-# CHECK-INST: vlseg6wuff.v v4, 0(a0)
+# CHECK-INST: vlseg6wuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xa3]
 
 vlseg6wuff.v v4, (a0), v0.t
-# CHECK-INST: vlseg6wuff.v v4, (a0), v0.t
+# CHECK-INST: vlseg6wuff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0xa1]
 
 vlseg6eff.v v4, (a0)
-# CHECK-INST: vlseg6eff.v v4, (a0)
+# CHECK-INST: vlseg6eff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0xa3]
 
 vlseg6eff.v v4, 0(a0)
-# CHECK-INST: vlseg6eff.v v4, 0(a0)
+# CHECK-INST: vlseg6eff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0xa3]
 
 vlseg6eff.v v4, (a0), v0.t
-# CHECK-INST: vlseg6eff.v v4, (a0), v0.t
+# CHECK-INST: vlseg6eff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0xa1]
 
 vlseg7bff.v v4, (a0)
-# CHECK-INST: vlseg7bff.v v4, (a0)
+# CHECK-INST: vlseg7bff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xd3]
 
 vlseg7bff.v v4, 0(a0)
-# CHECK-INST: vlseg7bff.v v4, 0(a0)
+# CHECK-INST: vlseg7bff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xd3]
 
 vlseg7bff.v v4, (a0), v0.t
-# CHECK-INST: vlseg7bff.v v4, (a0), v0.t
+# CHECK-INST: vlseg7bff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0xd1]
 
 vlseg7hff.v v4, (a0)
-# CHECK-INST: vlseg7hff.v v4, (a0)
+# CHECK-INST: vlseg7hff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xd3]
 
 vlseg7hff.v v4, 0(a0)
-# CHECK-INST: vlseg7hff.v v4, 0(a0)
+# CHECK-INST: vlseg7hff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xd3]
 
 vlseg7hff.v v4, (a0), v0.t
-# CHECK-INST: vlseg7hff.v v4, (a0), v0.t
+# CHECK-INST: vlseg7hff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0xd1]
 
 vlseg7wff.v v4, (a0)
-# CHECK-INST: vlseg7wff.v v4, (a0)
+# CHECK-INST: vlseg7wff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xd3]
 
 vlseg7wff.v v4, 0(a0)
-# CHECK-INST: vlseg7wff.v v4, 0(a0)
+# CHECK-INST: vlseg7wff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xd3]
 
 vlseg7wff.v v4, (a0), v0.t
-# CHECK-INST: vlseg7wff.v v4, (a0), v0.t
+# CHECK-INST: vlseg7wff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0xd1]
 
 vlseg7buff.v v4, (a0)
-# CHECK-INST: vlseg7buff.v v4, (a0)
+# CHECK-INST: vlseg7buff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xc3]
 
 vlseg7buff.v v4, 0(a0)
-# CHECK-INST: vlseg7buff.v v4, 0(a0)
+# CHECK-INST: vlseg7buff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xc3]
 
 vlseg7buff.v v4, (a0), v0.t
-# CHECK-INST: vlseg7buff.v v4, (a0), v0.t
+# CHECK-INST: vlseg7buff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0xc1]
 
 vlseg7huff.v v4, (a0)
-# CHECK-INST: vlseg7huff.v v4, (a0)
+# CHECK-INST: vlseg7huff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xc3]
 
 vlseg7huff.v v4, 0(a0)
-# CHECK-INST: vlseg7huff.v v4, 0(a0)
+# CHECK-INST: vlseg7huff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xc3]
 
 vlseg7huff.v v4, (a0), v0.t
-# CHECK-INST: vlseg7huff.v v4, (a0), v0.t
+# CHECK-INST: vlseg7huff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0xc1]
 
 vlseg7wuff.v v4, (a0)
-# CHECK-INST: vlseg7wuff.v v4, (a0)
+# CHECK-INST: vlseg7wuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xc3]
 
 vlseg7wuff.v v4, 0(a0)
-# CHECK-INST: vlseg7wuff.v v4, 0(a0)
+# CHECK-INST: vlseg7wuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xc3]
 
 vlseg7wuff.v v4, (a0), v0.t
-# CHECK-INST: vlseg7wuff.v v4, (a0), v0.t
+# CHECK-INST: vlseg7wuff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0xc1]
 
 vlseg7eff.v v4, (a0)
-# CHECK-INST: vlseg7eff.v v4, (a0)
+# CHECK-INST: vlseg7eff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0xc3]
 
 vlseg7eff.v v4, 0(a0)
-# CHECK-INST: vlseg7eff.v v4, 0(a0)
+# CHECK-INST: vlseg7eff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0xc3]
 
 vlseg7eff.v v4, (a0), v0.t
-# CHECK-INST: vlseg7eff.v v4, (a0), v0.t
+# CHECK-INST: vlseg7eff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0xc1]
 
 vlseg8bff.v v4, (a0)
-# CHECK-INST: vlseg8bff.v v4, (a0)
+# CHECK-INST: vlseg8bff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xf3]
 
 vlseg8bff.v v4, 0(a0)
-# CHECK-INST: vlseg8bff.v v4, 0(a0)
+# CHECK-INST: vlseg8bff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xf3]
 
 vlseg8bff.v v4, (a0), v0.t
-# CHECK-INST: vlseg8bff.v v4, (a0), v0.t
+# CHECK-INST: vlseg8bff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0xf1]
 
 vlseg8hff.v v4, (a0)
-# CHECK-INST: vlseg8hff.v v4, (a0)
+# CHECK-INST: vlseg8hff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xf3]
 
 vlseg8hff.v v4, 0(a0)
-# CHECK-INST: vlseg8hff.v v4, 0(a0)
+# CHECK-INST: vlseg8hff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xf3]
 
 vlseg8hff.v v4, (a0), v0.t
-# CHECK-INST: vlseg8hff.v v4, (a0), v0.t
+# CHECK-INST: vlseg8hff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0xf1]
 
 vlseg8wff.v v4, (a0)
-# CHECK-INST: vlseg8wff.v v4, (a0)
+# CHECK-INST: vlseg8wff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xf3]
 
 vlseg8wff.v v4, 0(a0)
-# CHECK-INST: vlseg8wff.v v4, 0(a0)
+# CHECK-INST: vlseg8wff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xf3]
 
 vlseg8wff.v v4, (a0), v0.t
-# CHECK-INST: vlseg8wff.v v4, (a0), v0.t
+# CHECK-INST: vlseg8wff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0xf1]
 
 vlseg8buff.v v4, (a0)
-# CHECK-INST: vlseg8buff.v v4, (a0)
+# CHECK-INST: vlseg8buff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xe3]
 
 vlseg8buff.v v4, 0(a0)
-# CHECK-INST: vlseg8buff.v v4, 0(a0)
+# CHECK-INST: vlseg8buff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x02,0x05,0xe3]
 
 vlseg8buff.v v4, (a0), v0.t
-# CHECK-INST: vlseg8buff.v v4, (a0), v0.t
+# CHECK-INST: vlseg8buff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x02,0x05,0xe1]
 
 vlseg8huff.v v4, (a0)
-# CHECK-INST: vlseg8huff.v v4, (a0)
+# CHECK-INST: vlseg8huff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xe3]
 
 vlseg8huff.v v4, 0(a0)
-# CHECK-INST: vlseg8huff.v v4, 0(a0)
+# CHECK-INST: vlseg8huff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x52,0x05,0xe3]
 
 vlseg8huff.v v4, (a0), v0.t
-# CHECK-INST: vlseg8huff.v v4, (a0), v0.t
+# CHECK-INST: vlseg8huff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x52,0x05,0xe1]
 
 vlseg8wuff.v v4, (a0)
-# CHECK-INST: vlseg8wuff.v v4, (a0)
+# CHECK-INST: vlseg8wuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xe3]
 
 vlseg8wuff.v v4, 0(a0)
-# CHECK-INST: vlseg8wuff.v v4, 0(a0)
+# CHECK-INST: vlseg8wuff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x62,0x05,0xe3]
 
 vlseg8wuff.v v4, (a0), v0.t
-# CHECK-INST: vlseg8wuff.v v4, (a0), v0.t
+# CHECK-INST: vlseg8wuff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x62,0x05,0xe1]
 
 vlseg8eff.v v4, (a0)
-# CHECK-INST: vlseg8eff.v v4, (a0)
+# CHECK-INST: vlseg8eff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0xe3]
 
 vlseg8eff.v v4, 0(a0)
-# CHECK-INST: vlseg8eff.v v4, 0(a0)
+# CHECK-INST: vlseg8eff.v	v4, (a0)
 # CHECK-ENCODING: [0x07,0x72,0x05,0xe3]
 
 vlseg8eff.v v4, (a0), v0.t
-# CHECK-INST: vlseg8eff.v v4, (a0), v0.t
+# CHECK-INST: vlseg8eff.v	v4, (a0), v0.t
 # CHECK-ENCODING: [0x07,0x72,0x05,0xe1]
 
 # TODO: rvv 0.7.1
@@ -4270,79 +4270,78 @@ vlseg8eff.v v4, (a0), v0.t
 # CHECK-ENCODING-TODO: [0x2f,0xf2,0x85,0xe0]
 
 vadd.vv v4, v8, v12
-# CHECK-INST: vadd.vv v4, v8, v12
+# CHECK-INST: vadd.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x02]
 
 vadd.vx v4, v8, a1
-# CHECK-INST: vadd.vx v4, v8, a1
+# CHECK-INST: vadd.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x02]
 
 vadd.vi v4, v8, 15
-# CHECK-INST: vadd.vi v4, v8, 15
+# CHECK-INST: vadd.vi	v4, v8, 15
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x02]
 
 vadd.vi v4, v8, -16
-# CHECK-INST: vadd.vi v4, v8, -16
+# CHECK-INST: vadd.vi	v4, v8, -16
 # CHECK-ENCODING: [0x57,0x32,0x88,0x02]
 
 vadd.vv v4, v8, v12, v0.t
-# CHECK-INST: vadd.vv v4, v8, v12, v0.t
+# CHECK-INST: vadd.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x00]
 
 vadd.vx v4, v8, a1, v0.t
-# CHECK-INST: vadd.vx v4, v8, a1, v0.t
+# CHECK-INST: vadd.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x00]
 
 vadd.vi v4, v8, 15, v0.t
-# CHECK-INST: vadd.vi v4, v8, 15, v0.t
+# CHECK-INST: vadd.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x00]
 
 vadd.vi v4, v8, -16, v0.t
-# CHECK-INST: vadd.vi v4, v8, -16, v0.t
+# CHECK-INST: vadd.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x88,0x00]
 
 vsub.vv v4, v8, v12
-# CHECK-INST: vsub.vv v4, v8, v12
+# CHECK-INST: vsub.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x0a]
 
 vsub.vx v4, v8, a1
-# CHECK-INST: vsub.vx v4, v8, a1
+# CHECK-INST: vsub.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x0a]
 
 vrsub.vx v4, v8, a1
-# CHECK-INST: vrsub.vx v4, v8, a1
+# CHECK-INST: vrsub.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x0e]
 
 vrsub.vi v4, v8, 15
-# CHECK-INST: vrsub.vi v4, v8, 15
+# CHECK-INST: vrsub.vi	v4, v8, 15
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x0e]
 
 vrsub.vi v4, v8, -16
-# CHECK-INST: vrsub.vi v4, v8, -16
+# CHECK-INST: vrsub.vi	v4, v8, -16
 # CHECK-ENCODING: [0x57,0x32,0x88,0x0e]
 
 vsub.vv v4, v8, v12, v0.t
-# CHECK-INST: vsub.vv v4, v8, v12, v0.t
+# CHECK-INST: vsub.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x08]
 
 vsub.vx v4, v8, a1, v0.t
-# CHECK-INST: vsub.vx v4, v8, a1, v0.t
+# CHECK-INST: vsub.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x08]
 
 vrsub.vx v4, v8, a1, v0.t
-# CHECK-INST: vrsub.vx v4, v8, a1, v0.t
+# CHECK-INST: vrsub.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x0c]
 
 vrsub.vi v4, v8, 15, v0.t
-# CHECK-INST: vrsub.vi v4, v8, 15, v0.t
+# CHECK-INST: vrsub.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x0c]
 
 vrsub.vi v4, v8, -16, v0.t
-# CHECK-INST: vrsub.vi v4, v8, -16, v0.t
+# CHECK-INST: vrsub.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x88,0x0c]
 
 # TODO: rvv 0.7.1
-# Aliases
 # vwcvt.x.x.v v4, v8
 # CHECK-INST-TODO: vwcvt.x.x.v v4, v8
 # CHECK-ENCODING-TODO: [0x57,0x62,0x80,0xc6]
@@ -4363,131 +4362,131 @@ vrsub.vi v4, v8, -16, v0.t
 # CHECK-ENCODING-TODO: [0x57,0x62,0x80,0xc0]
 
 vwaddu.vv v4, v8, v12
-# CHECK-INST: vwaddu.vv v4, v8, v12
+# CHECK-INST: vwaddu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0xc2]
 
 vwaddu.vx v4, v8, a1
-# CHECK-INST: vwaddu.vx v4, v8, a1
+# CHECK-INST: vwaddu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xc2]
 
 vwaddu.vv v4, v8, v12, v0.t
-# CHECK-INST: vwaddu.vv v4, v8, v12, v0.t
+# CHECK-INST: vwaddu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xc0]
 
 vwaddu.vx v4, v8, a1, v0.t
-# CHECK-INST: vwaddu.vx v4, v8, a1, v0.t
+# CHECK-INST: vwaddu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xc0]
 
 vwsubu.vv v4, v8, v12
-# CHECK-INST: vwsubu.vv v4, v8, v12
+# CHECK-INST: vwsubu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0xca]
 
 vwsubu.vx v4, v8, a1
-# CHECK-INST: vwsubu.vx v4, v8, a1
+# CHECK-INST: vwsubu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xca]
 
 vwsubu.vv v4, v8, v12, v0.t
-# CHECK-INST: vwsubu.vv v4, v8, v12, v0.t
+# CHECK-INST: vwsubu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xc8]
 
 vwsubu.vx v4, v8, a1, v0.t
-# CHECK-INST: vwsubu.vx v4, v8, a1, v0.t
+# CHECK-INST: vwsubu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xc8]
 
 vwadd.vv v4, v8, v12
-# CHECK-INST: vwadd.vv v4, v8, v12
+# CHECK-INST: vwadd.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0xc6]
 
 vwadd.vx v4, v8, a1
-# CHECK-INST: vwadd.vx v4, v8, a1
+# CHECK-INST: vwadd.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xc6]
 
 vwadd.vv v4, v8, v12, v0.t
-# CHECK-INST: vwadd.vv v4, v8, v12, v0.t
+# CHECK-INST: vwadd.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xc4]
 
 vwadd.vx v4, v8, a1, v0.t
-# CHECK-INST: vwadd.vx v4, v8, a1, v0.t
+# CHECK-INST: vwadd.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xc4]
 
 vwsub.vv v4, v8, v12
-# CHECK-INST: vwsub.vv v4, v8, v12
+# CHECK-INST: vwsub.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0xce]
 
 vwsub.vx v4, v8, a1
-# CHECK-INST: vwsub.vx v4, v8, a1
+# CHECK-INST: vwsub.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xce]
 
 vwsub.vv v4, v8, v12, v0.t
-# CHECK-INST: vwsub.vv v4, v8, v12, v0.t
+# CHECK-INST: vwsub.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xcc]
 
 vwsub.vx v4, v8, a1, v0.t
-# CHECK-INST: vwsub.vx v4, v8, a1, v0.t
+# CHECK-INST: vwsub.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xcc]
 
 vwaddu.wv v4, v8, v12
-# CHECK-INST: vwaddu.wv v4, v8, v12
+# CHECK-INST: vwaddu.wv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0xd2]
 
 vwaddu.wx v4, v8, a1
-# CHECK-INST: vwaddu.wx v4, v8, a1
+# CHECK-INST: vwaddu.wx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xd2]
 
 vwaddu.wv v4, v8, v12, v0.t
-# CHECK-INST: vwaddu.wv v4, v8, v12, v0.t
+# CHECK-INST: vwaddu.wv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xd0]
 
 vwaddu.wx v4, v8, a1, v0.t
-# CHECK-INST: vwaddu.wx v4, v8, a1, v0.t
+# CHECK-INST: vwaddu.wx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xd0]
 
 vwsubu.wv v4, v8, v12
-# CHECK-INST: vwsubu.wv v4, v8, v12
+# CHECK-INST: vwsubu.wv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0xda]
 
 vwsubu.wx v4, v8, a1
-# CHECK-INST: vwsubu.wx v4, v8, a1
+# CHECK-INST: vwsubu.wx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xda]
 
 vwsubu.wv v4, v8, v12, v0.t
-# CHECK-INST: vwsubu.wv v4, v8, v12, v0.t
+# CHECK-INST: vwsubu.wv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xd8]
 
 vwsubu.wx v4, v8, a1, v0.t
-# CHECK-INST: vwsubu.wx v4, v8, a1, v0.t
+# CHECK-INST: vwsubu.wx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xd8]
 
 vwadd.wv v4, v8, v12
-# CHECK-INST: vwadd.wv v4, v8, v12
+# CHECK-INST: vwadd.wv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0xd6]
 
 vwadd.wx v4, v8, a1
-# CHECK-INST: vwadd.wx v4, v8, a1
+# CHECK-INST: vwadd.wx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xd6]
 
 vwadd.wv v4, v8, v12, v0.t
-# CHECK-INST: vwadd.wv v4, v8, v12, v0.t
+# CHECK-INST: vwadd.wv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xd4]
 
 vwadd.wx v4, v8, a1, v0.t
-# CHECK-INST: vwadd.wx v4, v8, a1, v0.t
+# CHECK-INST: vwadd.wx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xd4]
 
 vwsub.wv v4, v8, v12
-# CHECK-INST: vwsub.wv v4, v8, v12
+# CHECK-INST: vwsub.wv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0xde]
 
 vwsub.wx v4, v8, a1
-# CHECK-INST: vwsub.wx v4, v8, a1
+# CHECK-INST: vwsub.wx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xde]
 
 vwsub.wv v4, v8, v12, v0.t
-# CHECK-INST: vwsub.wv v4, v8, v12, v0.t
+# CHECK-INST: vwsub.wv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xdc]
 
 vwsub.wx v4, v8, a1, v0.t
-# CHECK-INST: vwsub.wx v4, v8, a1, v0.t
+# CHECK-INST: vwsub.wx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xdc]
 
 vadc.vvm v4, v8, v12, v0
@@ -4539,7 +4538,6 @@ vmsbc.vxm v4, v8, a1, v0
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x4e]
 
 # TODO: rvv 0.7.1
-# Aliases
 # vnot.v v4, v8
 # CHECK-INST-TODO: vnot.v v4, v8
 # CHECK-ENCODING-TODO: [0x57,0xb2,0x8f,0x2e]
@@ -4550,263 +4548,262 @@ vmsbc.vxm v4, v8, a1, v0
 # CHECK-ENCODING-TODO: [0x57,0xb2,0x8f,0x2c]
 
 vand.vv v4, v8, v12
-# CHECK-INST: vand.vv v4, v8, v12
+# CHECK-INST: vand.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x26]
 
 vand.vx v4, v8, a1
-# CHECK-INST: vand.vx v4, v8, a1
+# CHECK-INST: vand.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x26]
 
 vand.vi v4, v8, 15
-# CHECK-INST: vand.vi v4, v8, 15
+# CHECK-INST: vand.vi	v4, v8, 15
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x26]
 
 vand.vi v4, v8, -16
-# CHECK-INST: vand.vi v4, v8, -16
+# CHECK-INST: vand.vi	v4, v8, -16
 # CHECK-ENCODING: [0x57,0x32,0x88,0x26]
 
 vand.vv v4, v8, v12, v0.t
-# CHECK-INST: vand.vv v4, v8, v12, v0.t
+# CHECK-INST: vand.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x24]
 
 vand.vx v4, v8, a1, v0.t
-# CHECK-INST: vand.vx v4, v8, a1, v0.t
+# CHECK-INST: vand.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x24]
 
 vand.vi v4, v8, 15, v0.t
-# CHECK-INST: vand.vi v4, v8, 15, v0.t
+# CHECK-INST: vand.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x24]
 
 vand.vi v4, v8, -16, v0.t
-# CHECK-INST: vand.vi v4, v8, -16, v0.t
+# CHECK-INST: vand.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x88,0x24]
 
 vor.vv v4, v8, v12
-# CHECK-INST: vor.vv v4, v8, v12
+# CHECK-INST: vor.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x2a]
 
 vor.vx v4, v8, a1
-# CHECK-INST: vor.vx v4, v8, a1
+# CHECK-INST: vor.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x2a]
 
 vor.vi v4, v8, 15
-# CHECK-INST: vor.vi v4, v8, 15
+# CHECK-INST: vor.vi	v4, v8, 15
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x2a]
 
 vor.vi v4, v8, -16
-# CHECK-INST: vor.vi v4, v8, -16
+# CHECK-INST: vor.vi	v4, v8, -16
 # CHECK-ENCODING: [0x57,0x32,0x88,0x2a]
 
 vor.vv v4, v8, v12, v0.t
-# CHECK-INST: vor.vv v4, v8, v12, v0.t
+# CHECK-INST: vor.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x28]
 
 vor.vx v4, v8, a1, v0.t
-# CHECK-INST: vor.vx v4, v8, a1, v0.t
+# CHECK-INST: vor.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x28]
 
 vor.vi v4, v8, 15, v0.t
-# CHECK-INST: vor.vi v4, v8, 15, v0.t
+# CHECK-INST: vor.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x28]
 
 vor.vi v4, v8, -16, v0.t
-# CHECK-INST: vor.vi v4, v8, -16, v0.t
+# CHECK-INST: vor.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x88,0x28]
 
 vxor.vv v4, v8, v12
-# CHECK-INST: vxor.vv v4, v8, v12
+# CHECK-INST: vxor.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x2e]
 
 vxor.vx v4, v8, a1
-# CHECK-INST: vxor.vx v4, v8, a1
+# CHECK-INST: vxor.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x2e]
 
 vxor.vi v4, v8, 15
-# CHECK-INST: vxor.vi v4, v8, 15
+# CHECK-INST: vxor.vi	v4, v8, 15
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x2e]
 
 vxor.vi v4, v8, -16
-# CHECK-INST: vxor.vi v4, v8, -16
+# CHECK-INST: vxor.vi	v4, v8, -16
 # CHECK-ENCODING: [0x57,0x32,0x88,0x2e]
 
 vxor.vv v4, v8, v12, v0.t
-# CHECK-INST: vxor.vv v4, v8, v12, v0.t
+# CHECK-INST: vxor.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x2c]
 
 vxor.vx v4, v8, a1, v0.t
-# CHECK-INST: vxor.vx v4, v8, a1, v0.t
+# CHECK-INST: vxor.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x2c]
 
 vxor.vi v4, v8, 15, v0.t
-# CHECK-INST: vxor.vi v4, v8, 15, v0.t
+# CHECK-INST: vxor.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x2c]
 
 vxor.vi v4, v8, -16, v0.t
-# CHECK-INST: vxor.vi v4, v8, -16, v0.t
+# CHECK-INST: vxor.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x88,0x2c]
 
 vsll.vv v4, v8, v12
-# CHECK-INST: vsll.vv v4, v8, v12
+# CHECK-INST: vsll.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x96]
 
 vsll.vx v4, v8, a1
-# CHECK-INST: vsll.vx v4, v8, a1
+# CHECK-INST: vsll.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x96]
 
 vsll.vi v4, v8, 1
-# CHECK-INST: vsll.vi v4, v8, 1
+# CHECK-INST: vsll.vi	v4, v8, 1
 # CHECK-ENCODING: [0x57,0xb2,0x80,0x96]
 
 vsll.vi v4, v8, 31
-# CHECK-INST: vsll.vi v4, v8, 31
+# CHECK-INST: vsll.vi	v4, v8, 31
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0x96]
 
 vsll.vv v4, v8, v12, v0.t
-# CHECK-INST: vsll.vv v4, v8, v12, v0.t
+# CHECK-INST: vsll.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x94]
 
 vsll.vx v4, v8, a1, v0.t
-# CHECK-INST: vsll.vx v4, v8, a1, v0.t
+# CHECK-INST: vsll.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x94]
 
 vsll.vi v4, v8, 1, v0.t
-# CHECK-INST: vsll.vi v4, v8, 1, v0.t
+# CHECK-INST: vsll.vi	v4, v8, 1, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x80,0x94]
 
 vsll.vi v4, v8, 31, v0.t
-# CHECK-INST: vsll.vi v4, v8, 31, v0.t
+# CHECK-INST: vsll.vi	v4, v8, 31, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0x94]
 
 vsrl.vv v4, v8, v12
-# CHECK-INST: vsrl.vv v4, v8, v12
+# CHECK-INST: vsrl.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0xa2]
 
 vsrl.vx v4, v8, a1
-# CHECK-INST: vsrl.vx v4, v8, a1
+# CHECK-INST: vsrl.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xa2]
 
 vsrl.vi v4, v8, 1
-# CHECK-INST: vsrl.vi v4, v8, 1
+# CHECK-INST: vsrl.vi	v4, v8, 1
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xa2]
 
 vsrl.vi v4, v8, 31
-# CHECK-INST: vsrl.vi v4, v8, 31
+# CHECK-INST: vsrl.vi	v4, v8, 31
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xa2]
 
 vsrl.vv v4, v8, v12, v0.t
-# CHECK-INST: vsrl.vv v4, v8, v12, v0.t
+# CHECK-INST: vsrl.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0xa0]
 
 vsrl.vx v4, v8, a1, v0.t
-# CHECK-INST: vsrl.vx v4, v8, a1, v0.t
+# CHECK-INST: vsrl.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xa0]
 
 vsrl.vi v4, v8, 1, v0.t
-# CHECK-INST: vsrl.vi v4, v8, 1, v0.t
+# CHECK-INST: vsrl.vi	v4, v8, 1, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xa0]
 
 vsrl.vi v4, v8, 31, v0.t
-# CHECK-INST: vsrl.vi v4, v8, 31, v0.t
+# CHECK-INST: vsrl.vi	v4, v8, 31, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xa0]
 
 vsra.vv v4, v8, v12
-# CHECK-INST: vsra.vv v4, v8, v12
+# CHECK-INST: vsra.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0xa6]
 
 vsra.vx v4, v8, a1
-# CHECK-INST: vsra.vx v4, v8, a1
+# CHECK-INST: vsra.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xa6]
 
 vsra.vi v4, v8, 1
-# CHECK-INST: vsra.vi v4, v8, 1
+# CHECK-INST: vsra.vi	v4, v8, 1
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xa6]
 
 vsra.vi v4, v8, 31
-# CHECK-INST: vsra.vi v4, v8, 31
+# CHECK-INST: vsra.vi	v4, v8, 31
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xa6]
 
 vsra.vv v4, v8, v12, v0.t
-# CHECK-INST: vsra.vv v4, v8, v12, v0.t
+# CHECK-INST: vsra.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0xa4]
 
 vsra.vx v4, v8, a1, v0.t
-# CHECK-INST: vsra.vx v4, v8, a1, v0.t
+# CHECK-INST: vsra.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xa4]
 
 vsra.vi v4, v8, 1, v0.t
-# CHECK-INST: vsra.vi v4, v8, 1, v0.t
+# CHECK-INST: vsra.vi	v4, v8, 1, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xa4]
 
 vsra.vi v4, v8, 31, v0.t
-# CHECK-INST: vsra.vi v4, v8, 31, v0.t
+# CHECK-INST: vsra.vi	v4, v8, 31, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xa4]
 
 vnsrl.vv v4, v8, v12
-# CHECK-INST: vnsrl.vv v4, v8, v12
+# CHECK-INST: vnsrl.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0xb2]
 
 vnsrl.vx v4, v8, a1
-# CHECK-INST: vnsrl.vx v4, v8, a1
+# CHECK-INST: vnsrl.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xb2]
 
 vnsrl.vi v4, v8, 1
-# CHECK-INST: vnsrl.vi v4, v8, 1
+# CHECK-INST: vnsrl.vi	v4, v8, 1
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xb2]
 
 vnsrl.vi v4, v8, 31
-# CHECK-INST: vnsrl.vi v4, v8, 31
+# CHECK-INST: vnsrl.vi	v4, v8, 31
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xb2]
 
 vnsrl.vv v4, v8, v12, v0.t
-# CHECK-INST: vnsrl.vv v4, v8, v12, v0.t
+# CHECK-INST: vnsrl.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0xb0]
 
 vnsrl.vx v4, v8, a1, v0.t
-# CHECK-INST: vnsrl.vx v4, v8, a1, v0.t
+# CHECK-INST: vnsrl.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xb0]
 
 vnsrl.vi v4, v8, 1, v0.t
-# CHECK-INST: vnsrl.vi v4, v8, 1, v0.t
+# CHECK-INST: vnsrl.vi	v4, v8, 1, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xb0]
 
 vnsrl.vi v4, v8, 31, v0.t
-# CHECK-INST: vnsrl.vi v4, v8, 31, v0.t
+# CHECK-INST: vnsrl.vi	v4, v8, 31, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xb0]
 
 vnsra.vv v4, v8, v12
-# CHECK-INST: vnsra.vv v4, v8, v12
+# CHECK-INST: vnsra.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0xb6]
 
 vnsra.vx v4, v8, a1
-# CHECK-INST: vnsra.vx v4, v8, a1
+# CHECK-INST: vnsra.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xb6]
 
 vnsra.vi v4, v8, 1
-# CHECK-INST: vnsra.vi v4, v8, 1
+# CHECK-INST: vnsra.vi	v4, v8, 1
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xb6]
 
 vnsra.vi v4, v8, 31
-# CHECK-INST: vnsra.vi v4, v8, 31
+# CHECK-INST: vnsra.vi	v4, v8, 31
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xb6]
 
 vnsra.vv v4, v8, v12, v0.t
-# CHECK-INST: vnsra.vv v4, v8, v12, v0.t
+# CHECK-INST: vnsra.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0xb4]
 
 vnsra.vx v4, v8, a1, v0.t
-# CHECK-INST: vnsra.vx v4, v8, a1, v0.t
+# CHECK-INST: vnsra.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xb4]
 
 vnsra.vi v4, v8, 1, v0.t
-# CHECK-INST: vnsra.vi v4, v8, 1, v0.t
+# CHECK-INST: vnsra.vi	v4, v8, 1, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xb4]
 
 vnsra.vi v4, v8, 31, v0.t
-# CHECK-INST: vnsra.vi v4, v8, 31, v0.t
+# CHECK-INST: vnsra.vi	v4, v8, 31, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xb4]
 
 # TODO: rvv 0.7.1
-# Aliases
 # vmsgt.vv v4, v8, v12
 # CHECK-INST-TODO: vmsgt.vv v4, v8, v12
 # CHECK-ENCODING-TODO: [0x57,0x02,0xc4,0x6e]
@@ -4848,571 +4845,562 @@ vnsra.vi v4, v8, 31, v0.t
 
 # TODO: rvv 0.7.1
 # vmslt.vi v4, v8, 16
-# CHECK-INST-TODO: vmslt.vi v4, v8, 16
+# CHECK-INST-TODO: vmsle.vi	v4, v8, 15
 # CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x76]
 
 # TODO: rvv 0.7.1
 # vmslt.vi v4, v8, -15
-# CHECK-INST-TODO: vmslt.vi v4, v8, -15
+# CHECK-INST-TODO: vmsle.vi	v4, v8, -16
 # CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x76]
 
 # TODO: rvv 0.7.1
 # vmsltu.vi v4, v8, 16
-# CHECK-INST-TODO: vmsltu.vi v4, v8, 16
+# CHECK-INST-TODO: vmsleu.vi	v4, v8, 15
 # CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x72]
 
 # TODO: rvv 0.7.1
 # vmsltu.vi v4, v8, -15
-# CHECK-INST-TODO: vmsltu.vi v4, v8, -15
+# CHECK-INST-TODO: vmsleu.vi	v4, v8, -16
 # CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x72]
 
 # TODO: rvv 0.7.1
 # vmsge.vi v4, v8, 16
-# CHECK-INST-TODO: vmsge.vi v4, v8, 16
+# CHECK-INST-TODO: vmsgt.vi	v4, v8, 15
 # CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x7e]
 
 # TODO: rvv 0.7.1
 # vmsge.vi v4, v8, -15
-# CHECK-INST-TODO: vmsge.vi v4, v8, -15
+# CHECK-INST-TODO: vmsgt.vi	v4, v8, -16
 # CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x7e]
 
 # TODO: rvv 0.7.1
 # vmsgeu.vi v4, v8, 16
-# CHECK-INST-TODO: vmsgeu.vi v4, v8, 16
+# CHECK-INST-TODO: vmsgtu.vi	v4, v8, 15
 # CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x7a]
 
 # TODO: rvv 0.7.1
 # vmsgeu.vi v4, v8, -15
-# CHECK-INST-TODO: vmsgeu.vi v4, v8, -15
+# CHECK-INST-TODO: vmsgtu.vi	v4, v8, -16
 # CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x7a]
 
 # TODO: rvv 0.7.1
 # vmslt.vi v4, v8, 16, v0.t
-# CHECK-INST-TODO: vmslt.vi v4, v8, 16, v0.t
+# CHECK-INST-TODO: vmsle.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x74]
 
 # TODO: rvv 0.7.1
 # vmslt.vi v4, v8, -15, v0.t
-# CHECK-INST-TODO: vmslt.vi v4, v8, -15, v0.t
+# CHECK-INST-TODO: vmsle.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x74]
 
 # TODO: rvv 0.7.1
 # vmsltu.vi v4, v8, 16, v0.t
-# CHECK-INST-TODO: vmsltu.vi v4, v8, 16, v0.t
+# CHECK-INST-TODO: vmsleu.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x70]
 
 # TODO: rvv 0.7.1
 # vmsltu.vi v4, v8, -15, v0.t
-# CHECK-INST-TODO: vmsltu.vi v4, v8, -15, v0.t
+# CHECK-INST-TODO: vmsleu.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x70]
 
 # TODO: rvv 0.7.1
 # vmsge.vi v4, v8, 16, v0.t
-# CHECK-INST-TODO: vmsge.vi v4, v8, 16, v0.t
+# CHECK-INST-TODO: vmsgt.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x7c]
 
 # TODO: rvv 0.7.1
 # vmsge.vi v4, v8, -15, v0.t
-# CHECK-INST-TODO: vmsge.vi v4, v8, -15, v0.t
+# CHECK-INST-TODO: vmsgt.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x7c]
 
 # TODO: rvv 0.7.1
 # vmsgeu.vi v4, v8, 16, v0.t
-# CHECK-INST-TODO: vmsgeu.vi v4, v8, 16, v0.t
+# CHECK-INST-TODO: vmsgtu.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x78]
 
 # TODO: rvv 0.7.1
 # vmsgeu.vi v4, v8, -15, v0.t
-# CHECK-INST-TODO: vmsgeu.vi v4, v8, -15, v0.t
+# CHECK-INST-TODO: vmsgtu.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x78]
 
-# TODO: rvv 0.7.1
-# Macros
-# vmsge.vx v4, v8, a1
-# vmsgeu.vx v4, v8, a1
-# vmsge.vx v8, v12, a2, v0.t
-# vmsgeu.vx v8, v12, a2, v0.t
-# vmsge.vx v4, v8, a1, v0.t, v12
-# vmsgeu.vx v4, v8, a1, v0.t, v12
-
 vmseq.vv v4, v8, v12
-# CHECK-INST: vmseq.vv v4, v8, v12
+# CHECK-INST: vmseq.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x62]
 
 vmseq.vx v4, v8, a1
-# CHECK-INST: vmseq.vx v4, v8, a1
+# CHECK-INST: vmseq.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x62]
 
 vmseq.vi v4, v8, 15
-# CHECK-INST: vmseq.vi v4, v8, 15
+# CHECK-INST: vmseq.vi	v4, v8, 15
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x62]
 
 vmseq.vi v4, v8, -16
-# CHECK-INST: vmseq.vi v4, v8, -16
+# CHECK-INST: vmseq.vi	v4, v8, -16
 # CHECK-ENCODING: [0x57,0x32,0x88,0x62]
 
 vmseq.vv v4, v8, v12, v0.t
-# CHECK-INST: vmseq.vv v4, v8, v12, v0.t
+# CHECK-INST: vmseq.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x60]
 
 vmseq.vx v4, v8, a1, v0.t
-# CHECK-INST: vmseq.vx v4, v8, a1, v0.t
+# CHECK-INST: vmseq.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x60]
 
 vmseq.vi v4, v8, 15, v0.t
-# CHECK-INST: vmseq.vi v4, v8, 15, v0.t
+# CHECK-INST: vmseq.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x60]
 
 vmseq.vi v4, v8, -16, v0.t
-# CHECK-INST: vmseq.vi v4, v8, -16, v0.t
+# CHECK-INST: vmseq.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x88,0x60]
 
 vmsne.vv v4, v8, v12
-# CHECK-INST: vmsne.vv v4, v8, v12
+# CHECK-INST: vmsne.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x66]
 
 vmsne.vx v4, v8, a1
-# CHECK-INST: vmsne.vx v4, v8, a1
+# CHECK-INST: vmsne.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x66]
 
 vmsne.vi v4, v8, 15
-# CHECK-INST: vmsne.vi v4, v8, 15
+# CHECK-INST: vmsne.vi	v4, v8, 15
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x66]
 
 vmsne.vi v4, v8, -16
-# CHECK-INST: vmsne.vi v4, v8, -16
+# CHECK-INST: vmsne.vi	v4, v8, -16
 # CHECK-ENCODING: [0x57,0x32,0x88,0x66]
 
 vmsne.vv v4, v8, v12, v0.t
-# CHECK-INST: vmsne.vv v4, v8, v12, v0.t
+# CHECK-INST: vmsne.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x64]
 
 vmsne.vx v4, v8, a1, v0.t
-# CHECK-INST: vmsne.vx v4, v8, a1, v0.t
+# CHECK-INST: vmsne.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x64]
 
 vmsne.vi v4, v8, 15, v0.t
-# CHECK-INST: vmsne.vi v4, v8, 15, v0.t
+# CHECK-INST: vmsne.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x64]
 
 vmsne.vi v4, v8, -16, v0.t
-# CHECK-INST: vmsne.vi v4, v8, -16, v0.t
+# CHECK-INST: vmsne.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x88,0x64]
 
 vmsltu.vv v4, v8, v12
-# CHECK-INST: vmsltu.vv v4, v8, v12
+# CHECK-INST: vmsltu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x6a]
 
 vmsltu.vx v4, v8, a1
-# CHECK-INST: vmsltu.vx v4, v8, a1
+# CHECK-INST: vmsltu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x6a]
 
 vmsltu.vv v4, v8, v12, v0.t
-# CHECK-INST: vmsltu.vv v4, v8, v12, v0.t
+# CHECK-INST: vmsltu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x68]
 
 vmsltu.vx v4, v8, a1, v0.t
-# CHECK-INST: vmsltu.vx v4, v8, a1, v0.t
+# CHECK-INST: vmsltu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x68]
 
 vmslt.vv v4, v8, v12
-# CHECK-INST: vmslt.vv v4, v8, v12
+# CHECK-INST: vmslt.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x6e]
 
 vmslt.vx v4, v8, a1
-# CHECK-INST: vmslt.vx v4, v8, a1
+# CHECK-INST: vmslt.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x6e]
 
 vmslt.vv v4, v8, v12, v0.t
-# CHECK-INST: vmslt.vv v4, v8, v12, v0.t
+# CHECK-INST: vmslt.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x6c]
 
 vmslt.vx v4, v8, a1, v0.t
-# CHECK-INST: vmslt.vx v4, v8, a1, v0.t
+# CHECK-INST: vmslt.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x6c]
 
 vmsleu.vv v4, v8, v12
-# CHECK-INST: vmsleu.vv v4, v8, v12
+# CHECK-INST: vmsleu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x72]
 
 vmsleu.vx v4, v8, a1
-# CHECK-INST: vmsleu.vx v4, v8, a1
+# CHECK-INST: vmsleu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x72]
 
 vmsleu.vi v4, v8, 15
-# CHECK-INST: vmsleu.vi v4, v8, 15
+# CHECK-INST: vmsleu.vi	v4, v8, 15
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x72]
 
 vmsleu.vi v4, v8, -16
-# CHECK-INST: vmsleu.vi v4, v8, -16
+# CHECK-INST: vmsleu.vi	v4, v8, -16
 # CHECK-ENCODING: [0x57,0x32,0x88,0x72]
 
 vmsleu.vv v4, v8, v12, v0.t
-# CHECK-INST: vmsleu.vv v4, v8, v12, v0.t
+# CHECK-INST: vmsleu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x70]
 
 vmsleu.vx v4, v8, a1, v0.t
-# CHECK-INST: vmsleu.vx v4, v8, a1, v0.t
+# CHECK-INST: vmsleu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x70]
 
 vmsleu.vi v4, v8, 15, v0.t
-# CHECK-INST: vmsleu.vi v4, v8, 15, v0.t
+# CHECK-INST: vmsleu.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x70]
 
 vmsleu.vi v4, v8, -16, v0.t
-# CHECK-INST: vmsleu.vi v4, v8, -16, v0.t
+# CHECK-INST: vmsleu.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x88,0x70]
 
 vmsle.vv v4, v8, v12
-# CHECK-INST: vmsle.vv v4, v8, v12
+# CHECK-INST: vmsle.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x76]
 
 vmsle.vx v4, v8, a1
-# CHECK-INST: vmsle.vx v4, v8, a1
+# CHECK-INST: vmsle.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x76]
 
 vmsle.vi v4, v8, 15
-# CHECK-INST: vmsle.vi v4, v8, 15
+# CHECK-INST: vmsle.vi	v4, v8, 15
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x76]
 
 vmsle.vi v4, v8, -16
-# CHECK-INST: vmsle.vi v4, v8, -16
+# CHECK-INST: vmsle.vi	v4, v8, -16
 # CHECK-ENCODING: [0x57,0x32,0x88,0x76]
 
 vmsle.vv v4, v8, v12, v0.t
-# CHECK-INST: vmsle.vv v4, v8, v12, v0.t
+# CHECK-INST: vmsle.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x74]
 
 vmsle.vx v4, v8, a1, v0.t
-# CHECK-INST: vmsle.vx v4, v8, a1, v0.t
+# CHECK-INST: vmsle.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x74]
 
 vmsle.vi v4, v8, 15, v0.t
-# CHECK-INST: vmsle.vi v4, v8, 15, v0.t
+# CHECK-INST: vmsle.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x74]
 
 vmsle.vi v4, v8, -16, v0.t
-# CHECK-INST: vmsle.vi v4, v8, -16, v0.t
+# CHECK-INST: vmsle.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x88,0x74]
 
 vmsgtu.vx v4, v8, a1
-# CHECK-INST: vmsgtu.vx v4, v8, a1
+# CHECK-INST: vmsgtu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x7a]
 
 vmsgtu.vi v4, v8, 15
-# CHECK-INST: vmsgtu.vi v4, v8, 15
+# CHECK-INST: vmsgtu.vi	v4, v8, 15
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x7a]
 
 vmsgtu.vi v4, v8, -16
-# CHECK-INST: vmsgtu.vi v4, v8, -16
+# CHECK-INST: vmsgtu.vi	v4, v8, -16
 # CHECK-ENCODING: [0x57,0x32,0x88,0x7a]
 
 vmsgtu.vx v4, v8, a1, v0.t
-# CHECK-INST: vmsgtu.vx v4, v8, a1, v0.t
+# CHECK-INST: vmsgtu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x78]
 
 vmsgtu.vi v4, v8, 15, v0.t
-# CHECK-INST: vmsgtu.vi v4, v8, 15, v0.t
+# CHECK-INST: vmsgtu.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x78]
 
 vmsgtu.vi v4, v8, -16, v0.t
-# CHECK-INST: vmsgtu.vi v4, v8, -16, v0.t
+# CHECK-INST: vmsgtu.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x88,0x78]
 
 vmsgt.vx v4, v8, a1
-# CHECK-INST: vmsgt.vx v4, v8, a1
+# CHECK-INST: vmsgt.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x7e]
 
 vmsgt.vi v4, v8, 15
-# CHECK-INST: vmsgt.vi v4, v8, 15
+# CHECK-INST: vmsgt.vi	v4, v8, 15
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x7e]
 
 vmsgt.vi v4, v8, -16
-# CHECK-INST: vmsgt.vi v4, v8, -16
+# CHECK-INST: vmsgt.vi	v4, v8, -16
 # CHECK-ENCODING: [0x57,0x32,0x88,0x7e]
 
 vmsgt.vx v4, v8, a1, v0.t
-# CHECK-INST: vmsgt.vx v4, v8, a1, v0.t
+# CHECK-INST: vmsgt.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x7c]
 
 vmsgt.vi v4, v8, 15, v0.t
-# CHECK-INST: vmsgt.vi v4, v8, 15, v0.t
+# CHECK-INST: vmsgt.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x7c]
 
 vmsgt.vi v4, v8, -16, v0.t
-# CHECK-INST: vmsgt.vi v4, v8, -16, v0.t
+# CHECK-INST: vmsgt.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x88,0x7c]
 
 vminu.vv v4, v8, v12
-# CHECK-INST: vminu.vv v4, v8, v12
+# CHECK-INST: vminu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x12]
 
 vminu.vx v4, v8, a1
-# CHECK-INST: vminu.vx v4, v8, a1
+# CHECK-INST: vminu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x12]
 
 vminu.vv v4, v8, v12, v0.t
-# CHECK-INST: vminu.vv v4, v8, v12, v0.t
+# CHECK-INST: vminu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x10]
 
 vminu.vx v4, v8, a1, v0.t
-# CHECK-INST: vminu.vx v4, v8, a1, v0.t
+# CHECK-INST: vminu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x10]
 
 vmin.vv v4, v8, v12
-# CHECK-INST: vmin.vv v4, v8, v12
+# CHECK-INST: vmin.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x16]
 
 vmin.vx v4, v8, a1
-# CHECK-INST: vmin.vx v4, v8, a1
+# CHECK-INST: vmin.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x16]
 
 vmin.vv v4, v8, v12, v0.t
-# CHECK-INST: vmin.vv v4, v8, v12, v0.t
+# CHECK-INST: vmin.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x14]
 
 vmin.vx v4, v8, a1, v0.t
-# CHECK-INST: vmin.vx v4, v8, a1, v0.t
+# CHECK-INST: vmin.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x14]
 
 vmaxu.vv v4, v8, v12
-# CHECK-INST: vmaxu.vv v4, v8, v12
+# CHECK-INST: vmaxu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x1a]
 
 vmaxu.vx v4, v8, a1
-# CHECK-INST: vmaxu.vx v4, v8, a1
+# CHECK-INST: vmaxu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x1a]
 
 vmaxu.vv v4, v8, v12, v0.t
-# CHECK-INST: vmaxu.vv v4, v8, v12, v0.t
+# CHECK-INST: vmaxu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x18]
 
 vmaxu.vx v4, v8, a1, v0.t
-# CHECK-INST: vmaxu.vx v4, v8, a1, v0.t
+# CHECK-INST: vmaxu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x18]
 
 vmax.vv v4, v8, v12
-# CHECK-INST: vmax.vv v4, v8, v12
+# CHECK-INST: vmax.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x1e]
 
 vmax.vx v4, v8, a1
-# CHECK-INST: vmax.vx v4, v8, a1
+# CHECK-INST: vmax.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x1e]
 
 vmax.vv v4, v8, v12, v0.t
-# CHECK-INST: vmax.vv v4, v8, v12, v0.t
+# CHECK-INST: vmax.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x1c]
 
 vmax.vx v4, v8, a1, v0.t
-# CHECK-INST: vmax.vx v4, v8, a1, v0.t
+# CHECK-INST: vmax.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x1c]
 
 vmul.vv v4, v8, v12
-# CHECK-INST: vmul.vv v4, v8, v12
+# CHECK-INST: vmul.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x96]
 
 vmul.vx v4, v8, a1
-# CHECK-INST: vmul.vx v4, v8, a1
+# CHECK-INST: vmul.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x96]
 
 vmul.vv v4, v8, v12, v0.t
-# CHECK-INST: vmul.vv v4, v8, v12, v0.t
+# CHECK-INST: vmul.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0x94]
 
 vmul.vx v4, v8, a1, v0.t
-# CHECK-INST: vmul.vx v4, v8, a1, v0.t
+# CHECK-INST: vmul.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x94]
 
 vmulh.vv v4, v8, v12
-# CHECK-INST: vmulh.vv v4, v8, v12
+# CHECK-INST: vmulh.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x9e]
 
 vmulh.vx v4, v8, a1
-# CHECK-INST: vmulh.vx v4, v8, a1
+# CHECK-INST: vmulh.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x9e]
 
 vmulh.vv v4, v8, v12, v0.t
-# CHECK-INST: vmulh.vv v4, v8, v12, v0.t
+# CHECK-INST: vmulh.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0x9c]
 
 vmulh.vx v4, v8, a1, v0.t
-# CHECK-INST: vmulh.vx v4, v8, a1, v0.t
+# CHECK-INST: vmulh.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x9c]
 
 vmulhu.vv v4, v8, v12
-# CHECK-INST: vmulhu.vv v4, v8, v12
+# CHECK-INST: vmulhu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x92]
 
 vmulhu.vx v4, v8, a1
-# CHECK-INST: vmulhu.vx v4, v8, a1
+# CHECK-INST: vmulhu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x92]
 
 vmulhu.vv v4, v8, v12, v0.t
-# CHECK-INST: vmulhu.vv v4, v8, v12, v0.t
+# CHECK-INST: vmulhu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0x90]
 
 vmulhu.vx v4, v8, a1, v0.t
-# CHECK-INST: vmulhu.vx v4, v8, a1, v0.t
+# CHECK-INST: vmulhu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x90]
 
 vmulhsu.vv v4, v8, v12
-# CHECK-INST: vmulhsu.vv v4, v8, v12
+# CHECK-INST: vmulhsu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x9a]
 
 vmulhsu.vx v4, v8, a1
-# CHECK-INST: vmulhsu.vx v4, v8, a1
+# CHECK-INST: vmulhsu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x9a]
 
 vmulhsu.vv v4, v8, v12, v0.t
-# CHECK-INST: vmulhsu.vv v4, v8, v12, v0.t
+# CHECK-INST: vmulhsu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0x98]
 
 vmulhsu.vx v4, v8, a1, v0.t
-# CHECK-INST: vmulhsu.vx v4, v8, a1, v0.t
+# CHECK-INST: vmulhsu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x98]
 
 vwmul.vv v4, v8, v12
-# CHECK-INST: vwmul.vv v4, v8, v12
+# CHECK-INST: vwmul.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0xee]
 
 vwmul.vx v4, v8, a1
-# CHECK-INST: vwmul.vx v4, v8, a1
+# CHECK-INST: vwmul.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xee]
 
 vwmul.vv v4, v8, v12, v0.t
-# CHECK-INST: vwmul.vv v4, v8, v12, v0.t
+# CHECK-INST: vwmul.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xec]
 
 vwmul.vx v4, v8, a1, v0.t
-# CHECK-INST: vwmul.vx v4, v8, a1, v0.t
+# CHECK-INST: vwmul.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xec]
 
 vwmulu.vv v4, v8, v12
-# CHECK-INST: vwmulu.vv v4, v8, v12
+# CHECK-INST: vwmulu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0xe2]
 
 vwmulu.vx v4, v8, a1
-# CHECK-INST: vwmulu.vx v4, v8, a1
+# CHECK-INST: vwmulu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xe2]
 
 vwmulu.vv v4, v8, v12, v0.t
-# CHECK-INST: vwmulu.vv v4, v8, v12, v0.t
+# CHECK-INST: vwmulu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xe0]
 
 vwmulu.vx v4, v8, a1, v0.t
-# CHECK-INST: vwmulu.vx v4, v8, a1, v0.t
+# CHECK-INST: vwmulu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xe0]
 
 vwmulsu.vv v4, v8, v12
-# CHECK-INST: vwmulsu.vv v4, v8, v12
+# CHECK-INST: vwmulsu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0xea]
 
 vwmulsu.vx v4, v8, a1
-# CHECK-INST: vwmulsu.vx v4, v8, a1
+# CHECK-INST: vwmulsu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xea]
 
 vwmulsu.vv v4, v8, v12, v0.t
-# CHECK-INST: vwmulsu.vv v4, v8, v12, v0.t
+# CHECK-INST: vwmulsu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xe8]
 
 vwmulsu.vx v4, v8, a1, v0.t
-# CHECK-INST: vwmulsu.vx v4, v8, a1, v0.t
+# CHECK-INST: vwmulsu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xe8]
 
 vmacc.vv v4, v12, v8
-# CHECK-INST: vmacc.vv v4, v12, v8
+# CHECK-INST: vmacc.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x22,0x86,0xb6]
 
 vmacc.vx v4, a1, v8
-# CHECK-INST: vmacc.vx v4, a1, v8
+# CHECK-INST: vmacc.vx	v4, a1, v8
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xb6]
 
 vmacc.vv v4, v12, v8, v0.t
-# CHECK-INST: vmacc.vv v4, v12, v8, v0.t
+# CHECK-INST: vmacc.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xb4]
 
 vmacc.vx v4, a1, v8, v0.t
-# CHECK-INST: vmacc.vx v4, a1, v8, v0.t
+# CHECK-INST: vmacc.vx	v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xb4]
 
 vnmsac.vv v4, v12, v8
-# CHECK-INST: vnmsac.vv v4, v12, v8
+# CHECK-INST: vnmsac.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x22,0x86,0xbe]
 
 vnmsac.vx v4, a1, v8
-# CHECK-INST: vnmsac.vx v4, a1, v8
+# CHECK-INST: vnmsac.vx	v4, a1, v8
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xbe]
 
 vnmsac.vv v4, v12, v8, v0.t
-# CHECK-INST: vnmsac.vv v4, v12, v8, v0.t
+# CHECK-INST: vnmsac.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xbc]
 
 vnmsac.vx v4, a1, v8, v0.t
-# CHECK-INST: vnmsac.vx v4, a1, v8, v0.t
+# CHECK-INST: vnmsac.vx	v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xbc]
 
 vmadd.vv v4, v12, v8
-# CHECK-INST: vmadd.vv v4, v12, v8
+# CHECK-INST: vmadd.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x22,0x86,0xa6]
 
 vmadd.vx v4, a1, v8
-# CHECK-INST: vmadd.vx v4, a1, v8
+# CHECK-INST: vmadd.vx	v4, a1, v8
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xa6]
 
 vmadd.vv v4, v12, v8, v0.t
-# CHECK-INST: vmadd.vv v4, v12, v8, v0.t
+# CHECK-INST: vmadd.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xa4]
 
 vmadd.vx v4, a1, v8, v0.t
-# CHECK-INST: vmadd.vx v4, a1, v8, v0.t
+# CHECK-INST: vmadd.vx	v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xa4]
 
 vnmsub.vv v4, v12, v8
-# CHECK-INST: vnmsub.vv v4, v12, v8
+# CHECK-INST: vnmsub.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x22,0x86,0xae]
 
 vnmsub.vx v4, a1, v8
-# CHECK-INST: vnmsub.vx v4, a1, v8
+# CHECK-INST: vnmsub.vx	v4, a1, v8
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xae]
 
 vnmsub.vv v4, v12, v8, v0.t
-# CHECK-INST: vnmsub.vv v4, v12, v8, v0.t
+# CHECK-INST: vnmsub.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xac]
 
 vnmsub.vx v4, a1, v8, v0.t
-# CHECK-INST: vnmsub.vx v4, a1, v8, v0.t
+# CHECK-INST: vnmsub.vx	v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xac]
 
 vwmaccu.vv v4, v12, v8
-# CHECK-INST: vwmaccu.vv v4, v12, v8
+# CHECK-INST: vwmaccu.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x22,0x86,0xf2]
 
 vwmaccu.vx v4, a1, v8
-# CHECK-INST: vwmaccu.vx v4, a1, v8
+# CHECK-INST: vwmaccu.vx	v4, a1, v8
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xf2]
 
 vwmaccu.vv v4, v12, v8, v0.t
-# CHECK-INST: vwmaccu.vv v4, v12, v8, v0.t
+# CHECK-INST: vwmaccu.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xf0]
 
 vwmaccu.vx v4, a1, v8, v0.t
-# CHECK-INST: vwmaccu.vx v4, a1, v8, v0.t
+# CHECK-INST: vwmaccu.vx	v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xf0]
 
 vwmacc.vv v4, v12, v8
-# CHECK-INST: vwmacc.vv v4, v12, v8
+# CHECK-INST: vwmacc.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x22,0x86,0xf6]
 
 vwmacc.vx v4, a1, v8
-# CHECK-INST: vwmacc.vx v4, a1, v8
+# CHECK-INST: vwmacc.vx	v4, a1, v8
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xf6]
 
 vwmacc.vv v4, v12, v8, v0.t
-# CHECK-INST: vwmacc.vv v4, v12, v8, v0.t
+# CHECK-INST: vwmacc.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xf4]
 
 vwmacc.vx v4, a1, v8, v0.t
-# CHECK-INST: vwmacc.vx v4, a1, v8, v0.t
+# CHECK-INST: vwmacc.vx	v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xf4]
 
 vwmaccsu.vv v4, v12, v8
@@ -5420,7 +5408,7 @@ vwmaccsu.vv v4, v12, v8
 # CHECK-ENCODING: [0x57,0x22,0x86,0xfa]
 
 vwmaccsu.vx v4, a1, v8
-# CHECK-INST: vwmaccsu.vx v4, a1, v8
+# CHECK-INST: vwmaccus.vx	v4, a1, v8
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xfa]
 
 vwmaccsu.vv v4, v12, v8, v0.t
@@ -5428,899 +5416,898 @@ vwmaccsu.vv v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0xf8]
 
 vwmaccsu.vx v4, a1, v8, v0.t
-# CHECK-INST: vwmaccsu.vx v4, a1, v8, v0.t
+# CHECK-INST: vwmaccus.vx	v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xf8]
 
 vwmaccus.vx v4, a1, v8
-# CHECK-INST: vwmaccus.vx v4, a1, v8
+# CHECK-INST: vwmaccsu.vx	v4, a1, v8
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xfe]
 
 vwmaccus.vx v4, a1, v8, v0.t
-# CHECK-INST: vwmaccus.vx v4, a1, v8, v0.t
+# CHECK-INST: vwmaccsu.vx	v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0xfc]
 
 vdivu.vv v4, v8, v12
-# CHECK-INST: vdivu.vv v4, v8, v12
+# CHECK-INST: vdivu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x82]
 
 vdivu.vx v4, v8, a1
-# CHECK-INST: vdivu.vx v4, v8, a1
+# CHECK-INST: vdivu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x82]
 
 vdivu.vv v4, v8, v12, v0.t
-# CHECK-INST: vdivu.vv v4, v8, v12, v0.t
+# CHECK-INST: vdivu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0x80]
 
 vdivu.vx v4, v8, a1, v0.t
-# CHECK-INST: vdivu.vx v4, v8, a1, v0.t
+# CHECK-INST: vdivu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x80]
 
 vdiv.vv v4, v8, v12
-# CHECK-INST: vdiv.vv v4, v8, v12
+# CHECK-INST: vdiv.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x86]
 
 vdiv.vx v4, v8, a1
-# CHECK-INST: vdiv.vx v4, v8, a1
+# CHECK-INST: vdiv.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x86]
 
 vdiv.vv v4, v8, v12, v0.t
-# CHECK-INST: vdiv.vv v4, v8, v12, v0.t
+# CHECK-INST: vdiv.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0x84]
 
 vdiv.vx v4, v8, a1, v0.t
-# CHECK-INST: vdiv.vx v4, v8, a1, v0.t
+# CHECK-INST: vdiv.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x84]
 
 vremu.vv v4, v8, v12
-# CHECK-INST: vremu.vv v4, v8, v12
+# CHECK-INST: vremu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x8a]
 
 vremu.vx v4, v8, a1
-# CHECK-INST: vremu.vx v4, v8, a1
+# CHECK-INST: vremu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x8a]
 
 vremu.vv v4, v8, v12, v0.t
-# CHECK-INST: vremu.vv v4, v8, v12, v0.t
+# CHECK-INST: vremu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0x88]
 
 vremu.vx v4, v8, a1, v0.t
-# CHECK-INST: vremu.vx v4, v8, a1, v0.t
+# CHECK-INST: vremu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x88]
 
 vrem.vv v4, v8, v12
-# CHECK-INST: vrem.vv v4, v8, v12
+# CHECK-INST: vrem.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x8e]
 
 vrem.vx v4, v8, a1
-# CHECK-INST: vrem.vx v4, v8, a1
+# CHECK-INST: vrem.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x8e]
 
 vrem.vv v4, v8, v12, v0.t
-# CHECK-INST: vrem.vv v4, v8, v12, v0.t
+# CHECK-INST: vrem.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0x8c]
 
 vrem.vx v4, v8, a1, v0.t
-# CHECK-INST: vrem.vx v4, v8, a1, v0.t
+# CHECK-INST: vrem.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x8c]
 
 vmerge.vvm v4, v8, v12, v0
-# CHECK-INST: vmerge.vvm v4, v8, v12, v0
+# CHECK-INST: vmerge.vvm	v4, v8, v12, v0
 # CHECK-ENCODING: [0x57,0x02,0x86,0x5c]
 
 vmerge.vxm v4, v8, a1, v0
-# CHECK-INST: vmerge.vxm v4, v8, a1, v0
+# CHECK-INST: vmerge.vxm	v4, v8, a1, v0
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x5c]
 
 vmerge.vim v4, v8, 15, v0
-# CHECK-INST: vmerge.vim v4, v8, 15, v0
+# CHECK-INST: vmerge.vim	v4, v8, 15, v0
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x5c]
 
 vmerge.vim v4, v8, -16, v0
-# CHECK-INST: vmerge.vim v4, v8, -16, v0
+# CHECK-INST: vmerge.vim	v4, v8, -16, v0
 # CHECK-ENCODING: [0x57,0x32,0x88,0x5c]
 
 vmv.v.v v8, v12
-# CHECK-INST: vmv.v.v v8, v12
+# CHECK-INST: vmv.v.v	v8, v12
 # CHECK-ENCODING: [0x57,0x04,0x06,0x5e]
 
 vmv.v.x v8, a1
-# CHECK-INST: vmv.v.x v8, a1
+# CHECK-INST: vmv.v.x	v8, a1
 # CHECK-ENCODING: [0x57,0xc4,0x05,0x5e]
 
 vmv.v.i v8, 15
-# CHECK-INST: vmv.v.i v8, 15
+# CHECK-INST: vmv.v.i	v8, 15
 # CHECK-ENCODING: [0x57,0xb4,0x07,0x5e]
 
 vmv.v.i v8, -16
-# CHECK-INST: vmv.v.i v8, -16
+# CHECK-INST: vmv.v.i	v8, -16
 # CHECK-ENCODING: [0x57,0x34,0x08,0x5e]
 
 vsaddu.vv v4, v8, v12
-# CHECK-INST: vsaddu.vv v4, v8, v12
+# CHECK-INST: vsaddu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x82]
 
 vsaddu.vx v4, v8, a1
-# CHECK-INST: vsaddu.vx v4, v8, a1
+# CHECK-INST: vsaddu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x82]
 
 vsaddu.vi v4, v8, 15
-# CHECK-INST: vsaddu.vi v4, v8, 15
+# CHECK-INST: vsaddu.vi	v4, v8, 15
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x82]
 
 vsaddu.vi v4, v8, -16
-# CHECK-INST: vsaddu.vi v4, v8, -16
+# CHECK-INST: vsaddu.vi	v4, v8, -16
 # CHECK-ENCODING: [0x57,0x32,0x88,0x82]
 
 vsaddu.vv v4, v8, v12, v0.t
-# CHECK-INST: vsaddu.vv v4, v8, v12, v0.t
+# CHECK-INST: vsaddu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x80]
 
 vsaddu.vx v4, v8, a1, v0.t
-# CHECK-INST: vsaddu.vx v4, v8, a1, v0.t
+# CHECK-INST: vsaddu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x80]
 
 vsaddu.vi v4, v8, 15, v0.t
-# CHECK-INST: vsaddu.vi v4, v8, 15, v0.t
+# CHECK-INST: vsaddu.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x80]
 
 vsaddu.vi v4, v8, -16, v0.t
-# CHECK-INST: vsaddu.vi v4, v8, -16, v0.t
+# CHECK-INST: vsaddu.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x88,0x80]
 
 vsadd.vv v4, v8, v12
-# CHECK-INST: vsadd.vv v4, v8, v12
+# CHECK-INST: vsadd.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x86]
 
 vsadd.vx v4, v8, a1
-# CHECK-INST: vsadd.vx v4, v8, a1
+# CHECK-INST: vsadd.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x86]
 
 vsadd.vi v4, v8, 15
-# CHECK-INST: vsadd.vi v4, v8, 15
+# CHECK-INST: vsadd.vi	v4, v8, 15
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x86]
 
 vsadd.vi v4, v8, -16
-# CHECK-INST: vsadd.vi v4, v8, -16
+# CHECK-INST: vsadd.vi	v4, v8, -16
 # CHECK-ENCODING: [0x57,0x32,0x88,0x86]
 
 vsadd.vv v4, v8, v12, v0.t
-# CHECK-INST: vsadd.vv v4, v8, v12, v0.t
+# CHECK-INST: vsadd.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x84]
 
 vsadd.vx v4, v8, a1, v0.t
-# CHECK-INST: vsadd.vx v4, v8, a1, v0.t
+# CHECK-INST: vsadd.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x84]
 
 vsadd.vi v4, v8, 15, v0.t
-# CHECK-INST: vsadd.vi v4, v8, 15, v0.t
+# CHECK-INST: vsadd.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x84]
 
 vsadd.vi v4, v8, -16, v0.t
-# CHECK-INST: vsadd.vi v4, v8, -16, v0.t
+# CHECK-INST: vsadd.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x88,0x84]
 
 vssubu.vv v4, v8, v12
-# CHECK-INST: vssubu.vv v4, v8, v12
+# CHECK-INST: vssubu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x8a]
 
 vssubu.vx v4, v8, a1
-# CHECK-INST: vssubu.vx v4, v8, a1
+# CHECK-INST: vssubu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x8a]
 
 vssubu.vv v4, v8, v12, v0.t
-# CHECK-INST: vssubu.vv v4, v8, v12, v0.t
+# CHECK-INST: vssubu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x88]
 
 vssubu.vx v4, v8, a1, v0.t
-# CHECK-INST: vssubu.vx v4, v8, a1, v0.t
+# CHECK-INST: vssubu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x88]
 
 vssub.vv v4, v8, v12
-# CHECK-INST: vssub.vv v4, v8, v12
+# CHECK-INST: vssub.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x8e]
 
 vssub.vx v4, v8, a1
-# CHECK-INST: vssub.vx v4, v8, a1
+# CHECK-INST: vssub.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x8e]
 
 vssub.vv v4, v8, v12, v0.t
-# CHECK-INST: vssub.vv v4, v8, v12, v0.t
+# CHECK-INST: vssub.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x8c]
 
 vssub.vx v4, v8, a1, v0.t
-# CHECK-INST: vssub.vx v4, v8, a1, v0.t
+# CHECK-INST: vssub.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x8c]
 
 vaadd.vv v4, v8, v12
-# CHECK-INST: vaadd.vv v4, v8, v12
+# CHECK-INST: vaadd.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x92]
 
 vaadd.vx v4, v8, a1
-# CHECK-INST: vaadd.vx v4, v8, a1
+# CHECK-INST: vaadd.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x92]
 
 vaadd.vi v4, v8, 15
-# CHECK-INST: vaadd.vi v4, v8, 15
+# CHECK-INST: vaadd.vi	v4, v8, 15
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x92]
 
 vaadd.vi v4, v8, -16
-# CHECK-INST: vaadd.vi v4, v8, -16
+# CHECK-INST: vaadd.vi	v4, v8, -16
 # CHECK-ENCODING: [0x57,0x32,0x88,0x92]
 
 vaadd.vv v4, v8, v12, v0.t
-# CHECK-INST: vaadd.vv v4, v8, v12, v0.t
+# CHECK-INST: vaadd.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x90]
 
 vaadd.vx v4, v8, a1, v0.t
-# CHECK-INST: vaadd.vx v4, v8, a1, v0.t
+# CHECK-INST: vaadd.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x90]
 
 vaadd.vi v4, v8, 15, v0.t
-# CHECK-INST: vaadd.vi v4, v8, 15, v0.t
+# CHECK-INST: vaadd.vi	v4, v8, 15, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x87,0x90]
 
 vaadd.vi v4, v8, -16, v0.t
-# CHECK-INST: vaadd.vi v4, v8, -16, v0.t
+# CHECK-INST: vaadd.vi	v4, v8, -16, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x88,0x90]
 
 vasub.vv v4, v8, v12
-# CHECK-INST: vasub.vv v4, v8, v12
+# CHECK-INST: vasub.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x9a]
 
 vasub.vx v4, v8, a1
-# CHECK-INST: vasub.vx v4, v8, a1
+# CHECK-INST: vasub.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x9a]
 
 vasub.vv v4, v8, v12, v0.t
-# CHECK-INST: vasub.vv v4, v8, v12, v0.t
+# CHECK-INST: vasub.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x98]
 
 vasub.vx v4, v8, a1, v0.t
-# CHECK-INST: vasub.vx v4, v8, a1, v0.t
+# CHECK-INST: vasub.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x98]
 
 vsmul.vv v4, v8, v12
-# CHECK-INST: vsmul.vv v4, v8, v12
+# CHECK-INST: vsmul.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x9e]
 
 vsmul.vx v4, v8, a1
-# CHECK-INST: vsmul.vx v4, v8, a1
+# CHECK-INST: vsmul.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x9e]
 
 vsmul.vv v4, v8, v12, v0.t
-# CHECK-INST: vsmul.vv v4, v8, v12, v0.t
+# CHECK-INST: vsmul.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x9c]
 
 vsmul.vx v4, v8, a1, v0.t
-# CHECK-INST: vsmul.vx v4, v8, a1, v0.t
+# CHECK-INST: vsmul.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x9c]
 
 vwsmaccu.vv v4, v12, v8
-# CHECK-INST: vwsmaccu.vv v4, v12, v8
+# CHECK-INST: vwsmaccu.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x02,0x86,0xf2]
 
 vwsmaccu.vx v4, a1, v8
-# CHECK-INST: vwsmaccu.vx v4, a1, v8
+# CHECK-INST: vwsmaccu.vx	v4, a1, v8
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xf2]
 
 vwsmacc.vv v4, v12, v8
-# CHECK-INST: vwsmacc.vv v4, v12, v8
+# CHECK-INST: vwsmacc.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x02,0x86,0xf6]
 
 vwsmacc.vx v4, a1, v8
-# CHECK-INST: vwsmacc.vx v4, a1, v8
+# CHECK-INST: vwsmacc.vx	v4, a1, v8
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xf6]
 
 vwsmaccsu.vv v4, v12, v8
-# CHECK-INST: vwsmaccsu.vv v4, v12, v8
+# CHECK-INST: vwsmaccsu.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x02,0x86,0xfa]
 
 vwsmaccsu.vx v4, a1, v8
-# CHECK-INST: vwsmaccsu.vx v4, a1, v8
+# CHECK-INST: vwsmaccsu.vx	v4, a1, v8
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xfa]
 
 vwsmaccus.vx v4, a1, v8
-# CHECK-INST: vwsmaccus.vx v4, a1, v8
+# CHECK-INST: vwsmaccus.vx	v4, a1, v8
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xfe]
 
 vwsmaccu.vv v4, v12, v8, v0.t
-# CHECK-INST: vwsmaccu.vv v4, v12, v8, v0.t
+# CHECK-INST: vwsmaccu.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0xf0]
 
 vwsmaccu.vx v4, a1, v8, v0.t
-# CHECK-INST: vwsmaccu.vx v4, a1, v8, v0.t
+# CHECK-INST: vwsmaccu.vx	v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xf0]
 
 vwsmacc.vv v4, v12, v8, v0.t
-# CHECK-INST: vwsmacc.vv v4, v12, v8, v0.t
+# CHECK-INST: vwsmacc.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0xf4]
 
 vwsmacc.vx v4, a1, v8, v0.t
-# CHECK-INST: vwsmacc.vx v4, a1, v8, v0.t
+# CHECK-INST: vwsmacc.vx	v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xf4]
 
 vwsmaccsu.vv v4, v12, v8, v0.t
-# CHECK-INST: vwsmaccsu.vv v4, v12, v8, v0.t
+# CHECK-INST: vwsmaccsu.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0xf8]
 
 vwsmaccsu.vx v4, a1, v8, v0.t
-# CHECK-INST: vwsmaccsu.vx v4, a1, v8, v0.t
+# CHECK-INST: vwsmaccsu.vx	v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xf8]
 
 vwsmaccus.vx v4, a1, v8, v0.t
-# CHECK-INST: vwsmaccus.vx v4, a1, v8, v0.t
+# CHECK-INST: vwsmaccus.vx	v4, a1, v8, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xfc]
 
 vssrl.vv v4, v8, v12
-# CHECK-INST: vssrl.vv v4, v8, v12
+# CHECK-INST: vssrl.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0xaa]
 
 vssrl.vx v4, v8, a1
-# CHECK-INST: vssrl.vx v4, v8, a1
+# CHECK-INST: vssrl.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xaa]
 
 vssrl.vi v4, v8, 1
-# CHECK-INST: vssrl.vi v4, v8, 1
+# CHECK-INST: vssrl.vi	v4, v8, 1
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xaa]
 
 vssrl.vi v4, v8, 31
-# CHECK-INST: vssrl.vi v4, v8, 31
+# CHECK-INST: vssrl.vi	v4, v8, 31
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xaa]
 
 vssrl.vv v4, v8, v12, v0.t
-# CHECK-INST: vssrl.vv v4, v8, v12, v0.t
+# CHECK-INST: vssrl.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0xa8]
 
 vssrl.vx v4, v8, a1, v0.t
-# CHECK-INST: vssrl.vx v4, v8, a1, v0.t
+# CHECK-INST: vssrl.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xa8]
 
 vssrl.vi v4, v8, 1, v0.t
-# CHECK-INST: vssrl.vi v4, v8, 1, v0.t
+# CHECK-INST: vssrl.vi	v4, v8, 1, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xa8]
 
 vssrl.vi v4, v8, 31, v0.t
-# CHECK-INST: vssrl.vi v4, v8, 31, v0.t
+# CHECK-INST: vssrl.vi	v4, v8, 31, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xa8]
 
 vssra.vv v4, v8, v12
-# CHECK-INST: vssra.vv v4, v8, v12
+# CHECK-INST: vssra.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0xae]
 
 vssra.vx v4, v8, a1
-# CHECK-INST: vssra.vx v4, v8, a1
+# CHECK-INST: vssra.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xae]
 
 vssra.vi v4, v8, 1
-# CHECK-INST: vssra.vi v4, v8, 1
+# CHECK-INST: vssra.vi	v4, v8, 1
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xae]
 
 vssra.vi v4, v8, 31
-# CHECK-INST: vssra.vi v4, v8, 31
+# CHECK-INST: vssra.vi	v4, v8, 31
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xae]
 
 vssra.vv v4, v8, v12, v0.t
-# CHECK-INST: vssra.vv v4, v8, v12, v0.t
+# CHECK-INST: vssra.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0xac]
 
 vssra.vx v4, v8, a1, v0.t
-# CHECK-INST: vssra.vx v4, v8, a1, v0.t
+# CHECK-INST: vssra.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xac]
 
 vssra.vi v4, v8, 1, v0.t
-# CHECK-INST: vssra.vi v4, v8, 1, v0.t
+# CHECK-INST: vssra.vi	v4, v8, 1, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xac]
 
 vssra.vi v4, v8, 31, v0.t
-# CHECK-INST: vssra.vi v4, v8, 31, v0.t
+# CHECK-INST: vssra.vi	v4, v8, 31, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xac]
 
 vnclipu.vv v4, v8, v12
-# CHECK-INST: vnclipu.vv v4, v8, v12
+# CHECK-INST: vnclipu.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0xba]
 
 vnclipu.vx v4, v8, a1
-# CHECK-INST: vnclipu.vx v4, v8, a1
+# CHECK-INST: vnclipu.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xba]
 
 vnclipu.vi v4, v8, 1
-# CHECK-INST: vnclipu.vi v4, v8, 1
+# CHECK-INST: vnclipu.vi	v4, v8, 1
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xba]
 
 vnclipu.vi v4, v8, 31
-# CHECK-INST: vnclipu.vi v4, v8, 31
+# CHECK-INST: vnclipu.vi	v4, v8, 31
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xba]
 
 vnclipu.vv v4, v8, v12, v0.t
-# CHECK-INST: vnclipu.vv v4, v8, v12, v0.t
+# CHECK-INST: vnclipu.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0xb8]
 
 vnclipu.vx v4, v8, a1, v0.t
-# CHECK-INST: vnclipu.vx v4, v8, a1, v0.t
+# CHECK-INST: vnclipu.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xb8]
 
 vnclipu.vi v4, v8, 1, v0.t
-# CHECK-INST: vnclipu.vi v4, v8, 1, v0.t
+# CHECK-INST: vnclipu.vi	v4, v8, 1, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xb8]
 
 vnclipu.vi v4, v8, 31, v0.t
-# CHECK-INST: vnclipu.vi v4, v8, 31, v0.t
+# CHECK-INST: vnclipu.vi	v4, v8, 31, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xb8]
 
 vnclip.vv v4, v8, v12
-# CHECK-INST: vnclip.vv v4, v8, v12
+# CHECK-INST: vnclip.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0xbe]
 
 vnclip.vx v4, v8, a1
-# CHECK-INST: vnclip.vx v4, v8, a1
+# CHECK-INST: vnclip.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xbe]
 
 vnclip.vi v4, v8, 1
-# CHECK-INST: vnclip.vi v4, v8, 1
+# CHECK-INST: vnclip.vi	v4, v8, 1
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xbe]
 
 vnclip.vi v4, v8, 31
-# CHECK-INST: vnclip.vi v4, v8, 31
+# CHECK-INST: vnclip.vi	v4, v8, 31
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xbe]
 
 vnclip.vv v4, v8, v12, v0.t
-# CHECK-INST: vnclip.vv v4, v8, v12, v0.t
+# CHECK-INST: vnclip.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0xbc]
 
 vnclip.vx v4, v8, a1, v0.t
-# CHECK-INST: vnclip.vx v4, v8, a1, v0.t
+# CHECK-INST: vnclip.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0xbc]
 
 vnclip.vi v4, v8, 1, v0.t
-# CHECK-INST: vnclip.vi v4, v8, 1, v0.t
+# CHECK-INST: vnclip.vi	v4, v8, 1, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x80,0xbc]
 
 vnclip.vi v4, v8, 31, v0.t
-# CHECK-INST: vnclip.vi v4, v8, 31, v0.t
+# CHECK-INST: vnclip.vi	v4, v8, 31, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0xbc]
 
 vfadd.vv v4, v8, v12
-# CHECK-INST: vfadd.vv v4, v8, v12
+# CHECK-INST: vfadd.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x02]
 
 vfadd.vf v4, v8, fa2
-# CHECK-INST: vfadd.vf v4, v8, fa2
+# CHECK-INST: vfadd.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x02]
 
 vfadd.vv v4, v8, v12, v0.t
-# CHECK-INST: vfadd.vv v4, v8, v12, v0.t
+# CHECK-INST: vfadd.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x00]
 
 vfadd.vf v4, v8, fa2, v0.t
-# CHECK-INST: vfadd.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfadd.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x00]
 
 vfsub.vv v4, v8, v12
-# CHECK-INST: vfsub.vv v4, v8, v12
+# CHECK-INST: vfsub.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x0a]
 
 vfsub.vf v4, v8, fa2
-# CHECK-INST: vfsub.vf v4, v8, fa2
+# CHECK-INST: vfsub.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x0a]
 
 vfsub.vv v4, v8, v12, v0.t
-# CHECK-INST: vfsub.vv v4, v8, v12, v0.t
+# CHECK-INST: vfsub.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x08]
 
 vfsub.vf v4, v8, fa2, v0.t
-# CHECK-INST: vfsub.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfsub.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x08]
 
 vfrsub.vf v4, v8, fa2
-# CHECK-INST: vfrsub.vf v4, v8, fa2
+# CHECK-INST: vfrsub.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x9e]
 
 vfrsub.vf v4, v8, fa2, v0.t
-# CHECK-INST: vfrsub.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfrsub.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x9c]
 
 vfwadd.vv v4, v8, v12
-# CHECK-INST: vfwadd.vv v4, v8, v12
+# CHECK-INST: vfwadd.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0xc2]
 
 vfwadd.vf v4, v8, fa2
-# CHECK-INST: vfwadd.vf v4, v8, fa2
+# CHECK-INST: vfwadd.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0xc2]
 
 vfwadd.vv v4, v8, v12, v0.t
-# CHECK-INST: vfwadd.vv v4, v8, v12, v0.t
+# CHECK-INST: vfwadd.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xc0]
 
 vfwadd.vf v4, v8, fa2, v0.t
-# CHECK-INST: vfwadd.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfwadd.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xc0]
 
 vfwsub.vv v4, v8, v12
-# CHECK-INST: vfwsub.vv v4, v8, v12
+# CHECK-INST: vfwsub.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0xca]
 
 vfwsub.vf v4, v8, fa2
-# CHECK-INST: vfwsub.vf v4, v8, fa2
+# CHECK-INST: vfwsub.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0xca]
 
 vfwsub.vv v4, v8, v12, v0.t
-# CHECK-INST: vfwsub.vv v4, v8, v12, v0.t
+# CHECK-INST: vfwsub.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xc8]
 
 vfwsub.vf v4, v8, fa2, v0.t
-# CHECK-INST: vfwsub.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfwsub.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xc8]
 
 vfwadd.wv v4, v8, v12
-# CHECK-INST: vfwadd.wv v4, v8, v12
+# CHECK-INST: vfwadd.wv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0xd2]
 
 vfwadd.wf v4, v8, fa2
-# CHECK-INST: vfwadd.wf v4, v8, fa2
+# CHECK-INST: vfwadd.wf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0xd2]
 
 vfwadd.wv v4, v8, v12, v0.t
-# CHECK-INST: vfwadd.wv v4, v8, v12, v0.t
+# CHECK-INST: vfwadd.wv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xd0]
 
 vfwadd.wf v4, v8, fa2, v0.t
-# CHECK-INST: vfwadd.wf v4, v8, fa2, v0.t
+# CHECK-INST: vfwadd.wf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xd0]
 
 vfwsub.wv v4, v8, v12
-# CHECK-INST: vfwsub.wv v4, v8, v12
+# CHECK-INST: vfwsub.wv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0xda]
 
 vfwsub.wf v4, v8, fa2
-# CHECK-INST: vfwsub.wf v4, v8, fa2
+# CHECK-INST: vfwsub.wf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0xda]
 
 vfwsub.wv v4, v8, v12, v0.t
-# CHECK-INST: vfwsub.wv v4, v8, v12, v0.t
+# CHECK-INST: vfwsub.wv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xd8]
 
 vfwsub.wf v4, v8, fa2, v0.t
-# CHECK-INST: vfwsub.wf v4, v8, fa2, v0.t
+# CHECK-INST: vfwsub.wf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xd8]
 
 vfmul.vv v4, v8, v12
-# CHECK-INST: vfmul.vv v4, v8, v12
+# CHECK-INST: vfmul.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x92]
 
 vfmul.vf v4, v8, fa2
-# CHECK-INST: vfmul.vf v4, v8, fa2
+# CHECK-INST: vfmul.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x92]
 
 vfmul.vv v4, v8, v12, v0.t
-# CHECK-INST: vfmul.vv v4, v8, v12, v0.t
+# CHECK-INST: vfmul.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x90]
 
 vfmul.vf v4, v8, fa2, v0.t
-# CHECK-INST: vfmul.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfmul.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x90]
 
 vfdiv.vv v4, v8, v12
-# CHECK-INST: vfdiv.vv v4, v8, v12
+# CHECK-INST: vfdiv.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x82]
 
 vfdiv.vf v4, v8, fa2
-# CHECK-INST: vfdiv.vf v4, v8, fa2
+# CHECK-INST: vfdiv.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x82]
 
 vfdiv.vv v4, v8, v12, v0.t
-# CHECK-INST: vfdiv.vv v4, v8, v12, v0.t
+# CHECK-INST: vfdiv.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x80]
 
 vfdiv.vf v4, v8, fa2, v0.t
-# CHECK-INST: vfdiv.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfdiv.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x80]
 
 vfrdiv.vf v4, v8, fa2
-# CHECK-INST: vfrdiv.vf v4, v8, fa2
+# CHECK-INST: vfrdiv.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x86]
 
 vfrdiv.vf v4, v8, fa2, v0.t
-# CHECK-INST: vfrdiv.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfrdiv.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x84]
 
 vfwmul.vv v4, v8, v12
-# CHECK-INST: vfwmul.vv v4, v8, v12
+# CHECK-INST: vfwmul.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0xe2]
 
 vfwmul.vf v4, v8, fa2
-# CHECK-INST: vfwmul.vf v4, v8, fa2
+# CHECK-INST: vfwmul.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0xe2]
 
 vfwmul.vv v4, v8, v12, v0.t
-# CHECK-INST: vfwmul.vv v4, v8, v12, v0.t
+# CHECK-INST: vfwmul.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xe0]
 
 vfwmul.vf v4, v8, fa2, v0.t
-# CHECK-INST: vfwmul.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfwmul.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xe0]
 
 vfmadd.vv v4, v12, v8
-# CHECK-INST: vfmadd.vv v4, v12, v8
+# CHECK-INST: vfmadd.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x12,0x86,0xa2]
 
 vfmadd.vf v4, fa2, v8
-# CHECK-INST: vfmadd.vf v4, fa2, v8
+# CHECK-INST: vfmadd.vf	v4, fa2, v8
 # CHECK-ENCODING: [0x57,0x52,0x86,0xa2]
 
 vfnmadd.vv v4, v12, v8
-# CHECK-INST: vfnmadd.vv v4, v12, v8
+# CHECK-INST: vfnmadd.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x12,0x86,0xa6]
 
 vfnmadd.vf v4, fa2, v8
-# CHECK-INST: vfnmadd.vf v4, fa2, v8
+# CHECK-INST: vfnmadd.vf	v4, fa2, v8
 # CHECK-ENCODING: [0x57,0x52,0x86,0xa6]
 
 vfmsub.vv v4, v12, v8
-# CHECK-INST: vfmsub.vv v4, v12, v8
+# CHECK-INST: vfmsub.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x12,0x86,0xaa]
 
 vfmsub.vf v4, fa2, v8
-# CHECK-INST: vfmsub.vf v4, fa2, v8
+# CHECK-INST: vfmsub.vf	v4, fa2, v8
 # CHECK-ENCODING: [0x57,0x52,0x86,0xaa]
 
 vfnmsub.vv v4, v12, v8
-# CHECK-INST: vfnmsub.vv v4, v12, v8
+# CHECK-INST: vfnmsub.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x12,0x86,0xae]
 
 vfnmsub.vf v4, fa2, v8
-# CHECK-INST: vfnmsub.vf v4, fa2, v8
+# CHECK-INST: vfnmsub.vf	v4, fa2, v8
 # CHECK-ENCODING: [0x57,0x52,0x86,0xae]
 
 vfmadd.vv v4, v12, v8, v0.t
-# CHECK-INST: vfmadd.vv v4, v12, v8, v0.t
+# CHECK-INST: vfmadd.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xa0]
 
 vfmadd.vf v4, fa2, v8, v0.t
-# CHECK-INST: vfmadd.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfmadd.vf	v4, fa2, v8, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xa0]
 
 vfnmadd.vv v4, v12, v8, v0.t
-# CHECK-INST: vfnmadd.vv v4, v12, v8, v0.t
+# CHECK-INST: vfnmadd.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xa4]
 
 vfnmadd.vf v4, fa2, v8, v0.t
-# CHECK-INST: vfnmadd.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfnmadd.vf	v4, fa2, v8, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xa4]
 
 vfmsub.vv v4, v12, v8, v0.t
-# CHECK-INST: vfmsub.vv v4, v12, v8, v0.t
+# CHECK-INST: vfmsub.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xa8]
 
 vfmsub.vf v4, fa2, v8, v0.t
-# CHECK-INST: vfmsub.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfmsub.vf	v4, fa2, v8, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xa8]
 
 vfnmsub.vv v4, v12, v8, v0.t
-# CHECK-INST: vfnmsub.vv v4, v12, v8, v0.t
+# CHECK-INST: vfnmsub.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xac]
 
 vfnmsub.vf v4, fa2, v8, v0.t
-# CHECK-INST: vfnmsub.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfnmsub.vf	v4, fa2, v8, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xac]
 
 vfmacc.vv v4, v12, v8
-# CHECK-INST: vfmacc.vv v4, v12, v8
+# CHECK-INST: vfmacc.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x12,0x86,0xb2]
 
 vfmacc.vf v4, fa2, v8
-# CHECK-INST: vfmacc.vf v4, fa2, v8
+# CHECK-INST: vfmacc.vf	v4, fa2, v8
 # CHECK-ENCODING: [0x57,0x52,0x86,0xb2]
 
 vfnmacc.vv v4, v12, v8
-# CHECK-INST: vfnmacc.vv v4, v12, v8
+# CHECK-INST: vfnmacc.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x12,0x86,0xb6]
 
 vfnmacc.vf v4, fa2, v8
-# CHECK-INST: vfnmacc.vf v4, fa2, v8
+# CHECK-INST: vfnmacc.vf	v4, fa2, v8
 # CHECK-ENCODING: [0x57,0x52,0x86,0xb6]
 
 vfmsac.vv v4, v12, v8
-# CHECK-INST: vfmsac.vv v4, v12, v8
+# CHECK-INST: vfmsac.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x12,0x86,0xba]
 
 vfmsac.vf v4, fa2, v8
-# CHECK-INST: vfmsac.vf v4, fa2, v8
+# CHECK-INST: vfmsac.vf	v4, fa2, v8
 # CHECK-ENCODING: [0x57,0x52,0x86,0xba]
 
 vfnmsac.vv v4, v12, v8
-# CHECK-INST: vfnmsac.vv v4, v12, v8
+# CHECK-INST: vfnmsac.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x12,0x86,0xbe]
 
 vfnmsac.vf v4, fa2, v8
-# CHECK-INST: vfnmsac.vf v4, fa2, v8
+# CHECK-INST: vfnmsac.vf	v4, fa2, v8
 # CHECK-ENCODING: [0x57,0x52,0x86,0xbe]
 
 vfmacc.vv v4, v12, v8, v0.t
-# CHECK-INST: vfmacc.vv v4, v12, v8, v0.t
+# CHECK-INST: vfmacc.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xb0]
 
 vfmacc.vf v4, fa2, v8, v0.t
-# CHECK-INST: vfmacc.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfmacc.vf	v4, fa2, v8, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xb0]
 
 vfnmacc.vv v4, v12, v8, v0.t
-# CHECK-INST: vfnmacc.vv v4, v12, v8, v0.t
+# CHECK-INST: vfnmacc.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xb4]
 
 vfnmacc.vf v4, fa2, v8, v0.t
-# CHECK-INST: vfnmacc.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfnmacc.vf	v4, fa2, v8, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xb4]
 
 vfmsac.vv v4, v12, v8, v0.t
-# CHECK-INST: vfmsac.vv v4, v12, v8, v0.t
+# CHECK-INST: vfmsac.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xb8]
 
 vfmsac.vf v4, fa2, v8, v0.t
-# CHECK-INST: vfmsac.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfmsac.vf	v4, fa2, v8, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xb8]
 
 vfnmsac.vv v4, v12, v8, v0.t
-# CHECK-INST: vfnmsac.vv v4, v12, v8, v0.t
+# CHECK-INST: vfnmsac.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xbc]
 
 vfnmsac.vf v4, fa2, v8, v0.t
-# CHECK-INST: vfnmsac.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfnmsac.vf	v4, fa2, v8, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xbc]
 
 vfwmacc.vv v4, v12, v8
-# CHECK-INST: vfwmacc.vv v4, v12, v8
+# CHECK-INST: vfwmacc.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x12,0x86,0xf2]
 
 vfwmacc.vf v4, fa2, v8
-# CHECK-INST: vfwmacc.vf v4, fa2, v8
+# CHECK-INST: vfwmacc.vf	v4, fa2, v8
 # CHECK-ENCODING: [0x57,0x52,0x86,0xf2]
 
 vfwnmacc.vv v4, v12, v8
-# CHECK-INST: vfwnmacc.vv v4, v12, v8
+# CHECK-INST: vfwnmacc.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x12,0x86,0xf6]
 
 vfwnmacc.vf v4, fa2, v8
-# CHECK-INST: vfwnmacc.vf v4, fa2, v8
+# CHECK-INST: vfwnmacc.vf	v4, fa2, v8
 # CHECK-ENCODING: [0x57,0x52,0x86,0xf6]
 
 vfwmsac.vv v4, v12, v8
-# CHECK-INST: vfwmsac.vv v4, v12, v8
+# CHECK-INST: vfwmsac.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x12,0x86,0xfa]
 
 vfwmsac.vf v4, fa2, v8
-# CHECK-INST: vfwmsac.vf v4, fa2, v8
+# CHECK-INST: vfwmsac.vf	v4, fa2, v8
 # CHECK-ENCODING: [0x57,0x52,0x86,0xfa]
 
 vfwnmsac.vv v4, v12, v8
-# CHECK-INST: vfwnmsac.vv v4, v12, v8
+# CHECK-INST: vfwnmsac.vv	v4, v12, v8
 # CHECK-ENCODING: [0x57,0x12,0x86,0xfe]
 
 vfwnmsac.vf v4, fa2, v8
-# CHECK-INST: vfwnmsac.vf v4, fa2, v8
+# CHECK-INST: vfwnmsac.vf	v4, fa2, v8
 # CHECK-ENCODING: [0x57,0x52,0x86,0xfe]
 
 vfwmacc.vv v4, v12, v8, v0.t
-# CHECK-INST: vfwmacc.vv v4, v12, v8, v0.t
+# CHECK-INST: vfwmacc.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xf0]
 
 vfwmacc.vf v4, fa2, v8, v0.t
-# CHECK-INST: vfwmacc.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfwmacc.vf	v4, fa2, v8, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xf0]
 
 vfwnmacc.vv v4, v12, v8, v0.t
-# CHECK-INST: vfwnmacc.vv v4, v12, v8, v0.t
+# CHECK-INST: vfwnmacc.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xf4]
 
 vfwnmacc.vf v4, fa2, v8, v0.t
-# CHECK-INST: vfwnmacc.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfwnmacc.vf	v4, fa2, v8, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xf4]
 
 vfwmsac.vv v4, v12, v8, v0.t
-# CHECK-INST: vfwmsac.vv v4, v12, v8, v0.t
+# CHECK-INST: vfwmsac.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xf8]
 
 vfwmsac.vf v4, fa2, v8, v0.t
-# CHECK-INST: vfwmsac.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfwmsac.vf	v4, fa2, v8, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xf8]
 
 vfwnmsac.vv v4, v12, v8, v0.t
-# CHECK-INST: vfwnmsac.vv v4, v12, v8, v0.t
+# CHECK-INST: vfwnmsac.vv	v4, v12, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xfc]
 
 vfwnmsac.vf v4, fa2, v8, v0.t
-# CHECK-INST: vfwnmsac.vf v4, fa2, v8, v0.t
+# CHECK-INST: vfwnmsac.vf	v4, fa2, v8, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0xfc]
 
 vfsqrt.v v4, v8
-# CHECK-INST: vfsqrt.v v4, v8
+# CHECK-INST: vfsqrt.v	v4, v8
 # CHECK-ENCODING: [0x57,0x12,0x80,0x8e]
 
 vfsqrt.v v4, v8, v0.t
-# CHECK-INST: vfsqrt.v v4, v8, v0.t
+# CHECK-INST: vfsqrt.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x80,0x8c]
 
 vfmin.vv v4, v8, v12
-# CHECK-INST: vfmin.vv v4, v8, v12
+# CHECK-INST: vfmin.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x12]
 
 vfmin.vf v4, v8, fa2
-# CHECK-INST: vfmin.vf v4, v8, fa2
+# CHECK-INST: vfmin.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x12]
 
 vfmax.vv v4, v8, v12
-# CHECK-INST: vfmax.vv v4, v8, v12
+# CHECK-INST: vfmax.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x1a]
 
 vfmax.vf v4, v8, fa2
-# CHECK-INST: vfmax.vf v4, v8, fa2
+# CHECK-INST: vfmax.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x1a]
 
 vfmin.vv v4, v8, v12, v0.t
-# CHECK-INST: vfmin.vv v4, v8, v12, v0.t
+# CHECK-INST: vfmin.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x10]
 
 vfmin.vf v4, v8, fa2, v0.t
-# CHECK-INST: vfmin.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfmin.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x10]
 
 vfmax.vv v4, v8, v12, v0.t
-# CHECK-INST: vfmax.vv v4, v8, v12, v0.t
+# CHECK-INST: vfmax.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x18]
 
 vfmax.vf v4, v8, fa2, v0.t
-# CHECK-INST: vfmax.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfmax.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x18]
 
 vfsgnj.vv v4, v8, v12
-# CHECK-INST: vfsgnj.vv v4, v8, v12
+# CHECK-INST: vfsgnj.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x22]
 
 vfsgnj.vf v4, v8, fa2
-# CHECK-INST: vfsgnj.vf v4, v8, fa2
+# CHECK-INST: vfsgnj.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x22]
 
 vfsgnjn.vv v4, v8, v12
-# CHECK-INST: vfsgnjn.vv v4, v8, v12
+# CHECK-INST: vfsgnjn.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x26]
 
 vfsgnjn.vf v4, v8, fa2
-# CHECK-INST: vfsgnjn.vf v4, v8, fa2
+# CHECK-INST: vfsgnjn.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x26]
 
 vfsgnjx.vv v4, v8, v12
-# CHECK-INST: vfsgnjx.vv v4, v8, v12
+# CHECK-INST: vfsgnjx.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x2a]
 
 vfsgnjx.vf v4, v8, fa2
-# CHECK-INST: vfsgnjx.vf v4, v8, fa2
+# CHECK-INST: vfsgnjx.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x2a]
 
 vfsgnj.vv v4, v8, v12, v0.t
-# CHECK-INST: vfsgnj.vv v4, v8, v12, v0.t
+# CHECK-INST: vfsgnj.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x20]
 
 vfsgnj.vf v4, v8, fa2, v0.t
-# CHECK-INST: vfsgnj.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfsgnj.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x20]
 
 vfsgnjn.vv v4, v8, v12, v0.t
-# CHECK-INST: vfsgnjn.vv v4, v8, v12, v0.t
+# CHECK-INST: vfsgnjn.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x24]
 
 vfsgnjn.vf v4, v8, fa2, v0.t
-# CHECK-INST: vfsgnjn.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfsgnjn.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x24]
 
 vfsgnjx.vv v4, v8, v12, v0.t
-# CHECK-INST: vfsgnjx.vv v4, v8, v12, v0.t
+# CHECK-INST: vfsgnjx.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x28]
 
 vfsgnjx.vf v4, v8, fa2, v0.t
-# CHECK-INST: vfsgnjx.vf v4, v8, fa2, v0.t
+# CHECK-INST: vfsgnjx.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x28]
 
 # TODO: rvv 0.7.1
-# Aliases
 # vmfgt.vv v4, v8, v12
 # CHECK-INST-TODO: vmfgt.vv v4, v8, v12
 # CHECK-ENCODING-TODO: [0x57,0x12,0xc4,0x6e]
@@ -6341,359 +6328,358 @@ vfsgnjx.vf v4, v8, fa2, v0.t
 # CHECK-ENCODING-TODO: [0x57,0x12,0xc4,0x64]
 
 vmfeq.vv v4, v8, v12
-# CHECK-INST: vmfeq.vv v4, v8, v12
+# CHECK-INST: vmfeq.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x62]
 
 vmfeq.vf v4, v8, fa2
-# CHECK-INST: vmfeq.vf v4, v8, fa2
+# CHECK-INST: vmfeq.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x62]
 
 vmfne.vv v4, v8, v12
-# CHECK-INST: vmfne.vv v4, v8, v12
+# CHECK-INST: vmfne.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x72]
 
 vmfne.vf v4, v8, fa2
-# CHECK-INST: vmfne.vf v4, v8, fa2
+# CHECK-INST: vmfne.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x72]
 
 vmflt.vv v4, v8, v12
-# CHECK-INST: vmflt.vv v4, v8, v12
+# CHECK-INST: vmflt.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x6e]
 
 vmflt.vf v4, v8, fa2
-# CHECK-INST: vmflt.vf v4, v8, fa2
+# CHECK-INST: vmflt.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x6e]
 
 vmfle.vv v4, v8, v12
-# CHECK-INST: vmfle.vv v4, v8, v12
+# CHECK-INST: vmfle.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x66]
 
 vmfle.vf v4, v8, fa2
-# CHECK-INST: vmfle.vf v4, v8, fa2
+# CHECK-INST: vmfle.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x66]
 
 vmfgt.vf v4, v8, fa2
-# CHECK-INST: vmfgt.vf v4, v8, fa2
+# CHECK-INST: vmfgt.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x76]
 
 vmfge.vf v4, v8, fa2
-# CHECK-INST: vmfge.vf v4, v8, fa2
+# CHECK-INST: vmfge.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x7e]
 
 vmfeq.vv v4, v8, v12, v0.t
-# CHECK-INST: vmfeq.vv v4, v8, v12, v0.t
+# CHECK-INST: vmfeq.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x60]
 
 vmfeq.vf v4, v8, fa2, v0.t
-# CHECK-INST: vmfeq.vf v4, v8, fa2, v0.t
+# CHECK-INST: vmfeq.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x60]
 
 vmfne.vv v4, v8, v12, v0.t
-# CHECK-INST: vmfne.vv v4, v8, v12, v0.t
+# CHECK-INST: vmfne.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x70]
 
 vmfne.vf v4, v8, fa2, v0.t
-# CHECK-INST: vmfne.vf v4, v8, fa2, v0.t
+# CHECK-INST: vmfne.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x70]
 
 vmflt.vv v4, v8, v12, v0.t
-# CHECK-INST: vmflt.vv v4, v8, v12, v0.t
+# CHECK-INST: vmflt.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x6c]
 
 vmflt.vf v4, v8, fa2, v0.t
-# CHECK-INST: vmflt.vf v4, v8, fa2, v0.t
+# CHECK-INST: vmflt.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x6c]
 
 vmfle.vv v4, v8, v12, v0.t
-# CHECK-INST: vmfle.vv v4, v8, v12, v0.t
+# CHECK-INST: vmfle.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x64]
 
 vmfle.vf v4, v8, fa2, v0.t
-# CHECK-INST: vmfle.vf v4, v8, fa2, v0.t
+# CHECK-INST: vmfle.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x64]
 
 vmfgt.vf v4, v8, fa2, v0.t
-# CHECK-INST: vmfgt.vf v4, v8, fa2, v0.t
+# CHECK-INST: vmfgt.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x74]
 
 vmfge.vf v4, v8, fa2, v0.t
-# CHECK-INST: vmfge.vf v4, v8, fa2, v0.t
+# CHECK-INST: vmfge.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x7c]
 
 vmford.vv v4, v8, v12
-# CHECK-INST: vmford.vv v4, v8, v12
+# CHECK-INST: vmford.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x6a]
 
 vmford.vf v4, v8, fa2
-# CHECK-INST: vmford.vf v4, v8, fa2
+# CHECK-INST: vmford.vf	v4, v8, fa2
 # CHECK-ENCODING: [0x57,0x52,0x86,0x6a]
 
 vmford.vv v4, v8, v12, v0.t
-# CHECK-INST: vmford.vv v4, v8, v12, v0.t
+# CHECK-INST: vmford.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x68]
 
 vmford.vf v4, v8, fa2, v0.t
-# CHECK-INST: vmford.vf v4, v8, fa2, v0.t
+# CHECK-INST: vmford.vf	v4, v8, fa2, v0.t
 # CHECK-ENCODING: [0x57,0x52,0x86,0x68]
 
 vfclass.v v4, v8
-# CHECK-INST: vfclass.v v4, v8
+# CHECK-INST: vfclass.v	v4, v8
 # CHECK-ENCODING: [0x57,0x12,0x88,0x8e]
 
 vfclass.v v4, v8, v0.t
-# CHECK-INST: vfclass.v v4, v8, v0.t
+# CHECK-INST: vfclass.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x88,0x8c]
 
 vfmerge.vfm v4, v8, fa2, v0
-# CHECK-INST: vfmerge.vfm v4, v8, fa2, v0
+# CHECK-INST: vfmerge.vfm	v4, v8, fa2, v0
 # CHECK-ENCODING: [0x57,0x52,0x86,0x5c]
 
 vfmv.v.f v4, fa1
-# CHECK-INST: vfmv.v.f v4, fa1
+# CHECK-INST: vfmv.v.f	v4, fa1
 # CHECK-ENCODING: [0x57,0xd2,0x05,0x5e]
 
 vfcvt.xu.f.v v4, v8
-# CHECK-INST: vfcvt.xu.f.v v4, v8
+# CHECK-INST: vfcvt.xu.f.v	v4, v8
 # CHECK-ENCODING: [0x57,0x12,0x80,0x8a]
 
 vfcvt.x.f.v v4, v8
-# CHECK-INST: vfcvt.x.f.v v4, v8
+# CHECK-INST: vfcvt.x.f.v	v4, v8
 # CHECK-ENCODING: [0x57,0x92,0x80,0x8a]
 
 vfcvt.f.xu.v v4, v8
-# CHECK-INST: vfcvt.f.xu.v v4, v8
+# CHECK-INST: vfcvt.f.xu.v	v4, v8
 # CHECK-ENCODING: [0x57,0x12,0x81,0x8a]
 
 vfcvt.f.x.v v4, v8
-# CHECK-INST: vfcvt.f.x.v v4, v8
+# CHECK-INST: vfcvt.f.x.v	v4, v8
 # CHECK-ENCODING: [0x57,0x92,0x81,0x8a]
 
 vfcvt.xu.f.v v4, v8, v0.t
-# CHECK-INST: vfcvt.xu.f.v v4, v8, v0.t
+# CHECK-INST: vfcvt.xu.f.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x80,0x88]
 
 vfcvt.x.f.v v4, v8, v0.t
-# CHECK-INST: vfcvt.x.f.v v4, v8, v0.t
+# CHECK-INST: vfcvt.x.f.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x92,0x80,0x88]
 
 vfcvt.f.xu.v v4, v8, v0.t
-# CHECK-INST: vfcvt.f.xu.v v4, v8, v0.t
+# CHECK-INST: vfcvt.f.xu.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x81,0x88]
 
 vfcvt.f.x.v v4, v8, v0.t
-# CHECK-INST: vfcvt.f.x.v v4, v8, v0.t
+# CHECK-INST: vfcvt.f.x.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x92,0x81,0x88]
 
 vfwcvt.xu.f.v v4, v8
-# CHECK-INST: vfwcvt.xu.f.v v4, v8
+# CHECK-INST: vfwcvt.xu.f.v	v4, v8
 # CHECK-ENCODING: [0x57,0x12,0x84,0x8a]
 
 vfwcvt.x.f.v v4, v8
-# CHECK-INST: vfwcvt.x.f.v v4, v8
+# CHECK-INST: vfwcvt.x.f.v	v4, v8
 # CHECK-ENCODING: [0x57,0x92,0x84,0x8a]
 
 vfwcvt.f.xu.v v4, v8
-# CHECK-INST: vfwcvt.f.xu.v v4, v8
+# CHECK-INST: vfwcvt.f.xu.v	v4, v8
 # CHECK-ENCODING: [0x57,0x12,0x85,0x8a]
 
 vfwcvt.f.x.v v4, v8
-# CHECK-INST: vfwcvt.f.x.v v4, v8
+# CHECK-INST: vfwcvt.f.x.v	v4, v8
 # CHECK-ENCODING: [0x57,0x92,0x85,0x8a]
 
 vfwcvt.f.f.v v4, v8
-# CHECK-INST: vfwcvt.f.f.v v4, v8
+# CHECK-INST: vfwcvt.f.f.v	v4, v8
 # CHECK-ENCODING: [0x57,0x12,0x86,0x8a]
 
 vfwcvt.xu.f.v v4, v8, v0.t
-# CHECK-INST: vfwcvt.xu.f.v v4, v8, v0.t
+# CHECK-INST: vfwcvt.xu.f.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x84,0x88]
 
 vfwcvt.x.f.v v4, v8, v0.t
-# CHECK-INST: vfwcvt.x.f.v v4, v8, v0.t
+# CHECK-INST: vfwcvt.x.f.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x92,0x84,0x88]
 
 vfwcvt.f.xu.v v4, v8, v0.t
-# CHECK-INST: vfwcvt.f.xu.v v4, v8, v0.t
+# CHECK-INST: vfwcvt.f.xu.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x85,0x88]
 
 vfwcvt.f.x.v v4, v8, v0.t
-# CHECK-INST: vfwcvt.f.x.v v4, v8, v0.t
+# CHECK-INST: vfwcvt.f.x.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x92,0x85,0x88]
 
 vfwcvt.f.f.v v4, v8, v0.t
-# CHECK-INST: vfwcvt.f.f.v v4, v8, v0.t
+# CHECK-INST: vfwcvt.f.f.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x88]
 
 vfncvt.xu.f.v v4, v8
-# CHECK-INST: vfncvt.xu.f.v v4, v8
+# CHECK-INST: vfncvt.xu.f.v	v4, v8
 # CHECK-ENCODING: [0x57,0x12,0x88,0x8a]
 
 vfncvt.x.f.v v4, v8
-# CHECK-INST: vfncvt.x.f.v v4, v8
+# CHECK-INST: vfncvt.x.f.v	v4, v8
 # CHECK-ENCODING: [0x57,0x92,0x88,0x8a]
 
 vfncvt.f.xu.v v4, v8
-# CHECK-INST: vfncvt.f.xu.v v4, v8
+# CHECK-INST: vfncvt.f.xu.v	v4, v8
 # CHECK-ENCODING: [0x57,0x12,0x89,0x8a]
 
 vfncvt.f.x.v v4, v8
-# CHECK-INST: vfncvt.f.x.v v4, v8
+# CHECK-INST: vfncvt.f.x.v	v4, v8
 # CHECK-ENCODING: [0x57,0x92,0x89,0x8a]
 
 vfncvt.f.f.v v4, v8
-# CHECK-INST: vfncvt.f.f.v v4, v8
+# CHECK-INST: vfncvt.f.f.v	v4, v8
 # CHECK-ENCODING: [0x57,0x12,0x8a,0x8a]
 
 vfncvt.xu.f.v v4, v8, v0.t
-# CHECK-INST: vfncvt.xu.f.v v4, v8, v0.t
+# CHECK-INST: vfncvt.xu.f.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x88,0x88]
 
 vfncvt.x.f.v v4, v8, v0.t
-# CHECK-INST: vfncvt.x.f.v v4, v8, v0.t
+# CHECK-INST: vfncvt.x.f.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x92,0x88,0x88]
 
 vfncvt.f.xu.v v4, v8, v0.t
-# CHECK-INST: vfncvt.f.xu.v v4, v8, v0.t
+# CHECK-INST: vfncvt.f.xu.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x89,0x88]
 
 vfncvt.f.x.v v4, v8, v0.t
-# CHECK-INST: vfncvt.f.x.v v4, v8, v0.t
+# CHECK-INST: vfncvt.f.x.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x92,0x89,0x88]
 
 vfncvt.f.f.v v4, v8, v0.t
-# CHECK-INST: vfncvt.f.f.v v4, v8, v0.t
+# CHECK-INST: vfncvt.f.f.v	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x8a,0x88]
 
 vredsum.vs v4, v8, v12
-# CHECK-INST: vredsum.vs v4, v8, v12
+# CHECK-INST: vredsum.vs	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x02]
 
 vredmaxu.vs v4, v8, v8
-# CHECK-INST: vredmaxu.vs v4, v8, v8
+# CHECK-INST: vredmaxu.vs	v4, v8, v8
 # CHECK-ENCODING: [0x57,0x22,0x84,0x1a]
 
 vredmax.vs v4, v8, v8
-# CHECK-INST: vredmax.vs v4, v8, v8
+# CHECK-INST: vredmax.vs	v4, v8, v8
 # CHECK-ENCODING: [0x57,0x22,0x84,0x1e]
 
 vredminu.vs v4, v8, v8
-# CHECK-INST: vredminu.vs v4, v8, v8
+# CHECK-INST: vredminu.vs	v4, v8, v8
 # CHECK-ENCODING: [0x57,0x22,0x84,0x12]
 
 vredmin.vs v4, v8, v8
-# CHECK-INST: vredmin.vs v4, v8, v8
+# CHECK-INST: vredmin.vs	v4, v8, v8
 # CHECK-ENCODING: [0x57,0x22,0x84,0x16]
 
 vredand.vs v4, v8, v12
-# CHECK-INST: vredand.vs v4, v8, v12
+# CHECK-INST: vredand.vs	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x06]
 
 vredor.vs v4, v8, v12
-# CHECK-INST: vredor.vs v4, v8, v12
+# CHECK-INST: vredor.vs	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x0a]
 
 vredxor.vs v4, v8, v12
-# CHECK-INST: vredxor.vs v4, v8, v12
+# CHECK-INST: vredxor.vs	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x0e]
 
 vredsum.vs v4, v8, v12, v0.t
-# CHECK-INST: vredsum.vs v4, v8, v12, v0.t
+# CHECK-INST: vredsum.vs	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0x00]
 
 vredmaxu.vs v4, v8, v8, v0.t
-# CHECK-INST: vredmaxu.vs v4, v8, v8, v0.t
+# CHECK-INST: vredmaxu.vs	v4, v8, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x84,0x18]
 
 vredmax.vs v4, v8, v8, v0.t
-# CHECK-INST: vredmax.vs v4, v8, v8, v0.t
+# CHECK-INST: vredmax.vs	v4, v8, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x84,0x1c]
 
 vredminu.vs v4, v8, v8, v0.t
-# CHECK-INST: vredminu.vs v4, v8, v8, v0.t
+# CHECK-INST: vredminu.vs	v4, v8, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x84,0x10]
 
 vredmin.vs v4, v8, v8, v0.t
-# CHECK-INST: vredmin.vs v4, v8, v8, v0.t
+# CHECK-INST: vredmin.vs	v4, v8, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x84,0x14]
 
 vredand.vs v4, v8, v12, v0.t
-# CHECK-INST: vredand.vs v4, v8, v12, v0.t
+# CHECK-INST: vredand.vs	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0x04]
 
 vredor.vs v4, v8, v12, v0.t
-# CHECK-INST: vredor.vs v4, v8, v12, v0.t
+# CHECK-INST: vredor.vs	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0x08]
 
 vredxor.vs v4, v8, v12, v0.t
-# CHECK-INST: vredxor.vs v4, v8, v12, v0.t
+# CHECK-INST: vredxor.vs	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x86,0x0c]
 
 vwredsumu.vs v4, v8, v12
-# CHECK-INST: vwredsumu.vs v4, v8, v12
+# CHECK-INST: vwredsumu.vs	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0xc2]
 
 vwredsum.vs v4, v8, v12
-# CHECK-INST: vwredsum.vs v4, v8, v12
+# CHECK-INST: vwredsum.vs	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0xc6]
 
 vwredsumu.vs v4, v8, v12, v0.t
-# CHECK-INST: vwredsumu.vs v4, v8, v12, v0.t
+# CHECK-INST: vwredsumu.vs	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0xc0]
 
 vwredsum.vs v4, v8, v12, v0.t
-# CHECK-INST: vwredsum.vs v4, v8, v12, v0.t
+# CHECK-INST: vwredsum.vs	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0xc4]
 
 vfredosum.vs v4, v8, v12
-# CHECK-INST: vfredosum.vs v4, v8, v12
+# CHECK-INST: vfredosum.vs	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x0e]
 
 vfredsum.vs v4, v8, v12
-# CHECK-INST: vfredsum.vs v4, v8, v12
+# CHECK-INST: vfredsum.vs	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x06]
 
 vfredmax.vs v4, v8, v12
-# CHECK-INST: vfredmax.vs v4, v8, v12
+# CHECK-INST: vfredmax.vs	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x1e]
 
 vfredmin.vs v4, v8, v12
-# CHECK-INST: vfredmin.vs v4, v8, v12
+# CHECK-INST: vfredmin.vs	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0x16]
 
 vfredosum.vs v4, v8, v12, v0.t
-# CHECK-INST: vfredosum.vs v4, v8, v12, v0.t
+# CHECK-INST: vfredosum.vs	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x0c]
 
 vfredsum.vs v4, v8, v12, v0.t
-# CHECK-INST: vfredsum.vs v4, v8, v12, v0.t
+# CHECK-INST: vfredsum.vs	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x04]
 
 vfredmax.vs v4, v8, v12, v0.t
-# CHECK-INST: vfredmax.vs v4, v8, v12, v0.t
+# CHECK-INST: vfredmax.vs	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x1c]
 
 vfredmin.vs v4, v8, v12, v0.t
-# CHECK-INST: vfredmin.vs v4, v8, v12, v0.t
+# CHECK-INST: vfredmin.vs	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0x14]
 
 vfwredosum.vs v4, v8, v12
-# CHECK-INST: vfwredosum.vs v4, v8, v12
+# CHECK-INST: vfwredosum.vs	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0xce]
 
 vfwredsum.vs v4, v8, v12
-# CHECK-INST: vfwredsum.vs v4, v8, v12
+# CHECK-INST: vfwredsum.vs	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x12,0x86,0xc6]
 
 vfwredosum.vs v4, v8, v12, v0.t
-# CHECK-INST: vfwredosum.vs v4, v8, v12, v0.t
+# CHECK-INST: vfwredosum.vs	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xcc]
 
 vfwredsum.vs v4, v8, v12, v0.t
-# CHECK-INST: vfwredsum.vs v4, v8, v12, v0.t
+# CHECK-INST: vfwredsum.vs	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x12,0x86,0xc4]
 
 # TODO: rvv 0.7.1
-# Aliases
 # vmcpy.m v4, v8
 # CHECK-INST-TODO: vmcpy.m v4, v8
 # CHECK-ENCODING-TODO: [0x57,0x22,0x84,0x66]
@@ -6714,231 +6700,260 @@ vfwredsum.vs v4, v8, v12, v0.t
 # CHECK-ENCODING-TODO: [0x57,0x22,0x84,0x76]
 
 vmand.mm v4, v8, v12
-# CHECK-INST: vmand.mm v4, v8, v12
+# CHECK-INST: vmand.mm	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x66]
 
 vmnand.mm v4, v8, v12
-# CHECK-INST: vmnand.mm v4, v8, v12
+# CHECK-INST: vmnand.mm	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x76]
 
 vmandnot.mm v4, v8, v12
-# CHECK-INST: vmandnot.mm v4, v8, v12
+# CHECK-INST: vmandnot.mm	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x62]
 
 vmxor.mm v4, v8, v12
-# CHECK-INST: vmxor.mm v4, v8, v12
+# CHECK-INST: vmxor.mm	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x6e]
 
 vmor.mm v4, v8, v12
-# CHECK-INST: vmor.mm v4, v8, v12
+# CHECK-INST: vmor.mm	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x6a]
 
 vmnor.mm v4, v8, v12
-# CHECK-INST: vmnor.mm v4, v8, v12
+# CHECK-INST: vmnor.mm	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x7a]
 
 vmornot.mm v4, v8, v12
-# CHECK-INST: vmornot.mm v4, v8, v12
+# CHECK-INST: vmornot.mm	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x72]
 
 vmxnor.mm v4, v8, v12
-# CHECK-INST: vmxnor.mm v4, v8, v12
+# CHECK-INST: vmxnor.mm	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x7e]
 
 vmpopc.m a0, v12
-# CHECK-INST: vmpopc.m a0, v12
+# CHECK-INST: vmpopc.m	a0, v12
 # CHECK-ENCODING: [0x57,0x25,0xc0,0x52]
 
 vmfirst.m a0, v12
-# CHECK-INST: vmfirst.m a0, v12
+# CHECK-INST: vmfirst.m	a0, v12
 # CHECK-ENCODING: [0x57,0x25,0xc0,0x56]
 
 vmsbf.m v4, v8
-# CHECK-INST: vmsbf.m v4, v8
+# CHECK-INST: vmsbf.m	v4, v8
 # CHECK-ENCODING: [0x57,0xa2,0x80,0x5a]
 
 vmsif.m v4, v8
-# CHECK-INST: vmsif.m v4, v8
+# CHECK-INST: vmsif.m	v4, v8
 # CHECK-ENCODING: [0x57,0xa2,0x81,0x5a]
 
 vmsof.m v4, v8
-# CHECK-INST: vmsof.m v4, v8
+# CHECK-INST: vmsof.m	v4, v8
 # CHECK-ENCODING: [0x57,0x22,0x81,0x5a]
 
 viota.m v4, v8
-# CHECK-INST: viota.m v4, v8
+# CHECK-INST: viota.m	v4, v8
 # CHECK-ENCODING: [0x57,0x22,0x88,0x5a]
 
 vid.v v4
-# CHECK-INST: vid.v v4
+# CHECK-INST: vid.v	v4
 # CHECK-ENCODING: [0x57,0xa2,0x08,0x5a]
 
 vmpopc.m a0, v12, v0.t
-# CHECK-INST: vmpopc.m a0, v12, v0.t
+# CHECK-INST: vmpopc.m	a0, v12, v0.t
 # CHECK-ENCODING: [0x57,0x25,0xc0,0x50]
 
 vmfirst.m a0, v12, v0.t
-# CHECK-INST: vmfirst.m a0, v12, v0.t
+# CHECK-INST: vmfirst.m	a0, v12, v0.t
 # CHECK-ENCODING: [0x57,0x25,0xc0,0x54]
 
 vmsbf.m v4, v8, v0.t
-# CHECK-INST: vmsbf.m v4, v8, v0.t
+# CHECK-INST: vmsbf.m	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0xa2,0x80,0x58]
 
 vmsif.m v4, v8, v0.t
-# CHECK-INST: vmsif.m v4, v8, v0.t
+# CHECK-INST: vmsif.m	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0xa2,0x81,0x58]
 
 vmsof.m v4, v8, v0.t
-# CHECK-INST: vmsof.m v4, v8, v0.t
+# CHECK-INST: vmsof.m	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x81,0x58]
 
 viota.m v4, v8, v0.t
-# CHECK-INST: viota.m v4, v8, v0.t
+# CHECK-INST: viota.m	v4, v8, v0.t
 # CHECK-ENCODING: [0x57,0x22,0x88,0x58]
 
 vid.v v4, v0.t
-# CHECK-INST: vid.v v4, v0.t
+# CHECK-INST: vid.v	v4, v0.t
 # CHECK-ENCODING: [0x57,0xa2,0x08,0x58]
 
 # TODO: rvv 0.7.1
-# Alias
 # vmv.x.s a0, v12
 # CHECK-INST-TODO: vmv.x.s a0, v12
 # CHECK-ENCODING-TODO: [0x57,0x25,0xc0,0x32]
 
 vext.x.v a0, v12, a2
-# CHECK-INST: vext.x.v a0, v12, a2
+# CHECK-INST: vext.x.v	a0, v12, a2
 # CHECK-ENCODING: [0x57,0x25,0xc6,0x32]
 
 vmv.s.x v4, a0
-# CHECK-INST: vmv.s.x v4, a0
+# CHECK-INST: vmv.s.x	v4, a0
 # CHECK-ENCODING: [0x57,0x62,0x05,0x36]
 
 vfmv.f.s fa0, v8
-# CHECK-INST: vfmv.f.s fa0, v8
+# CHECK-INST: vfmv.f.s	fa0, v8
 # CHECK-ENCODING: [0x57,0x15,0x80,0x32]
 
 vfmv.s.f v4, fa1
-# CHECK-INST: vfmv.s.f v4, fa1
+# CHECK-INST: vfmv.s.f	v4, fa1
 # CHECK-ENCODING: [0x57,0xd2,0x05,0x36]
 
 vslideup.vx v4, v8, a1
-# CHECK-INST: vslideup.vx v4, v8, a1
+# CHECK-INST: vslideup.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x3a]
 
 vslideup.vi v4, v8, 0
-# CHECK-INST: vslideup.vi v4, v8, 0
+# CHECK-INST: vslideup.vi	v4, v8, 0
 # CHECK-ENCODING: [0x57,0x32,0x80,0x3a]
 
 vslideup.vi v4, v8, 31
-# CHECK-INST: vslideup.vi v4, v8, 31
+# CHECK-INST: vslideup.vi	v4, v8, 31
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0x3a]
 
 vslidedown.vx v4, v8, a1
-# CHECK-INST: vslidedown.vx v4, v8, a1
+# CHECK-INST: vslidedown.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x3e]
 
 vslidedown.vi v4, v8, 0
-# CHECK-INST: vslidedown.vi v4, v8, 0
+# CHECK-INST: vslidedown.vi	v4, v8, 0
 # CHECK-ENCODING: [0x57,0x32,0x80,0x3e]
 
 vslidedown.vi v4, v8, 31
-# CHECK-INST: vslidedown.vi v4, v8, 31
+# CHECK-INST: vslidedown.vi	v4, v8, 31
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0x3e]
 
 vslideup.vx v4, v8, a1, v0.t
-# CHECK-INST: vslideup.vx v4, v8, a1, v0.t
+# CHECK-INST: vslideup.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x38]
 
 vslideup.vi v4, v8, 0, v0.t
-# CHECK-INST: vslideup.vi v4, v8, 0, v0.t
+# CHECK-INST: vslideup.vi	v4, v8, 0, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x80,0x38]
 
 vslideup.vi v4, v8, 31, v0.t
-# CHECK-INST: vslideup.vi v4, v8, 31, v0.t
+# CHECK-INST: vslideup.vi	v4, v8, 31, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0x38]
 
 vslidedown.vx v4, v8, a1, v0.t
-# CHECK-INST: vslidedown.vx v4, v8, a1, v0.t
+# CHECK-INST: vslidedown.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x3c]
 
 vslidedown.vi v4, v8, 0, v0.t
-# CHECK-INST: vslidedown.vi v4, v8, 0, v0.t
+# CHECK-INST: vslidedown.vi	v4, v8, 0, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x80,0x3c]
 
 vslidedown.vi v4, v8, 31, v0.t
-# CHECK-INST: vslidedown.vi v4, v8, 31, v0.t
+# CHECK-INST: vslidedown.vi	v4, v8, 31, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0x3c]
 
 vslide1up.vx v4, v8, a1
-# CHECK-INST: vslide1up.vx v4, v8, a1
+# CHECK-INST: vslide1up.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x3a]
 
 vslide1down.vx v4, v8, a1
-# CHECK-INST: vslide1down.vx v4, v8, a1
+# CHECK-INST: vslide1down.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x3e]
 
 vslide1up.vx v4, v8, a1, v0.t
-# CHECK-INST: vslide1up.vx v4, v8, a1, v0.t
+# CHECK-INST: vslide1up.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x38]
 
 vslide1down.vx v4, v8, a1, v0.t
-# CHECK-INST: vslide1down.vx v4, v8, a1, v0.t
+# CHECK-INST: vslide1down.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xe2,0x85,0x3c]
 
 vrgather.vv v4, v8, v12
-# CHECK-INST: vrgather.vv v4, v8, v12
+# CHECK-INST: vrgather.vv	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x02,0x86,0x32]
 
 vrgather.vx v4, v8, a1
-# CHECK-INST: vrgather.vx v4, v8, a1
+# CHECK-INST: vrgather.vx	v4, v8, a1
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x32]
 
 vrgather.vi v4, v8, 0
-# CHECK-INST: vrgather.vi v4, v8, 0
+# CHECK-INST: vrgather.vi	v4, v8, 0
 # CHECK-ENCODING: [0x57,0x32,0x80,0x32]
 
 vrgather.vi v4, v8, 31
-# CHECK-INST: vrgather.vi v4, v8, 31
+# CHECK-INST: vrgather.vi	v4, v8, 31
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0x32]
 
 vrgather.vv v4, v8, v12, v0.t
-# CHECK-INST: vrgather.vv v4, v8, v12, v0.t
+# CHECK-INST: vrgather.vv	v4, v8, v12, v0.t
 # CHECK-ENCODING: [0x57,0x02,0x86,0x30]
 
 vrgather.vx v4, v8, a1, v0.t
-# CHECK-INST: vrgather.vx v4, v8, a1, v0.t
+# CHECK-INST: vrgather.vx	v4, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc2,0x85,0x30]
 
 vrgather.vi v4, v8, 0, v0.t
-# CHECK-INST: vrgather.vi v4, v8, 0, v0.t
+# CHECK-INST: vrgather.vi	v4, v8, 0, v0.t
 # CHECK-ENCODING: [0x57,0x32,0x80,0x30]
 
 vrgather.vi v4, v8, 31, v0.t
-# CHECK-INST: vrgather.vi v4, v8, 31, v0.t
+# CHECK-INST: vrgather.vi	v4, v8, 31, v0.t
 # CHECK-ENCODING: [0x57,0xb2,0x8f,0x30]
 
 vcompress.vm v4, v8, v12
-# CHECK-INST: vcompress.vm v4, v8, v12
+# CHECK-INST: vcompress.vm	v4, v8, v12
 # CHECK-ENCODING: [0x57,0x22,0x86,0x5e]
 
+# TODO: rvv 0.7.1
+# vdot.vv v4, v8, v12
+# CHECK-INST-TODO: vdot.vv v4, v8, v12
+# CHECK-ENCODING-TODO: [0x57,0x02,0x86,0xe6]
+
+# TODO: rvv 0.7.1
+# vdotu.vv v4, v8, v12
+# CHECK-INST-TODO: vdotu.vv v4, v8, v12
+# CHECK-ENCODING-TODO: [0x57,0x02,0x86,0xe2]
+
+# TODO: rvv 0.7.1
+# vfdot.vv v4, v8, v12
+# CHECK-INST-TODO: vfdot.vv v4, v8, v12
+# CHECK-ENCODING-TODO: [0x57,0x12,0x86,0xe6]
+
+# TODO: rvv 0.7.1
+# vdot.vv v4, v8, v12, v0.t
+# CHECK-INST-TODO: vdot.vv v4, v8, v12, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x02,0x86,0xe4]
+
+# TODO: rvv 0.7.1
+# vdotu.vv v4, v8, v12, v0.t
+# CHECK-INST-TODO: vdotu.vv v4, v8, v12, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x02,0x86,0xe0]
+
+# TODO: rvv 0.7.1
+# vfdot.vv v4, v8, v12, v0.t
+# CHECK-INST-TODO: vfdot.vv v4, v8, v12, v0.t
+# CHECK-ENCODING-TODO: [0x57,0x12,0x86,0xe4]
+
 csrr a0, vstart
-# CHECK-INST: csrr a0, vstart
+# CHECK-INST: csrr	a0, vstart
 # CHECK-ENCODING: [0x73,0x25,0x80,0x00]
 
 csrr a0, vxsat
-# CHECK-INST: csrr a0, vxsat
+# CHECK-INST: csrr	a0, vxsat
 # CHECK-ENCODING: [0x73,0x25,0x90,0x00]
 
 csrr a0, vxrm
-# CHECK-INST: csrr a0, vxrm
+# CHECK-INST: csrr	a0, vxrm
 # CHECK-ENCODING: [0x73,0x25,0xa0,0x00]
 
 csrr a0, vl
-# CHECK-INST: csrr a0, vl
+# CHECK-INST: csrr	a0, vl
 # CHECK-ENCODING: [0x73,0x25,0x00,0xc2]
 
 csrr a0, vtype
-# CHECK-INST: csrr a0, vtype
+# CHECK-INST: csrr	a0, vtype
 # CHECK-ENCODING: [0x73,0x25,0x10,0xc2]

--- a/llvm/test/MC/RISCV/rvv0p71/vector-insns.s
+++ b/llvm/test/MC/RISCV/rvv0p71/vector-insns.s
@@ -1,0 +1,1821 @@
+# Adapted from https://github.com/riscvarchive/riscv-binutils-gdb/blob/1aeeeab05f3c39e2bfc6e99384490d4c7f484ba0/gas/testsuite/gas/riscv/vector-insns.s
+
+# RUN: llvm-mc -triple=riscv64 -show-encoding --mattr=+f,+a,+xtheadv,+xtheadvlsseg,+xtheadvamo %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+
+vsetvl a0, a1, a2
+vsetvli a0, a1, 0
+vsetvli a0, a1, 0x7ff
+vsetvli a0, a1, e16,m2,d4
+
+vlb.v v4, (a0)
+vlb.v v4, 0(a0)
+vlb.v v4, (a0), v0.t
+vlh.v v4, (a0)
+vlh.v v4, 0(a0)
+vlh.v v4, (a0), v0.t
+vlw.v v4, (a0)
+vlw.v v4, 0(a0)
+vlw.v v4, (a0), v0.t
+vlbu.v v4, (a0)
+vlbu.v v4, 0(a0)
+vlbu.v v4, (a0), v0.t
+vlhu.v v4, (a0)
+vlhu.v v4, 0(a0)
+vlhu.v v4, (a0), v0.t
+vlwu.v v4, (a0)
+vlwu.v v4, 0(a0)
+vlwu.v v4, (a0), v0.t
+vle.v v4, (a0)
+vle.v v4, 0(a0)
+vle.v v4, (a0), v0.t
+vsb.v v4, (a0)
+vsb.v v4, 0(a0)
+vsb.v v4, (a0), v0.t
+vsh.v v4, (a0)
+vsh.v v4, 0(a0)
+vsh.v v4, (a0), v0.t
+vsw.v v4, (a0)
+vsw.v v4, 0(a0)
+vsw.v v4, (a0), v0.t
+vse.v v4, (a0)
+vse.v v4, 0(a0)
+vse.v v4, (a0), v0.t
+
+vlsb.v v4, (a0), a1
+vlsb.v v4, 0(a0), a1
+vlsb.v v4, (a0), a1, v0.t
+vlsh.v v4, (a0), a1
+vlsh.v v4, 0(a0), a1
+vlsh.v v4, (a0), a1, v0.t
+vlsw.v v4, (a0), a1
+vlsw.v v4, 0(a0), a1
+vlsw.v v4, (a0), a1, v0.t
+vlsbu.v v4, (a0), a1
+vlsbu.v v4, 0(a0), a1
+vlsbu.v v4, (a0), a1, v0.t
+vlshu.v v4, (a0), a1
+vlshu.v v4, 0(a0), a1
+vlshu.v v4, (a0), a1, v0.t
+vlswu.v v4, (a0), a1
+vlswu.v v4, 0(a0), a1
+vlswu.v v4, (a0), a1, v0.t
+vlse.v v4, (a0), a1
+vlse.v v4, 0(a0), a1
+vlse.v v4, (a0), a1, v0.t
+vssb.v v4, (a0), a1
+vssb.v v4, 0(a0), a1
+vssb.v v4, (a0), a1, v0.t
+vssh.v v4, (a0), a1
+vssh.v v4, 0(a0), a1
+vssh.v v4, (a0), a1, v0.t
+vssw.v v4, (a0), a1
+vssw.v v4, 0(a0), a1
+vssw.v v4, (a0), a1, v0.t
+vsse.v v4, (a0), a1
+vsse.v v4, 0(a0), a1
+vsse.v v4, (a0), a1, v0.t
+
+vlxb.v v4, (a0), v12
+vlxb.v v4, 0(a0), v12
+vlxb.v v4, (a0), v12, v0.t
+vlxh.v v4, (a0), v12
+vlxh.v v4, 0(a0), v12
+vlxh.v v4, (a0), v12, v0.t
+vlxw.v v4, (a0), v12
+vlxw.v v4, 0(a0), v12
+vlxw.v v4, (a0), v12, v0.t
+vlxbu.v v4, (a0), v12
+vlxbu.v v4, 0(a0), v12
+vlxbu.v v4, (a0), v12, v0.t
+vlxhu.v v4, (a0), v12
+vlxhu.v v4, 0(a0), v12
+vlxhu.v v4, (a0), v12, v0.t
+vlxwu.v v4, (a0), v12
+vlxwu.v v4, 0(a0), v12
+vlxwu.v v4, (a0), v12, v0.t
+vlxe.v v4, (a0), v12
+vlxe.v v4, 0(a0), v12
+vlxe.v v4, (a0), v12, v0.t
+vsxb.v v4, (a0), v12
+vsxb.v v4, 0(a0), v12
+vsxb.v v4, (a0), v12, v0.t
+vsxh.v v4, (a0), v12
+vsxh.v v4, 0(a0), v12
+vsxh.v v4, (a0), v12, v0.t
+vsxw.v v4, (a0), v12
+vsxw.v v4, 0(a0), v12
+vsxw.v v4, (a0), v12, v0.t
+vsxe.v v4, (a0), v12
+vsxe.v v4, 0(a0), v12
+vsxe.v v4, (a0), v12, v0.t
+vsuxb.v v4, (a0), v12
+vsuxb.v v4, 0(a0), v12
+vsuxb.v v4, (a0), v12, v0.t
+vsuxh.v v4, (a0), v12
+vsuxh.v v4, 0(a0), v12
+vsuxh.v v4, (a0), v12, v0.t
+vsuxw.v v4, (a0), v12
+vsuxw.v v4, 0(a0), v12
+vsuxw.v v4, (a0), v12, v0.t
+vsuxe.v v4, (a0), v12
+vsuxe.v v4, 0(a0), v12
+vsuxe.v v4, (a0), v12, v0.t
+
+vlbff.v v4, (a0)
+vlbff.v v4, 0(a0)
+vlbff.v v4, (a0), v0.t
+vlhff.v v4, (a0)
+vlhff.v v4, 0(a0)
+vlhff.v v4, (a0), v0.t
+vlwff.v v4, (a0)
+vlwff.v v4, 0(a0)
+vlwff.v v4, (a0), v0.t
+vlbuff.v v4, (a0)
+vlbuff.v v4, 0(a0)
+vlbuff.v v4, (a0), v0.t
+vlhuff.v v4, (a0)
+vlhuff.v v4, 0(a0)
+vlhuff.v v4, (a0), v0.t
+vlwuff.v v4, (a0)
+vlwuff.v v4, 0(a0)
+vlwuff.v v4, (a0), v0.t
+vleff.v v4, (a0)
+vleff.v v4, 0(a0)
+vleff.v v4, (a0), v0.t
+
+vlseg2b.v v4, (a0)
+vlseg2b.v v4, 0(a0)
+vlseg2b.v v4, (a0), v0.t
+vlseg2h.v v4, (a0)
+vlseg2h.v v4, 0(a0)
+vlseg2h.v v4, (a0), v0.t
+vlseg2w.v v4, (a0)
+vlseg2w.v v4, 0(a0)
+vlseg2w.v v4, (a0), v0.t
+vlseg2bu.v v4, (a0)
+vlseg2bu.v v4, 0(a0)
+vlseg2bu.v v4, (a0), v0.t
+vlseg2hu.v v4, (a0)
+vlseg2hu.v v4, 0(a0)
+vlseg2hu.v v4, (a0), v0.t
+vlseg2wu.v v4, (a0)
+vlseg2wu.v v4, 0(a0)
+vlseg2wu.v v4, (a0), v0.t
+vlseg2e.v v4, (a0)
+vlseg2e.v v4, 0(a0)
+vlseg2e.v v4, (a0), v0.t
+vsseg2b.v v4, (a0)
+vsseg2b.v v4, 0(a0)
+vsseg2b.v v4, (a0), v0.t
+vsseg2h.v v4, (a0)
+vsseg2h.v v4, 0(a0)
+vsseg2h.v v4, (a0), v0.t
+vsseg2w.v v4, (a0)
+vsseg2w.v v4, 0(a0)
+vsseg2w.v v4, (a0), v0.t
+vsseg2e.v v4, (a0)
+vsseg2e.v v4, 0(a0)
+vsseg2e.v v4, (a0), v0.t
+
+vlseg3b.v v4, (a0)
+vlseg3b.v v4, 0(a0)
+vlseg3b.v v4, (a0), v0.t
+vlseg3h.v v4, (a0)
+vlseg3h.v v4, 0(a0)
+vlseg3h.v v4, (a0), v0.t
+vlseg3w.v v4, (a0)
+vlseg3w.v v4, 0(a0)
+vlseg3w.v v4, (a0), v0.t
+vlseg3bu.v v4, (a0)
+vlseg3bu.v v4, 0(a0)
+vlseg3bu.v v4, (a0), v0.t
+vlseg3hu.v v4, (a0)
+vlseg3hu.v v4, 0(a0)
+vlseg3hu.v v4, (a0), v0.t
+vlseg3wu.v v4, (a0)
+vlseg3wu.v v4, 0(a0)
+vlseg3wu.v v4, (a0), v0.t
+vlseg3e.v v4, (a0)
+vlseg3e.v v4, 0(a0)
+vlseg3e.v v4, (a0), v0.t
+vsseg3b.v v4, (a0)
+vsseg3b.v v4, 0(a0)
+vsseg3b.v v4, (a0), v0.t
+vsseg3h.v v4, (a0)
+vsseg3h.v v4, 0(a0)
+vsseg3h.v v4, (a0), v0.t
+vsseg3w.v v4, (a0)
+vsseg3w.v v4, 0(a0)
+vsseg3w.v v4, (a0), v0.t
+vsseg3e.v v4, (a0)
+vsseg3e.v v4, 0(a0)
+vsseg3e.v v4, (a0), v0.t
+
+vlseg4b.v v4, (a0)
+vlseg4b.v v4, 0(a0)
+vlseg4b.v v4, (a0), v0.t
+vlseg4h.v v4, (a0)
+vlseg4h.v v4, 0(a0)
+vlseg4h.v v4, (a0), v0.t
+vlseg4w.v v4, (a0)
+vlseg4w.v v4, 0(a0)
+vlseg4w.v v4, (a0), v0.t
+vlseg4bu.v v4, (a0)
+vlseg4bu.v v4, 0(a0)
+vlseg4bu.v v4, (a0), v0.t
+vlseg4hu.v v4, (a0)
+vlseg4hu.v v4, 0(a0)
+vlseg4hu.v v4, (a0), v0.t
+vlseg4wu.v v4, (a0)
+vlseg4wu.v v4, 0(a0)
+vlseg4wu.v v4, (a0), v0.t
+vlseg4e.v v4, (a0)
+vlseg4e.v v4, 0(a0)
+vlseg4e.v v4, (a0), v0.t
+vsseg4b.v v4, (a0)
+vsseg4b.v v4, 0(a0)
+vsseg4b.v v4, (a0), v0.t
+vsseg4h.v v4, (a0)
+vsseg4h.v v4, 0(a0)
+vsseg4h.v v4, (a0), v0.t
+vsseg4w.v v4, (a0)
+vsseg4w.v v4, 0(a0)
+vsseg4w.v v4, (a0), v0.t
+vsseg4e.v v4, (a0)
+vsseg4e.v v4, 0(a0)
+vsseg4e.v v4, (a0), v0.t
+
+vlseg5b.v v4, (a0)
+vlseg5b.v v4, 0(a0)
+vlseg5b.v v4, (a0), v0.t
+vlseg5h.v v4, (a0)
+vlseg5h.v v4, 0(a0)
+vlseg5h.v v4, (a0), v0.t
+vlseg5w.v v4, (a0)
+vlseg5w.v v4, 0(a0)
+vlseg5w.v v4, (a0), v0.t
+vlseg5bu.v v4, (a0)
+vlseg5bu.v v4, 0(a0)
+vlseg5bu.v v4, (a0), v0.t
+vlseg5hu.v v4, (a0)
+vlseg5hu.v v4, 0(a0)
+vlseg5hu.v v4, (a0), v0.t
+vlseg5wu.v v4, (a0)
+vlseg5wu.v v4, 0(a0)
+vlseg5wu.v v4, (a0), v0.t
+vlseg5e.v v4, (a0)
+vlseg5e.v v4, 0(a0)
+vlseg5e.v v4, (a0), v0.t
+vsseg5b.v v4, (a0)
+vsseg5b.v v4, 0(a0)
+vsseg5b.v v4, (a0), v0.t
+vsseg5h.v v4, (a0)
+vsseg5h.v v4, 0(a0)
+vsseg5h.v v4, (a0), v0.t
+vsseg5w.v v4, (a0)
+vsseg5w.v v4, 0(a0)
+vsseg5w.v v4, (a0), v0.t
+vsseg5e.v v4, (a0)
+vsseg5e.v v4, 0(a0)
+vsseg5e.v v4, (a0), v0.t
+
+vlseg6b.v v4, (a0)
+vlseg6b.v v4, 0(a0)
+vlseg6b.v v4, (a0), v0.t
+vlseg6h.v v4, (a0)
+vlseg6h.v v4, 0(a0)
+vlseg6h.v v4, (a0), v0.t
+vlseg6w.v v4, (a0)
+vlseg6w.v v4, 0(a0)
+vlseg6w.v v4, (a0), v0.t
+vlseg6bu.v v4, (a0)
+vlseg6bu.v v4, 0(a0)
+vlseg6bu.v v4, (a0), v0.t
+vlseg6hu.v v4, (a0)
+vlseg6hu.v v4, 0(a0)
+vlseg6hu.v v4, (a0), v0.t
+vlseg6wu.v v4, (a0)
+vlseg6wu.v v4, 0(a0)
+vlseg6wu.v v4, (a0), v0.t
+vlseg6e.v v4, (a0)
+vlseg6e.v v4, 0(a0)
+vlseg6e.v v4, (a0), v0.t
+vsseg6b.v v4, (a0)
+vsseg6b.v v4, 0(a0)
+vsseg6b.v v4, (a0), v0.t
+vsseg6h.v v4, (a0)
+vsseg6h.v v4, 0(a0)
+vsseg6h.v v4, (a0), v0.t
+vsseg6w.v v4, (a0)
+vsseg6w.v v4, 0(a0)
+vsseg6w.v v4, (a0), v0.t
+vsseg6e.v v4, (a0)
+vsseg6e.v v4, 0(a0)
+vsseg6e.v v4, (a0), v0.t
+
+vlseg7b.v v4, (a0)
+vlseg7b.v v4, 0(a0)
+vlseg7b.v v4, (a0), v0.t
+vlseg7h.v v4, (a0)
+vlseg7h.v v4, 0(a0)
+vlseg7h.v v4, (a0), v0.t
+vlseg7w.v v4, (a0)
+vlseg7w.v v4, 0(a0)
+vlseg7w.v v4, (a0), v0.t
+vlseg7bu.v v4, (a0)
+vlseg7bu.v v4, 0(a0)
+vlseg7bu.v v4, (a0), v0.t
+vlseg7hu.v v4, (a0)
+vlseg7hu.v v4, 0(a0)
+vlseg7hu.v v4, (a0), v0.t
+vlseg7wu.v v4, (a0)
+vlseg7wu.v v4, 0(a0)
+vlseg7wu.v v4, (a0), v0.t
+vlseg7e.v v4, (a0)
+vlseg7e.v v4, 0(a0)
+vlseg7e.v v4, (a0), v0.t
+vsseg7b.v v4, (a0)
+vsseg7b.v v4, 0(a0)
+vsseg7b.v v4, (a0), v0.t
+vsseg7h.v v4, (a0)
+vsseg7h.v v4, 0(a0)
+vsseg7h.v v4, (a0), v0.t
+vsseg7w.v v4, (a0)
+vsseg7w.v v4, 0(a0)
+vsseg7w.v v4, (a0), v0.t
+vsseg7e.v v4, (a0)
+vsseg7e.v v4, 0(a0)
+vsseg7e.v v4, (a0), v0.t
+
+vlseg8b.v v4, (a0)
+vlseg8b.v v4, 0(a0)
+vlseg8b.v v4, (a0), v0.t
+vlseg8h.v v4, (a0)
+vlseg8h.v v4, 0(a0)
+vlseg8h.v v4, (a0), v0.t
+vlseg8w.v v4, (a0)
+vlseg8w.v v4, 0(a0)
+vlseg8w.v v4, (a0), v0.t
+vlseg8bu.v v4, (a0)
+vlseg8bu.v v4, 0(a0)
+vlseg8bu.v v4, (a0), v0.t
+vlseg8hu.v v4, (a0)
+vlseg8hu.v v4, 0(a0)
+vlseg8hu.v v4, (a0), v0.t
+vlseg8wu.v v4, (a0)
+vlseg8wu.v v4, 0(a0)
+vlseg8wu.v v4, (a0), v0.t
+vlseg8e.v v4, (a0)
+vlseg8e.v v4, 0(a0)
+vlseg8e.v v4, (a0), v0.t
+vsseg8b.v v4, (a0)
+vsseg8b.v v4, 0(a0)
+vsseg8b.v v4, (a0), v0.t
+vsseg8h.v v4, (a0)
+vsseg8h.v v4, 0(a0)
+vsseg8h.v v4, (a0), v0.t
+vsseg8w.v v4, (a0)
+vsseg8w.v v4, 0(a0)
+vsseg8w.v v4, (a0), v0.t
+vsseg8e.v v4, (a0)
+vsseg8e.v v4, 0(a0)
+vsseg8e.v v4, (a0), v0.t
+
+vlsseg2b.v v4, (a0), a1
+vlsseg2b.v v4, 0(a0), a1
+vlsseg2b.v v4, (a0), a1, v0.t
+vlsseg2h.v v4, (a0), a1
+vlsseg2h.v v4, 0(a0), a1
+vlsseg2h.v v4, (a0), a1, v0.t
+vlsseg2w.v v4, (a0), a1
+vlsseg2w.v v4, 0(a0), a1
+vlsseg2w.v v4, (a0), a1, v0.t
+vlsseg2bu.v v4, (a0), a1
+vlsseg2bu.v v4, 0(a0), a1
+vlsseg2bu.v v4, (a0), a1, v0.t
+vlsseg2hu.v v4, (a0), a1
+vlsseg2hu.v v4, 0(a0), a1
+vlsseg2hu.v v4, (a0), a1, v0.t
+vlsseg2wu.v v4, (a0), a1
+vlsseg2wu.v v4, 0(a0), a1
+vlsseg2wu.v v4, (a0), a1, v0.t
+vlsseg2e.v v4, (a0), a1
+vlsseg2e.v v4, 0(a0), a1
+vlsseg2e.v v4, (a0), a1, v0.t
+vssseg2b.v v4, (a0), a1
+vssseg2b.v v4, 0(a0), a1
+vssseg2b.v v4, (a0), a1, v0.t
+vssseg2h.v v4, (a0), a1
+vssseg2h.v v4, 0(a0), a1
+vssseg2h.v v4, (a0), a1, v0.t
+vssseg2w.v v4, (a0), a1
+vssseg2w.v v4, 0(a0), a1
+vssseg2w.v v4, (a0), a1, v0.t
+vssseg2e.v v4, (a0), a1
+vssseg2e.v v4, 0(a0), a1
+vssseg2e.v v4, (a0), a1, v0.t
+
+vlsseg3b.v v4, (a0), a1
+vlsseg3b.v v4, 0(a0), a1
+vlsseg3b.v v4, (a0), a1, v0.t
+vlsseg3h.v v4, (a0), a1
+vlsseg3h.v v4, 0(a0), a1
+vlsseg3h.v v4, (a0), a1, v0.t
+vlsseg3w.v v4, (a0), a1
+vlsseg3w.v v4, 0(a0), a1
+vlsseg3w.v v4, (a0), a1, v0.t
+vlsseg3bu.v v4, (a0), a1
+vlsseg3bu.v v4, 0(a0), a1
+vlsseg3bu.v v4, (a0), a1, v0.t
+vlsseg3hu.v v4, (a0), a1
+vlsseg3hu.v v4, 0(a0), a1
+vlsseg3hu.v v4, (a0), a1, v0.t
+vlsseg3wu.v v4, (a0), a1
+vlsseg3wu.v v4, 0(a0), a1
+vlsseg3wu.v v4, (a0), a1, v0.t
+vlsseg3e.v v4, (a0), a1
+vlsseg3e.v v4, 0(a0), a1
+vlsseg3e.v v4, (a0), a1, v0.t
+vssseg3b.v v4, (a0), a1
+vssseg3b.v v4, 0(a0), a1
+vssseg3b.v v4, (a0), a1, v0.t
+vssseg3h.v v4, (a0), a1
+vssseg3h.v v4, 0(a0), a1
+vssseg3h.v v4, (a0), a1, v0.t
+vssseg3w.v v4, (a0), a1
+vssseg3w.v v4, 0(a0), a1
+vssseg3w.v v4, (a0), a1, v0.t
+vssseg3e.v v4, (a0), a1
+vssseg3e.v v4, 0(a0), a1
+vssseg3e.v v4, (a0), a1, v0.t
+
+vlsseg4b.v v4, (a0), a1
+vlsseg4b.v v4, 0(a0), a1
+vlsseg4b.v v4, (a0), a1, v0.t
+vlsseg4h.v v4, (a0), a1
+vlsseg4h.v v4, 0(a0), a1
+vlsseg4h.v v4, (a0), a1, v0.t
+vlsseg4w.v v4, (a0), a1
+vlsseg4w.v v4, 0(a0), a1
+vlsseg4w.v v4, (a0), a1, v0.t
+vlsseg4bu.v v4, (a0), a1
+vlsseg4bu.v v4, 0(a0), a1
+vlsseg4bu.v v4, (a0), a1, v0.t
+vlsseg4hu.v v4, (a0), a1
+vlsseg4hu.v v4, 0(a0), a1
+vlsseg4hu.v v4, (a0), a1, v0.t
+vlsseg4wu.v v4, (a0), a1
+vlsseg4wu.v v4, 0(a0), a1
+vlsseg4wu.v v4, (a0), a1, v0.t
+vlsseg4e.v v4, (a0), a1
+vlsseg4e.v v4, 0(a0), a1
+vlsseg4e.v v4, (a0), a1, v0.t
+vssseg4b.v v4, (a0), a1
+vssseg4b.v v4, 0(a0), a1
+vssseg4b.v v4, (a0), a1, v0.t
+vssseg4h.v v4, (a0), a1
+vssseg4h.v v4, 0(a0), a1
+vssseg4h.v v4, (a0), a1, v0.t
+vssseg4w.v v4, (a0), a1
+vssseg4w.v v4, 0(a0), a1
+vssseg4w.v v4, (a0), a1, v0.t
+vssseg4e.v v4, (a0), a1
+vssseg4e.v v4, 0(a0), a1
+vssseg4e.v v4, (a0), a1, v0.t
+
+vlsseg5b.v v4, (a0), a1
+vlsseg5b.v v4, 0(a0), a1
+vlsseg5b.v v4, (a0), a1, v0.t
+vlsseg5h.v v4, (a0), a1
+vlsseg5h.v v4, 0(a0), a1
+vlsseg5h.v v4, (a0), a1, v0.t
+vlsseg5w.v v4, (a0), a1
+vlsseg5w.v v4, 0(a0), a1
+vlsseg5w.v v4, (a0), a1, v0.t
+vlsseg5bu.v v4, (a0), a1
+vlsseg5bu.v v4, 0(a0), a1
+vlsseg5bu.v v4, (a0), a1, v0.t
+vlsseg5hu.v v4, (a0), a1
+vlsseg5hu.v v4, 0(a0), a1
+vlsseg5hu.v v4, (a0), a1, v0.t
+vlsseg5wu.v v4, (a0), a1
+vlsseg5wu.v v4, 0(a0), a1
+vlsseg5wu.v v4, (a0), a1, v0.t
+vlsseg5e.v v4, (a0), a1
+vlsseg5e.v v4, 0(a0), a1
+vlsseg5e.v v4, (a0), a1, v0.t
+vssseg5b.v v4, (a0), a1
+vssseg5b.v v4, 0(a0), a1
+vssseg5b.v v4, (a0), a1, v0.t
+vssseg5h.v v4, (a0), a1
+vssseg5h.v v4, 0(a0), a1
+vssseg5h.v v4, (a0), a1, v0.t
+vssseg5w.v v4, (a0), a1
+vssseg5w.v v4, 0(a0), a1
+vssseg5w.v v4, (a0), a1, v0.t
+vssseg5e.v v4, (a0), a1
+vssseg5e.v v4, 0(a0), a1
+vssseg5e.v v4, (a0), a1, v0.t
+
+vlsseg6b.v v4, (a0), a1
+vlsseg6b.v v4, 0(a0), a1
+vlsseg6b.v v4, (a0), a1, v0.t
+vlsseg6h.v v4, (a0), a1
+vlsseg6h.v v4, 0(a0), a1
+vlsseg6h.v v4, (a0), a1, v0.t
+vlsseg6w.v v4, (a0), a1
+vlsseg6w.v v4, 0(a0), a1
+vlsseg6w.v v4, (a0), a1, v0.t
+vlsseg6bu.v v4, (a0), a1
+vlsseg6bu.v v4, 0(a0), a1
+vlsseg6bu.v v4, (a0), a1, v0.t
+vlsseg6hu.v v4, (a0), a1
+vlsseg6hu.v v4, 0(a0), a1
+vlsseg6hu.v v4, (a0), a1, v0.t
+vlsseg6wu.v v4, (a0), a1
+vlsseg6wu.v v4, 0(a0), a1
+vlsseg6wu.v v4, (a0), a1, v0.t
+vlsseg6e.v v4, (a0), a1
+vlsseg6e.v v4, 0(a0), a1
+vlsseg6e.v v4, (a0), a1, v0.t
+vssseg6b.v v4, (a0), a1
+vssseg6b.v v4, 0(a0), a1
+vssseg6b.v v4, (a0), a1, v0.t
+vssseg6h.v v4, (a0), a1
+vssseg6h.v v4, 0(a0), a1
+vssseg6h.v v4, (a0), a1, v0.t
+vssseg6w.v v4, (a0), a1
+vssseg6w.v v4, 0(a0), a1
+vssseg6w.v v4, (a0), a1, v0.t
+vssseg6e.v v4, (a0), a1
+vssseg6e.v v4, 0(a0), a1
+vssseg6e.v v4, (a0), a1, v0.t
+
+vlsseg7b.v v4, (a0), a1
+vlsseg7b.v v4, 0(a0), a1
+vlsseg7b.v v4, (a0), a1, v0.t
+vlsseg7h.v v4, (a0), a1
+vlsseg7h.v v4, 0(a0), a1
+vlsseg7h.v v4, (a0), a1, v0.t
+vlsseg7w.v v4, (a0), a1
+vlsseg7w.v v4, 0(a0), a1
+vlsseg7w.v v4, (a0), a1, v0.t
+vlsseg7bu.v v4, (a0), a1
+vlsseg7bu.v v4, 0(a0), a1
+vlsseg7bu.v v4, (a0), a1, v0.t
+vlsseg7hu.v v4, (a0), a1
+vlsseg7hu.v v4, 0(a0), a1
+vlsseg7hu.v v4, (a0), a1, v0.t
+vlsseg7wu.v v4, (a0), a1
+vlsseg7wu.v v4, 0(a0), a1
+vlsseg7wu.v v4, (a0), a1, v0.t
+vlsseg7e.v v4, (a0), a1
+vlsseg7e.v v4, 0(a0), a1
+vlsseg7e.v v4, (a0), a1, v0.t
+vssseg7b.v v4, (a0), a1
+vssseg7b.v v4, 0(a0), a1
+vssseg7b.v v4, (a0), a1, v0.t
+vssseg7h.v v4, (a0), a1
+vssseg7h.v v4, 0(a0), a1
+vssseg7h.v v4, (a0), a1, v0.t
+vssseg7w.v v4, (a0), a1
+vssseg7w.v v4, 0(a0), a1
+vssseg7w.v v4, (a0), a1, v0.t
+vssseg7e.v v4, (a0), a1
+vssseg7e.v v4, 0(a0), a1
+vssseg7e.v v4, (a0), a1, v0.t
+
+vlsseg8b.v v4, (a0), a1
+vlsseg8b.v v4, 0(a0), a1
+vlsseg8b.v v4, (a0), a1, v0.t
+vlsseg8h.v v4, (a0), a1
+vlsseg8h.v v4, 0(a0), a1
+vlsseg8h.v v4, (a0), a1, v0.t
+vlsseg8w.v v4, (a0), a1
+vlsseg8w.v v4, 0(a0), a1
+vlsseg8w.v v4, (a0), a1, v0.t
+vlsseg8bu.v v4, (a0), a1
+vlsseg8bu.v v4, 0(a0), a1
+vlsseg8bu.v v4, (a0), a1, v0.t
+vlsseg8hu.v v4, (a0), a1
+vlsseg8hu.v v4, 0(a0), a1
+vlsseg8hu.v v4, (a0), a1, v0.t
+vlsseg8wu.v v4, (a0), a1
+vlsseg8wu.v v4, 0(a0), a1
+vlsseg8wu.v v4, (a0), a1, v0.t
+vlsseg8e.v v4, (a0), a1
+vlsseg8e.v v4, 0(a0), a1
+vlsseg8e.v v4, (a0), a1, v0.t
+vssseg8b.v v4, (a0), a1
+vssseg8b.v v4, 0(a0), a1
+vssseg8b.v v4, (a0), a1, v0.t
+vssseg8h.v v4, (a0), a1
+vssseg8h.v v4, 0(a0), a1
+vssseg8h.v v4, (a0), a1, v0.t
+vssseg8w.v v4, (a0), a1
+vssseg8w.v v4, 0(a0), a1
+vssseg8w.v v4, (a0), a1, v0.t
+vssseg8e.v v4, (a0), a1
+vssseg8e.v v4, 0(a0), a1
+vssseg8e.v v4, (a0), a1, v0.t
+
+vlxseg2b.v v4, (a0), v12
+vlxseg2b.v v4, 0(a0), v12
+vlxseg2b.v v4, (a0), v12, v0.t
+vlxseg2h.v v4, (a0), v12
+vlxseg2h.v v4, 0(a0), v12
+vlxseg2h.v v4, (a0), v12, v0.t
+vlxseg2w.v v4, (a0), v12
+vlxseg2w.v v4, 0(a0), v12
+vlxseg2w.v v4, (a0), v12, v0.t
+vlxseg2bu.v v4, (a0), v12
+vlxseg2bu.v v4, 0(a0), v12
+vlxseg2bu.v v4, (a0), v12, v0.t
+vlxseg2hu.v v4, (a0), v12
+vlxseg2hu.v v4, 0(a0), v12
+vlxseg2hu.v v4, (a0), v12, v0.t
+vlxseg2wu.v v4, (a0), v12
+vlxseg2wu.v v4, 0(a0), v12
+vlxseg2wu.v v4, (a0), v12, v0.t
+vlxseg2e.v v4, (a0), v12
+vlxseg2e.v v4, 0(a0), v12
+vlxseg2e.v v4, (a0), v12, v0.t
+vsxseg2b.v v4, (a0), v12
+vsxseg2b.v v4, 0(a0), v12
+vsxseg2b.v v4, (a0), v12, v0.t
+vsxseg2h.v v4, (a0), v12
+vsxseg2h.v v4, 0(a0), v12
+vsxseg2h.v v4, (a0), v12, v0.t
+vsxseg2w.v v4, (a0), v12
+vsxseg2w.v v4, 0(a0), v12
+vsxseg2w.v v4, (a0), v12, v0.t
+vsxseg2e.v v4, (a0), v12
+vsxseg2e.v v4, 0(a0), v12
+vsxseg2e.v v4, (a0), v12, v0.t
+
+vlxseg3b.v v4, (a0), v12
+vlxseg3b.v v4, 0(a0), v12
+vlxseg3b.v v4, (a0), v12, v0.t
+vlxseg3h.v v4, (a0), v12
+vlxseg3h.v v4, 0(a0), v12
+vlxseg3h.v v4, (a0), v12, v0.t
+vlxseg3w.v v4, (a0), v12
+vlxseg3w.v v4, 0(a0), v12
+vlxseg3w.v v4, (a0), v12, v0.t
+vlxseg3bu.v v4, (a0), v12
+vlxseg3bu.v v4, 0(a0), v12
+vlxseg3bu.v v4, (a0), v12, v0.t
+vlxseg3hu.v v4, (a0), v12
+vlxseg3hu.v v4, 0(a0), v12
+vlxseg3hu.v v4, (a0), v12, v0.t
+vlxseg3wu.v v4, (a0), v12
+vlxseg3wu.v v4, 0(a0), v12
+vlxseg3wu.v v4, (a0), v12, v0.t
+vlxseg3e.v v4, (a0), v12
+vlxseg3e.v v4, 0(a0), v12
+vlxseg3e.v v4, (a0), v12, v0.t
+vsxseg3b.v v4, (a0), v12
+vsxseg3b.v v4, 0(a0), v12
+vsxseg3b.v v4, (a0), v12, v0.t
+vsxseg3h.v v4, (a0), v12
+vsxseg3h.v v4, 0(a0), v12
+vsxseg3h.v v4, (a0), v12, v0.t
+vsxseg3w.v v4, (a0), v12
+vsxseg3w.v v4, 0(a0), v12
+vsxseg3w.v v4, (a0), v12, v0.t
+vsxseg3e.v v4, (a0), v12
+vsxseg3e.v v4, 0(a0), v12
+vsxseg3e.v v4, (a0), v12, v0.t
+
+vlxseg4b.v v4, (a0), v12
+vlxseg4b.v v4, 0(a0), v12
+vlxseg4b.v v4, (a0), v12, v0.t
+vlxseg4h.v v4, (a0), v12
+vlxseg4h.v v4, 0(a0), v12
+vlxseg4h.v v4, (a0), v12, v0.t
+vlxseg4w.v v4, (a0), v12
+vlxseg4w.v v4, 0(a0), v12
+vlxseg4w.v v4, (a0), v12, v0.t
+vlxseg4bu.v v4, (a0), v12
+vlxseg4bu.v v4, 0(a0), v12
+vlxseg4bu.v v4, (a0), v12, v0.t
+vlxseg4hu.v v4, (a0), v12
+vlxseg4hu.v v4, 0(a0), v12
+vlxseg4hu.v v4, (a0), v12, v0.t
+vlxseg4wu.v v4, (a0), v12
+vlxseg4wu.v v4, 0(a0), v12
+vlxseg4wu.v v4, (a0), v12, v0.t
+vlxseg4e.v v4, (a0), v12
+vlxseg4e.v v4, 0(a0), v12
+vlxseg4e.v v4, (a0), v12, v0.t
+vsxseg4b.v v4, (a0), v12
+vsxseg4b.v v4, 0(a0), v12
+vsxseg4b.v v4, (a0), v12, v0.t
+vsxseg4h.v v4, (a0), v12
+vsxseg4h.v v4, 0(a0), v12
+vsxseg4h.v v4, (a0), v12, v0.t
+vsxseg4w.v v4, (a0), v12
+vsxseg4w.v v4, 0(a0), v12
+vsxseg4w.v v4, (a0), v12, v0.t
+vsxseg4e.v v4, (a0), v12
+vsxseg4e.v v4, 0(a0), v12
+vsxseg4e.v v4, (a0), v12, v0.t
+
+vlxseg5b.v v4, (a0), v12
+vlxseg5b.v v4, 0(a0), v12
+vlxseg5b.v v4, (a0), v12, v0.t
+vlxseg5h.v v4, (a0), v12
+vlxseg5h.v v4, 0(a0), v12
+vlxseg5h.v v4, (a0), v12, v0.t
+vlxseg5w.v v4, (a0), v12
+vlxseg5w.v v4, 0(a0), v12
+vlxseg5w.v v4, (a0), v12, v0.t
+vlxseg5bu.v v4, (a0), v12
+vlxseg5bu.v v4, 0(a0), v12
+vlxseg5bu.v v4, (a0), v12, v0.t
+vlxseg5hu.v v4, (a0), v12
+vlxseg5hu.v v4, 0(a0), v12
+vlxseg5hu.v v4, (a0), v12, v0.t
+vlxseg5wu.v v4, (a0), v12
+vlxseg5wu.v v4, 0(a0), v12
+vlxseg5wu.v v4, (a0), v12, v0.t
+vlxseg5e.v v4, (a0), v12
+vlxseg5e.v v4, 0(a0), v12
+vlxseg5e.v v4, (a0), v12, v0.t
+vsxseg5b.v v4, (a0), v12
+vsxseg5b.v v4, 0(a0), v12
+vsxseg5b.v v4, (a0), v12, v0.t
+vsxseg5h.v v4, (a0), v12
+vsxseg5h.v v4, 0(a0), v12
+vsxseg5h.v v4, (a0), v12, v0.t
+vsxseg5w.v v4, (a0), v12
+vsxseg5w.v v4, 0(a0), v12
+vsxseg5w.v v4, (a0), v12, v0.t
+vsxseg5e.v v4, (a0), v12
+vsxseg5e.v v4, 0(a0), v12
+vsxseg5e.v v4, (a0), v12, v0.t
+
+vlxseg6b.v v4, (a0), v12
+vlxseg6b.v v4, 0(a0), v12
+vlxseg6b.v v4, (a0), v12, v0.t
+vlxseg6h.v v4, (a0), v12
+vlxseg6h.v v4, 0(a0), v12
+vlxseg6h.v v4, (a0), v12, v0.t
+vlxseg6w.v v4, (a0), v12
+vlxseg6w.v v4, 0(a0), v12
+vlxseg6w.v v4, (a0), v12, v0.t
+vlxseg6bu.v v4, (a0), v12
+vlxseg6bu.v v4, 0(a0), v12
+vlxseg6bu.v v4, (a0), v12, v0.t
+vlxseg6hu.v v4, (a0), v12
+vlxseg6hu.v v4, 0(a0), v12
+vlxseg6hu.v v4, (a0), v12, v0.t
+vlxseg6wu.v v4, (a0), v12
+vlxseg6wu.v v4, 0(a0), v12
+vlxseg6wu.v v4, (a0), v12, v0.t
+vlxseg6e.v v4, (a0), v12
+vlxseg6e.v v4, 0(a0), v12
+vlxseg6e.v v4, (a0), v12, v0.t
+vsxseg6b.v v4, (a0), v12
+vsxseg6b.v v4, 0(a0), v12
+vsxseg6b.v v4, (a0), v12, v0.t
+vsxseg6h.v v4, (a0), v12
+vsxseg6h.v v4, 0(a0), v12
+vsxseg6h.v v4, (a0), v12, v0.t
+vsxseg6w.v v4, (a0), v12
+vsxseg6w.v v4, 0(a0), v12
+vsxseg6w.v v4, (a0), v12, v0.t
+vsxseg6e.v v4, (a0), v12
+vsxseg6e.v v4, 0(a0), v12
+vsxseg6e.v v4, (a0), v12, v0.t
+
+vlxseg7b.v v4, (a0), v12
+vlxseg7b.v v4, 0(a0), v12
+vlxseg7b.v v4, (a0), v12, v0.t
+vlxseg7h.v v4, (a0), v12
+vlxseg7h.v v4, 0(a0), v12
+vlxseg7h.v v4, (a0), v12, v0.t
+vlxseg7w.v v4, (a0), v12
+vlxseg7w.v v4, 0(a0), v12
+vlxseg7w.v v4, (a0), v12, v0.t
+vlxseg7bu.v v4, (a0), v12
+vlxseg7bu.v v4, 0(a0), v12
+vlxseg7bu.v v4, (a0), v12, v0.t
+vlxseg7hu.v v4, (a0), v12
+vlxseg7hu.v v4, 0(a0), v12
+vlxseg7hu.v v4, (a0), v12, v0.t
+vlxseg7wu.v v4, (a0), v12
+vlxseg7wu.v v4, 0(a0), v12
+vlxseg7wu.v v4, (a0), v12, v0.t
+vlxseg7e.v v4, (a0), v12
+vlxseg7e.v v4, 0(a0), v12
+vlxseg7e.v v4, (a0), v12, v0.t
+vsxseg7b.v v4, (a0), v12
+vsxseg7b.v v4, 0(a0), v12
+vsxseg7b.v v4, (a0), v12, v0.t
+vsxseg7h.v v4, (a0), v12
+vsxseg7h.v v4, 0(a0), v12
+vsxseg7h.v v4, (a0), v12, v0.t
+vsxseg7w.v v4, (a0), v12
+vsxseg7w.v v4, 0(a0), v12
+vsxseg7w.v v4, (a0), v12, v0.t
+vsxseg7e.v v4, (a0), v12
+vsxseg7e.v v4, 0(a0), v12
+vsxseg7e.v v4, (a0), v12, v0.t
+
+vlxseg8b.v v4, (a0), v12
+vlxseg8b.v v4, 0(a0), v12
+vlxseg8b.v v4, (a0), v12, v0.t
+vlxseg8h.v v4, (a0), v12
+vlxseg8h.v v4, 0(a0), v12
+vlxseg8h.v v4, (a0), v12, v0.t
+vlxseg8w.v v4, (a0), v12
+vlxseg8w.v v4, 0(a0), v12
+vlxseg8w.v v4, (a0), v12, v0.t
+vlxseg8bu.v v4, (a0), v12
+vlxseg8bu.v v4, 0(a0), v12
+vlxseg8bu.v v4, (a0), v12, v0.t
+vlxseg8hu.v v4, (a0), v12
+vlxseg8hu.v v4, 0(a0), v12
+vlxseg8hu.v v4, (a0), v12, v0.t
+vlxseg8wu.v v4, (a0), v12
+vlxseg8wu.v v4, 0(a0), v12
+vlxseg8wu.v v4, (a0), v12, v0.t
+vlxseg8e.v v4, (a0), v12
+vlxseg8e.v v4, 0(a0), v12
+vlxseg8e.v v4, (a0), v12, v0.t
+vsxseg8b.v v4, (a0), v12
+vsxseg8b.v v4, 0(a0), v12
+vsxseg8b.v v4, (a0), v12, v0.t
+vsxseg8h.v v4, (a0), v12
+vsxseg8h.v v4, 0(a0), v12
+vsxseg8h.v v4, (a0), v12, v0.t
+vsxseg8w.v v4, (a0), v12
+vsxseg8w.v v4, 0(a0), v12
+vsxseg8w.v v4, (a0), v12, v0.t
+vsxseg8e.v v4, (a0), v12
+vsxseg8e.v v4, 0(a0), v12
+vsxseg8e.v v4, (a0), v12, v0.t
+
+vlseg2bff.v v4, (a0)
+vlseg2bff.v v4, 0(a0)
+vlseg2bff.v v4, (a0), v0.t
+vlseg2hff.v v4, (a0)
+vlseg2hff.v v4, 0(a0)
+vlseg2hff.v v4, (a0), v0.t
+vlseg2wff.v v4, (a0)
+vlseg2wff.v v4, 0(a0)
+vlseg2wff.v v4, (a0), v0.t
+vlseg2buff.v v4, (a0)
+vlseg2buff.v v4, 0(a0)
+vlseg2buff.v v4, (a0), v0.t
+vlseg2huff.v v4, (a0)
+vlseg2huff.v v4, 0(a0)
+vlseg2huff.v v4, (a0), v0.t
+vlseg2wuff.v v4, (a0)
+vlseg2wuff.v v4, 0(a0)
+vlseg2wuff.v v4, (a0), v0.t
+vlseg2eff.v v4, (a0)
+vlseg2eff.v v4, 0(a0)
+vlseg2eff.v v4, (a0), v0.t
+
+vlseg3bff.v v4, (a0)
+vlseg3bff.v v4, 0(a0)
+vlseg3bff.v v4, (a0), v0.t
+vlseg3hff.v v4, (a0)
+vlseg3hff.v v4, 0(a0)
+vlseg3hff.v v4, (a0), v0.t
+vlseg3wff.v v4, (a0)
+vlseg3wff.v v4, 0(a0)
+vlseg3wff.v v4, (a0), v0.t
+vlseg3buff.v v4, (a0)
+vlseg3buff.v v4, 0(a0)
+vlseg3buff.v v4, (a0), v0.t
+vlseg3huff.v v4, (a0)
+vlseg3huff.v v4, 0(a0)
+vlseg3huff.v v4, (a0), v0.t
+vlseg3wuff.v v4, (a0)
+vlseg3wuff.v v4, 0(a0)
+vlseg3wuff.v v4, (a0), v0.t
+vlseg3eff.v v4, (a0)
+vlseg3eff.v v4, 0(a0)
+vlseg3eff.v v4, (a0), v0.t
+
+vlseg4bff.v v4, (a0)
+vlseg4bff.v v4, 0(a0)
+vlseg4bff.v v4, (a0), v0.t
+vlseg4hff.v v4, (a0)
+vlseg4hff.v v4, 0(a0)
+vlseg4hff.v v4, (a0), v0.t
+vlseg4wff.v v4, (a0)
+vlseg4wff.v v4, 0(a0)
+vlseg4wff.v v4, (a0), v0.t
+vlseg4buff.v v4, (a0)
+vlseg4buff.v v4, 0(a0)
+vlseg4buff.v v4, (a0), v0.t
+vlseg4huff.v v4, (a0)
+vlseg4huff.v v4, 0(a0)
+vlseg4huff.v v4, (a0), v0.t
+vlseg4wuff.v v4, (a0)
+vlseg4wuff.v v4, 0(a0)
+vlseg4wuff.v v4, (a0), v0.t
+vlseg4eff.v v4, (a0)
+vlseg4eff.v v4, 0(a0)
+vlseg4eff.v v4, (a0), v0.t
+
+vlseg5bff.v v4, (a0)
+vlseg5bff.v v4, 0(a0)
+vlseg5bff.v v4, (a0), v0.t
+vlseg5hff.v v4, (a0)
+vlseg5hff.v v4, 0(a0)
+vlseg5hff.v v4, (a0), v0.t
+vlseg5wff.v v4, (a0)
+vlseg5wff.v v4, 0(a0)
+vlseg5wff.v v4, (a0), v0.t
+vlseg5buff.v v4, (a0)
+vlseg5buff.v v4, 0(a0)
+vlseg5buff.v v4, (a0), v0.t
+vlseg5huff.v v4, (a0)
+vlseg5huff.v v4, 0(a0)
+vlseg5huff.v v4, (a0), v0.t
+vlseg5wuff.v v4, (a0)
+vlseg5wuff.v v4, 0(a0)
+vlseg5wuff.v v4, (a0), v0.t
+vlseg5eff.v v4, (a0)
+vlseg5eff.v v4, 0(a0)
+vlseg5eff.v v4, (a0), v0.t
+
+vlseg6bff.v v4, (a0)
+vlseg6bff.v v4, 0(a0)
+vlseg6bff.v v4, (a0), v0.t
+vlseg6hff.v v4, (a0)
+vlseg6hff.v v4, 0(a0)
+vlseg6hff.v v4, (a0), v0.t
+vlseg6wff.v v4, (a0)
+vlseg6wff.v v4, 0(a0)
+vlseg6wff.v v4, (a0), v0.t
+vlseg6buff.v v4, (a0)
+vlseg6buff.v v4, 0(a0)
+vlseg6buff.v v4, (a0), v0.t
+vlseg6huff.v v4, (a0)
+vlseg6huff.v v4, 0(a0)
+vlseg6huff.v v4, (a0), v0.t
+vlseg6wuff.v v4, (a0)
+vlseg6wuff.v v4, 0(a0)
+vlseg6wuff.v v4, (a0), v0.t
+vlseg6eff.v v4, (a0)
+vlseg6eff.v v4, 0(a0)
+vlseg6eff.v v4, (a0), v0.t
+
+vlseg7bff.v v4, (a0)
+vlseg7bff.v v4, 0(a0)
+vlseg7bff.v v4, (a0), v0.t
+vlseg7hff.v v4, (a0)
+vlseg7hff.v v4, 0(a0)
+vlseg7hff.v v4, (a0), v0.t
+vlseg7wff.v v4, (a0)
+vlseg7wff.v v4, 0(a0)
+vlseg7wff.v v4, (a0), v0.t
+vlseg7buff.v v4, (a0)
+vlseg7buff.v v4, 0(a0)
+vlseg7buff.v v4, (a0), v0.t
+vlseg7huff.v v4, (a0)
+vlseg7huff.v v4, 0(a0)
+vlseg7huff.v v4, (a0), v0.t
+vlseg7wuff.v v4, (a0)
+vlseg7wuff.v v4, 0(a0)
+vlseg7wuff.v v4, (a0), v0.t
+vlseg7eff.v v4, (a0)
+vlseg7eff.v v4, 0(a0)
+vlseg7eff.v v4, (a0), v0.t
+
+vlseg8bff.v v4, (a0)
+vlseg8bff.v v4, 0(a0)
+vlseg8bff.v v4, (a0), v0.t
+vlseg8hff.v v4, (a0)
+vlseg8hff.v v4, 0(a0)
+vlseg8hff.v v4, (a0), v0.t
+vlseg8wff.v v4, (a0)
+vlseg8wff.v v4, 0(a0)
+vlseg8wff.v v4, (a0), v0.t
+vlseg8buff.v v4, (a0)
+vlseg8buff.v v4, 0(a0)
+vlseg8buff.v v4, (a0), v0.t
+vlseg8huff.v v4, (a0)
+vlseg8huff.v v4, 0(a0)
+vlseg8huff.v v4, (a0), v0.t
+vlseg8wuff.v v4, (a0)
+vlseg8wuff.v v4, 0(a0)
+vlseg8wuff.v v4, (a0), v0.t
+vlseg8eff.v v4, (a0)
+vlseg8eff.v v4, 0(a0)
+vlseg8eff.v v4, (a0), v0.t
+
+# TODO: rvv 0.7.1 with A
+# vamoaddw.v v4, v8, (a1), v4
+# vamoaddw.v x0, v8, (a1), v4
+# vamoaddd.v v4, v8, (a1), v4
+# vamoaddd.v x0, v8, (a1), v4
+# vamoaddw.v v4, v8, (a1), v4, v0.t
+# vamoaddw.v x0, v8, (a1), v4, v0.t
+# vamoaddd.v v4, v8, (a1), v4, v0.t
+# vamoaddd.v x0, v8, (a1), v4, v0.t
+# vamoswapw.v v4, v8, (a1), v4
+# vamoswapw.v x0, v8, (a1), v4
+# vamoswapd.v v4, v8, (a1), v4
+# vamoswapd.v x0, v8, (a1), v4
+# vamoswapw.v v4, v8, (a1), v4, v0.t
+# vamoswapw.v x0, v8, (a1), v4, v0.t
+# vamoswapd.v v4, v8, (a1), v4, v0.t
+# vamoswapd.v x0, v8, (a1), v4, v0.t
+
+# vamoxorw.v v4, v8, (a1), v4
+# vamoxorw.v x0, v8, (a1), v4
+# vamoxord.v v4, v8, (a1), v4
+# vamoxord.v x0, v8, (a1), v4
+# vamoxorw.v v4, v8, (a1), v4, v0.t
+# vamoxorw.v x0, v8, (a1), v4, v0.t
+# vamoxord.v v4, v8, (a1), v4, v0.t
+# vamoxord.v x0, v8, (a1), v4, v0.t
+# vamoandw.v v4, v8, (a1), v4
+# vamoandw.v x0, v8, (a1), v4
+# vamoandd.v v4, v8, (a1), v4
+# vamoandd.v x0, v8, (a1), v4
+# vamoandw.v v4, v8, (a1), v4, v0.t
+# vamoandw.v x0, v8, (a1), v4, v0.t
+# vamoandd.v v4, v8, (a1), v4, v0.t
+# vamoandd.v x0, v8, (a1), v4, v0.t
+# vamoorw.v v4, v8, (a1), v4
+# vamoorw.v x0, v8, (a1), v4
+# vamoord.v v4, v8, (a1), v4
+# vamoord.v x0, v8, (a1), v4
+# vamoorw.v v4, v8, (a1), v4, v0.t
+# vamoorw.v x0, v8, (a1), v4, v0.t
+# vamoord.v v4, v8, (a1), v4, v0.t
+# vamoord.v x0, v8, (a1), v4, v0.t
+
+# vamominw.v v4, v8, (a1), v4
+# vamominw.v x0, v8, (a1), v4
+# vamomind.v v4, v8, (a1), v4
+# vamomind.v x0, v8, (a1), v4
+# vamominw.v v4, v8, (a1), v4, v0.t
+# vamominw.v x0, v8, (a1), v4, v0.t
+# vamomind.v v4, v8, (a1), v4, v0.t
+# vamomind.v x0, v8, (a1), v4, v0.t
+# vamomaxw.v v4, v8, (a1), v4
+# vamomaxw.v x0, v8, (a1), v4
+# vamomaxd.v v4, v8, (a1), v4
+# vamomaxd.v x0, v8, (a1), v4
+# vamomaxw.v v4, v8, (a1), v4, v0.t
+# vamomaxw.v x0, v8, (a1), v4, v0.t
+# vamomaxd.v v4, v8, (a1), v4, v0.t
+# vamomaxd.v x0, v8, (a1), v4, v0.t
+# vamominuw.v v4, v8, (a1), v4
+# vamominuw.v x0, v8, (a1), v4
+# vamominud.v v4, v8, (a1), v4
+# vamominud.v x0, v8, (a1), v4
+# vamominuw.v v4, v8, (a1), v4, v0.t
+# vamominuw.v x0, v8, (a1), v4, v0.t
+# vamominud.v v4, v8, (a1), v4, v0.t
+# vamominud.v x0, v8, (a1), v4, v0.t
+# vamomaxuw.v v4, v8, (a1), v4
+# vamomaxuw.v x0, v8, (a1), v4
+# vamomaxud.v v4, v8, (a1), v4
+# vamomaxud.v x0, v8, (a1), v4
+# vamomaxuw.v v4, v8, (a1), v4, v0.t
+# vamomaxuw.v x0, v8, (a1), v4, v0.t
+# vamomaxud.v v4, v8, (a1), v4, v0.t
+# vamomaxud.v x0, v8, (a1), v4, v0.t
+
+vadd.vv v4, v8, v12
+vadd.vx v4, v8, a1
+vadd.vi v4, v8, 15
+vadd.vi v4, v8, -16
+vadd.vv v4, v8, v12, v0.t
+vadd.vx v4, v8, a1, v0.t
+vadd.vi v4, v8, 15, v0.t
+vadd.vi v4, v8, -16, v0.t
+vsub.vv v4, v8, v12
+vsub.vx v4, v8, a1
+vrsub.vx v4, v8, a1
+vrsub.vi v4, v8, 15
+vrsub.vi v4, v8, -16
+vsub.vv v4, v8, v12, v0.t
+vsub.vx v4, v8, a1, v0.t
+vrsub.vx v4, v8, a1, v0.t
+vrsub.vi v4, v8, 15, v0.t
+vrsub.vi v4, v8, -16, v0.t
+
+# TODO: rvv 0.7.1
+# Aliases
+# vwcvt.x.x.v v4, v8
+# vwcvtu.x.x.v v4, v8
+# vwcvt.x.x.v v4, v8, v0.t
+# vwcvtu.x.x.v v4, v8, v0.t
+
+vwaddu.vv v4, v8, v12
+vwaddu.vx v4, v8, a1
+vwaddu.vv v4, v8, v12, v0.t
+vwaddu.vx v4, v8, a1, v0.t
+vwsubu.vv v4, v8, v12
+vwsubu.vx v4, v8, a1
+vwsubu.vv v4, v8, v12, v0.t
+vwsubu.vx v4, v8, a1, v0.t
+vwadd.vv v4, v8, v12
+vwadd.vx v4, v8, a1
+vwadd.vv v4, v8, v12, v0.t
+vwadd.vx v4, v8, a1, v0.t
+vwsub.vv v4, v8, v12
+vwsub.vx v4, v8, a1
+vwsub.vv v4, v8, v12, v0.t
+vwsub.vx v4, v8, a1, v0.t
+vwaddu.wv v4, v8, v12
+vwaddu.wx v4, v8, a1
+vwaddu.wv v4, v8, v12, v0.t
+vwaddu.wx v4, v8, a1, v0.t
+vwsubu.wv v4, v8, v12
+vwsubu.wx v4, v8, a1
+vwsubu.wv v4, v8, v12, v0.t
+vwsubu.wx v4, v8, a1, v0.t
+vwadd.wv v4, v8, v12
+vwadd.wx v4, v8, a1
+vwadd.wv v4, v8, v12, v0.t
+vwadd.wx v4, v8, a1, v0.t
+vwsub.wv v4, v8, v12
+vwsub.wx v4, v8, a1
+vwsub.wv v4, v8, v12, v0.t
+vwsub.wx v4, v8, a1, v0.t
+
+vadc.vvm v4, v8, v12, v0
+vadc.vxm v4, v8, a1, v0
+vadc.vim v4, v8, 15, v0
+vadc.vim v4, v8, -16, v0
+vmadc.vvm v4, v8, v12, v0
+vmadc.vxm v4, v8, a1, v0
+vmadc.vim v4, v8, 15, v0
+vmadc.vim v4, v8, -16, v0
+vsbc.vvm v4, v8, v12, v0
+vsbc.vxm v4, v8, a1, v0
+vmsbc.vvm v4, v8, v12, v0
+vmsbc.vxm v4, v8, a1, v0
+
+# TODO: rvv 0.7.1
+# Aliases
+# vnot.v v4, v8
+# vnot.v v4, v8, v0.t
+
+vand.vv v4, v8, v12
+vand.vx v4, v8, a1
+vand.vi v4, v8, 15
+vand.vi v4, v8, -16
+vand.vv v4, v8, v12, v0.t
+vand.vx v4, v8, a1, v0.t
+vand.vi v4, v8, 15, v0.t
+vand.vi v4, v8, -16, v0.t
+vor.vv v4, v8, v12
+vor.vx v4, v8, a1
+vor.vi v4, v8, 15
+vor.vi v4, v8, -16
+vor.vv v4, v8, v12, v0.t
+vor.vx v4, v8, a1, v0.t
+vor.vi v4, v8, 15, v0.t
+vor.vi v4, v8, -16, v0.t
+vxor.vv v4, v8, v12
+vxor.vx v4, v8, a1
+vxor.vi v4, v8, 15
+vxor.vi v4, v8, -16
+vxor.vv v4, v8, v12, v0.t
+vxor.vx v4, v8, a1, v0.t
+vxor.vi v4, v8, 15, v0.t
+vxor.vi v4, v8, -16, v0.t
+
+vsll.vv v4, v8, v12
+vsll.vx v4, v8, a1
+vsll.vi v4, v8, 1
+vsll.vi v4, v8, 31
+vsll.vv v4, v8, v12, v0.t
+vsll.vx v4, v8, a1, v0.t
+vsll.vi v4, v8, 1, v0.t
+vsll.vi v4, v8, 31, v0.t
+vsrl.vv v4, v8, v12
+vsrl.vx v4, v8, a1
+vsrl.vi v4, v8, 1
+vsrl.vi v4, v8, 31
+vsrl.vv v4, v8, v12, v0.t
+vsrl.vx v4, v8, a1, v0.t
+vsrl.vi v4, v8, 1, v0.t
+vsrl.vi v4, v8, 31, v0.t
+vsra.vv v4, v8, v12
+vsra.vx v4, v8, a1
+vsra.vi v4, v8, 1
+vsra.vi v4, v8, 31
+vsra.vv v4, v8, v12, v0.t
+vsra.vx v4, v8, a1, v0.t
+vsra.vi v4, v8, 1, v0.t
+vsra.vi v4, v8, 31, v0.t
+
+vnsrl.vv v4, v8, v12
+vnsrl.vx v4, v8, a1
+vnsrl.vi v4, v8, 1
+vnsrl.vi v4, v8, 31
+vnsrl.vv v4, v8, v12, v0.t
+vnsrl.vx v4, v8, a1, v0.t
+vnsrl.vi v4, v8, 1, v0.t
+vnsrl.vi v4, v8, 31, v0.t
+vnsra.vv v4, v8, v12
+vnsra.vx v4, v8, a1
+vnsra.vi v4, v8, 1
+vnsra.vi v4, v8, 31
+vnsra.vv v4, v8, v12, v0.t
+vnsra.vx v4, v8, a1, v0.t
+vnsra.vi v4, v8, 1, v0.t
+vnsra.vi v4, v8, 31, v0.t
+
+# TODO: rvv 0.7.1
+# Aliases
+# vmsgt.vv v4, v8, v12
+# vmsgtu.vv v4, v8, v12
+# vmsge.vv v4, v8, v12
+# vmsgeu.vv v4, v8, v12
+# vmsgt.vv v4, v8, v12, v0.t
+# vmsgtu.vv v4, v8, v12, v0.t
+# vmsge.vv v4, v8, v12, v0.t
+# vmsgeu.vv v4, v8, v12, v0.t
+# vmslt.vi v4, v8, 16
+# vmslt.vi v4, v8, -15
+# vmsltu.vi v4, v8, 16
+# vmsltu.vi v4, v8, -15
+# vmsge.vi v4, v8, 16
+# vmsge.vi v4, v8, -15
+# vmsgeu.vi v4, v8, 16
+# vmsgeu.vi v4, v8, -15
+# vmslt.vi v4, v8, 16, v0.t
+# vmslt.vi v4, v8, -15, v0.t
+# vmsltu.vi v4, v8, 16, v0.t
+# vmsltu.vi v4, v8, -15, v0.t
+# vmsge.vi v4, v8, 16, v0.t
+# vmsge.vi v4, v8, -15, v0.t
+# vmsgeu.vi v4, v8, 16, v0.t
+# vmsgeu.vi v4, v8, -15, v0.t
+
+# TODO: rvv 0.7.1
+# Macros
+# vmsge.vx v4, v8, a1
+# vmsgeu.vx v4, v8, a1
+# vmsge.vx v8, v12, a2, v0.t
+# vmsgeu.vx v8, v12, a2, v0.t
+# vmsge.vx v4, v8, a1, v0.t, v12
+# vmsgeu.vx v4, v8, a1, v0.t, v12
+
+vmseq.vv v4, v8, v12
+vmseq.vx v4, v8, a1
+vmseq.vi v4, v8, 15
+vmseq.vi v4, v8, -16
+vmseq.vv v4, v8, v12, v0.t
+vmseq.vx v4, v8, a1, v0.t
+vmseq.vi v4, v8, 15, v0.t
+vmseq.vi v4, v8, -16, v0.t
+vmsne.vv v4, v8, v12
+vmsne.vx v4, v8, a1
+vmsne.vi v4, v8, 15
+vmsne.vi v4, v8, -16
+vmsne.vv v4, v8, v12, v0.t
+vmsne.vx v4, v8, a1, v0.t
+vmsne.vi v4, v8, 15, v0.t
+vmsne.vi v4, v8, -16, v0.t
+vmsltu.vv v4, v8, v12
+vmsltu.vx v4, v8, a1
+vmsltu.vv v4, v8, v12, v0.t
+vmsltu.vx v4, v8, a1, v0.t
+vmslt.vv v4, v8, v12
+vmslt.vx v4, v8, a1
+vmslt.vv v4, v8, v12, v0.t
+vmslt.vx v4, v8, a1, v0.t
+vmsleu.vv v4, v8, v12
+vmsleu.vx v4, v8, a1
+vmsleu.vi v4, v8, 15
+vmsleu.vi v4, v8, -16
+vmsleu.vv v4, v8, v12, v0.t
+vmsleu.vx v4, v8, a1, v0.t
+vmsleu.vi v4, v8, 15, v0.t
+vmsleu.vi v4, v8, -16, v0.t
+vmsle.vv v4, v8, v12
+vmsle.vx v4, v8, a1
+vmsle.vi v4, v8, 15
+vmsle.vi v4, v8, -16
+vmsle.vv v4, v8, v12, v0.t
+vmsle.vx v4, v8, a1, v0.t
+vmsle.vi v4, v8, 15, v0.t
+vmsle.vi v4, v8, -16, v0.t
+vmsgtu.vx v4, v8, a1
+vmsgtu.vi v4, v8, 15
+vmsgtu.vi v4, v8, -16
+vmsgtu.vx v4, v8, a1, v0.t
+vmsgtu.vi v4, v8, 15, v0.t
+vmsgtu.vi v4, v8, -16, v0.t
+vmsgt.vx v4, v8, a1
+vmsgt.vi v4, v8, 15
+vmsgt.vi v4, v8, -16
+vmsgt.vx v4, v8, a1, v0.t
+vmsgt.vi v4, v8, 15, v0.t
+vmsgt.vi v4, v8, -16, v0.t
+
+vminu.vv v4, v8, v12
+vminu.vx v4, v8, a1
+vminu.vv v4, v8, v12, v0.t
+vminu.vx v4, v8, a1, v0.t
+vmin.vv v4, v8, v12
+vmin.vx v4, v8, a1
+vmin.vv v4, v8, v12, v0.t
+vmin.vx v4, v8, a1, v0.t
+vmaxu.vv v4, v8, v12
+vmaxu.vx v4, v8, a1
+vmaxu.vv v4, v8, v12, v0.t
+vmaxu.vx v4, v8, a1, v0.t
+vmax.vv v4, v8, v12
+vmax.vx v4, v8, a1
+vmax.vv v4, v8, v12, v0.t
+vmax.vx v4, v8, a1, v0.t
+
+vmul.vv v4, v8, v12
+vmul.vx v4, v8, a1
+vmul.vv v4, v8, v12, v0.t
+vmul.vx v4, v8, a1, v0.t
+vmulh.vv v4, v8, v12
+vmulh.vx v4, v8, a1
+vmulh.vv v4, v8, v12, v0.t
+vmulh.vx v4, v8, a1, v0.t
+vmulhu.vv v4, v8, v12
+vmulhu.vx v4, v8, a1
+vmulhu.vv v4, v8, v12, v0.t
+vmulhu.vx v4, v8, a1, v0.t
+vmulhsu.vv v4, v8, v12
+vmulhsu.vx v4, v8, a1
+vmulhsu.vv v4, v8, v12, v0.t
+vmulhsu.vx v4, v8, a1, v0.t
+
+vwmul.vv v4, v8, v12
+vwmul.vx v4, v8, a1
+vwmul.vv v4, v8, v12, v0.t
+vwmul.vx v4, v8, a1, v0.t
+vwmulu.vv v4, v8, v12
+vwmulu.vx v4, v8, a1
+vwmulu.vv v4, v8, v12, v0.t
+vwmulu.vx v4, v8, a1, v0.t
+vwmulsu.vv v4, v8, v12
+vwmulsu.vx v4, v8, a1
+vwmulsu.vv v4, v8, v12, v0.t
+vwmulsu.vx v4, v8, a1, v0.t
+
+vmacc.vv v4, v12, v8
+vmacc.vx v4, a1, v8
+vmacc.vv v4, v12, v8, v0.t
+vmacc.vx v4, a1, v8, v0.t
+vnmsac.vv v4, v12, v8
+vnmsac.vx v4, a1, v8
+vnmsac.vv v4, v12, v8, v0.t
+vnmsac.vx v4, a1, v8, v0.t
+vmadd.vv v4, v12, v8
+vmadd.vx v4, a1, v8
+vmadd.vv v4, v12, v8, v0.t
+vmadd.vx v4, a1, v8, v0.t
+vnmsub.vv v4, v12, v8
+vnmsub.vx v4, a1, v8
+vnmsub.vv v4, v12, v8, v0.t
+vnmsub.vx v4, a1, v8, v0.t
+
+vwmaccu.vv v4, v12, v8
+vwmaccu.vx v4, a1, v8
+vwmaccu.vv v4, v12, v8, v0.t
+vwmaccu.vx v4, a1, v8, v0.t
+vwmacc.vv v4, v12, v8
+vwmacc.vx v4, a1, v8
+vwmacc.vv v4, v12, v8, v0.t
+vwmacc.vx v4, a1, v8, v0.t
+vwmaccsu.vv v4, v12, v8
+vwmaccsu.vx v4, a1, v8
+vwmaccsu.vv v4, v12, v8, v0.t
+vwmaccsu.vx v4, a1, v8, v0.t
+vwmaccus.vx v4, a1, v8
+vwmaccus.vx v4, a1, v8, v0.t
+
+vdivu.vv v4, v8, v12
+vdivu.vx v4, v8, a1
+vdivu.vv v4, v8, v12, v0.t
+vdivu.vx v4, v8, a1, v0.t
+vdiv.vv v4, v8, v12
+vdiv.vx v4, v8, a1
+vdiv.vv v4, v8, v12, v0.t
+vdiv.vx v4, v8, a1, v0.t
+vremu.vv v4, v8, v12
+vremu.vx v4, v8, a1
+vremu.vv v4, v8, v12, v0.t
+vremu.vx v4, v8, a1, v0.t
+vrem.vv v4, v8, v12
+vrem.vx v4, v8, a1
+vrem.vv v4, v8, v12, v0.t
+vrem.vx v4, v8, a1, v0.t
+
+vmerge.vvm v4, v8, v12, v0
+vmerge.vxm v4, v8, a1, v0
+vmerge.vim v4, v8, 15, v0
+vmerge.vim v4, v8, -16, v0
+
+vmv.v.v v8, v12
+vmv.v.x v8, a1
+vmv.v.i v8, 15
+vmv.v.i v8, -16
+
+vsaddu.vv v4, v8, v12
+vsaddu.vx v4, v8, a1
+vsaddu.vi v4, v8, 15
+vsaddu.vi v4, v8, -16
+vsaddu.vv v4, v8, v12, v0.t
+vsaddu.vx v4, v8, a1, v0.t
+vsaddu.vi v4, v8, 15, v0.t
+vsaddu.vi v4, v8, -16, v0.t
+vsadd.vv v4, v8, v12
+vsadd.vx v4, v8, a1
+vsadd.vi v4, v8, 15
+vsadd.vi v4, v8, -16
+vsadd.vv v4, v8, v12, v0.t
+vsadd.vx v4, v8, a1, v0.t
+vsadd.vi v4, v8, 15, v0.t
+vsadd.vi v4, v8, -16, v0.t
+vssubu.vv v4, v8, v12
+vssubu.vx v4, v8, a1
+vssubu.vv v4, v8, v12, v0.t
+vssubu.vx v4, v8, a1, v0.t
+vssub.vv v4, v8, v12
+vssub.vx v4, v8, a1
+vssub.vv v4, v8, v12, v0.t
+vssub.vx v4, v8, a1, v0.t
+
+vaadd.vv v4, v8, v12
+vaadd.vx v4, v8, a1
+vaadd.vi v4, v8, 15
+vaadd.vi v4, v8, -16
+vaadd.vv v4, v8, v12, v0.t
+vaadd.vx v4, v8, a1, v0.t
+vaadd.vi v4, v8, 15, v0.t
+vaadd.vi v4, v8, -16, v0.t
+vasub.vv v4, v8, v12
+vasub.vx v4, v8, a1
+vasub.vv v4, v8, v12, v0.t
+vasub.vx v4, v8, a1, v0.t
+
+vsmul.vv v4, v8, v12
+vsmul.vx v4, v8, a1
+vsmul.vv v4, v8, v12, v0.t
+vsmul.vx v4, v8, a1, v0.t
+
+vwsmaccu.vv v4, v12, v8
+vwsmaccu.vx v4, a1, v8
+vwsmacc.vv v4, v12, v8
+vwsmacc.vx v4, a1, v8
+vwsmaccsu.vv v4, v12, v8
+vwsmaccsu.vx v4, a1, v8
+vwsmaccus.vx v4, a1, v8
+vwsmaccu.vv v4, v12, v8, v0.t
+vwsmaccu.vx v4, a1, v8, v0.t
+vwsmacc.vv v4, v12, v8, v0.t
+vwsmacc.vx v4, a1, v8, v0.t
+vwsmaccsu.vv v4, v12, v8, v0.t
+vwsmaccsu.vx v4, a1, v8, v0.t
+vwsmaccus.vx v4, a1, v8, v0.t
+
+vssrl.vv v4, v8, v12
+vssrl.vx v4, v8, a1
+vssrl.vi v4, v8, 1
+vssrl.vi v4, v8, 31
+vssrl.vv v4, v8, v12, v0.t
+vssrl.vx v4, v8, a1, v0.t
+vssrl.vi v4, v8, 1, v0.t
+vssrl.vi v4, v8, 31, v0.t
+vssra.vv v4, v8, v12
+vssra.vx v4, v8, a1
+vssra.vi v4, v8, 1
+vssra.vi v4, v8, 31
+vssra.vv v4, v8, v12, v0.t
+vssra.vx v4, v8, a1, v0.t
+vssra.vi v4, v8, 1, v0.t
+vssra.vi v4, v8, 31, v0.t
+
+vnclipu.vv v4, v8, v12
+vnclipu.vx v4, v8, a1
+vnclipu.vi v4, v8, 1
+vnclipu.vi v4, v8, 31
+vnclipu.vv v4, v8, v12, v0.t
+vnclipu.vx v4, v8, a1, v0.t
+vnclipu.vi v4, v8, 1, v0.t
+vnclipu.vi v4, v8, 31, v0.t
+vnclip.vv v4, v8, v12
+vnclip.vx v4, v8, a1
+vnclip.vi v4, v8, 1
+vnclip.vi v4, v8, 31
+vnclip.vv v4, v8, v12, v0.t
+vnclip.vx v4, v8, a1, v0.t
+vnclip.vi v4, v8, 1, v0.t
+vnclip.vi v4, v8, 31, v0.t
+
+vfadd.vv v4, v8, v12
+vfadd.vf v4, v8, fa2
+vfadd.vv v4, v8, v12, v0.t
+vfadd.vf v4, v8, fa2, v0.t
+vfsub.vv v4, v8, v12
+vfsub.vf v4, v8, fa2
+vfsub.vv v4, v8, v12, v0.t
+vfsub.vf v4, v8, fa2, v0.t
+vfrsub.vf v4, v8, fa2
+vfrsub.vf v4, v8, fa2, v0.t
+
+vfwadd.vv v4, v8, v12
+vfwadd.vf v4, v8, fa2
+vfwadd.vv v4, v8, v12, v0.t
+vfwadd.vf v4, v8, fa2, v0.t
+vfwsub.vv v4, v8, v12
+vfwsub.vf v4, v8, fa2
+vfwsub.vv v4, v8, v12, v0.t
+vfwsub.vf v4, v8, fa2, v0.t
+vfwadd.wv v4, v8, v12
+vfwadd.wf v4, v8, fa2
+vfwadd.wv v4, v8, v12, v0.t
+vfwadd.wf v4, v8, fa2, v0.t
+vfwsub.wv v4, v8, v12
+vfwsub.wf v4, v8, fa2
+vfwsub.wv v4, v8, v12, v0.t
+vfwsub.wf v4, v8, fa2, v0.t
+
+vfmul.vv v4, v8, v12
+vfmul.vf v4, v8, fa2
+vfmul.vv v4, v8, v12, v0.t
+vfmul.vf v4, v8, fa2, v0.t
+vfdiv.vv v4, v8, v12
+vfdiv.vf v4, v8, fa2
+vfdiv.vv v4, v8, v12, v0.t
+vfdiv.vf v4, v8, fa2, v0.t
+vfrdiv.vf v4, v8, fa2
+vfrdiv.vf v4, v8, fa2, v0.t
+
+vfwmul.vv v4, v8, v12
+vfwmul.vf v4, v8, fa2
+vfwmul.vv v4, v8, v12, v0.t
+vfwmul.vf v4, v8, fa2, v0.t
+
+vfmadd.vv v4, v12, v8
+vfmadd.vf v4, fa2, v8
+vfnmadd.vv v4, v12, v8
+vfnmadd.vf v4, fa2, v8
+vfmsub.vv v4, v12, v8
+vfmsub.vf v4, fa2, v8
+vfnmsub.vv v4, v12, v8
+vfnmsub.vf v4, fa2, v8
+vfmadd.vv v4, v12, v8, v0.t
+vfmadd.vf v4, fa2, v8, v0.t
+vfnmadd.vv v4, v12, v8, v0.t
+vfnmadd.vf v4, fa2, v8, v0.t
+vfmsub.vv v4, v12, v8, v0.t
+vfmsub.vf v4, fa2, v8, v0.t
+vfnmsub.vv v4, v12, v8, v0.t
+vfnmsub.vf v4, fa2, v8, v0.t
+vfmacc.vv v4, v12, v8
+vfmacc.vf v4, fa2, v8
+vfnmacc.vv v4, v12, v8
+vfnmacc.vf v4, fa2, v8
+vfmsac.vv v4, v12, v8
+vfmsac.vf v4, fa2, v8
+vfnmsac.vv v4, v12, v8
+vfnmsac.vf v4, fa2, v8
+vfmacc.vv v4, v12, v8, v0.t
+vfmacc.vf v4, fa2, v8, v0.t
+vfnmacc.vv v4, v12, v8, v0.t
+vfnmacc.vf v4, fa2, v8, v0.t
+vfmsac.vv v4, v12, v8, v0.t
+vfmsac.vf v4, fa2, v8, v0.t
+vfnmsac.vv v4, v12, v8, v0.t
+vfnmsac.vf v4, fa2, v8, v0.t
+
+vfwmacc.vv v4, v12, v8
+vfwmacc.vf v4, fa2, v8
+vfwnmacc.vv v4, v12, v8
+vfwnmacc.vf v4, fa2, v8
+vfwmsac.vv v4, v12, v8
+vfwmsac.vf v4, fa2, v8
+vfwnmsac.vv v4, v12, v8
+vfwnmsac.vf v4, fa2, v8
+vfwmacc.vv v4, v12, v8, v0.t
+vfwmacc.vf v4, fa2, v8, v0.t
+vfwnmacc.vv v4, v12, v8, v0.t
+vfwnmacc.vf v4, fa2, v8, v0.t
+vfwmsac.vv v4, v12, v8, v0.t
+vfwmsac.vf v4, fa2, v8, v0.t
+vfwnmsac.vv v4, v12, v8, v0.t
+vfwnmsac.vf v4, fa2, v8, v0.t
+
+vfsqrt.v v4, v8
+vfsqrt.v v4, v8, v0.t
+
+vfmin.vv v4, v8, v12
+vfmin.vf v4, v8, fa2
+vfmax.vv v4, v8, v12
+vfmax.vf v4, v8, fa2
+vfmin.vv v4, v8, v12, v0.t
+vfmin.vf v4, v8, fa2, v0.t
+vfmax.vv v4, v8, v12, v0.t
+vfmax.vf v4, v8, fa2, v0.t
+
+vfsgnj.vv v4, v8, v12
+vfsgnj.vf v4, v8, fa2
+vfsgnjn.vv v4, v8, v12
+vfsgnjn.vf v4, v8, fa2
+vfsgnjx.vv v4, v8, v12
+vfsgnjx.vf v4, v8, fa2
+vfsgnj.vv v4, v8, v12, v0.t
+vfsgnj.vf v4, v8, fa2, v0.t
+vfsgnjn.vv v4, v8, v12, v0.t
+vfsgnjn.vf v4, v8, fa2, v0.t
+vfsgnjx.vv v4, v8, v12, v0.t
+vfsgnjx.vf v4, v8, fa2, v0.t
+
+# TODO: rvv 0.7.1
+# Aliases
+# vmfgt.vv v4, v8, v12
+# vmfge.vv v4, v8, v12
+# vmfgt.vv v4, v8, v12, v0.t
+# vmfge.vv v4, v8, v12, v0.t
+
+vmfeq.vv v4, v8, v12
+vmfeq.vf v4, v8, fa2
+vmfne.vv v4, v8, v12
+vmfne.vf v4, v8, fa2
+vmflt.vv v4, v8, v12
+vmflt.vf v4, v8, fa2
+vmfle.vv v4, v8, v12
+vmfle.vf v4, v8, fa2
+vmfgt.vf v4, v8, fa2
+vmfge.vf v4, v8, fa2
+vmfeq.vv v4, v8, v12, v0.t
+vmfeq.vf v4, v8, fa2, v0.t
+vmfne.vv v4, v8, v12, v0.t
+vmfne.vf v4, v8, fa2, v0.t
+vmflt.vv v4, v8, v12, v0.t
+vmflt.vf v4, v8, fa2, v0.t
+vmfle.vv v4, v8, v12, v0.t
+vmfle.vf v4, v8, fa2, v0.t
+vmfgt.vf v4, v8, fa2, v0.t
+vmfge.vf v4, v8, fa2, v0.t
+
+vmford.vv v4, v8, v12
+vmford.vf v4, v8, fa2
+vmford.vv v4, v8, v12, v0.t
+vmford.vf v4, v8, fa2, v0.t
+
+vfclass.v v4, v8
+vfclass.v v4, v8, v0.t
+
+vfmerge.vfm v4, v8, fa2, v0
+vfmv.v.f v4, fa1
+
+vfcvt.xu.f.v v4, v8
+vfcvt.x.f.v v4, v8
+vfcvt.f.xu.v v4, v8
+vfcvt.f.x.v v4, v8
+vfcvt.xu.f.v v4, v8, v0.t
+vfcvt.x.f.v v4, v8, v0.t
+vfcvt.f.xu.v v4, v8, v0.t
+vfcvt.f.x.v v4, v8, v0.t
+
+vfwcvt.xu.f.v v4, v8
+vfwcvt.x.f.v v4, v8
+vfwcvt.f.xu.v v4, v8
+vfwcvt.f.x.v v4, v8
+vfwcvt.f.f.v v4, v8
+vfwcvt.xu.f.v v4, v8, v0.t
+vfwcvt.x.f.v v4, v8, v0.t
+vfwcvt.f.xu.v v4, v8, v0.t
+vfwcvt.f.x.v v4, v8, v0.t
+vfwcvt.f.f.v v4, v8, v0.t
+
+vfncvt.xu.f.v v4, v8
+vfncvt.x.f.v v4, v8
+vfncvt.f.xu.v v4, v8
+vfncvt.f.x.v v4, v8
+vfncvt.f.f.v v4, v8
+vfncvt.xu.f.v v4, v8, v0.t
+vfncvt.x.f.v v4, v8, v0.t
+vfncvt.f.xu.v v4, v8, v0.t
+vfncvt.f.x.v v4, v8, v0.t
+vfncvt.f.f.v v4, v8, v0.t
+
+vredsum.vs v4, v8, v12
+vredmaxu.vs v4, v8, v8
+vredmax.vs v4, v8, v8
+vredminu.vs v4, v8, v8
+vredmin.vs v4, v8, v8
+vredand.vs v4, v8, v12
+vredor.vs v4, v8, v12
+vredxor.vs v4, v8, v12
+vredsum.vs v4, v8, v12, v0.t
+vredmaxu.vs v4, v8, v8, v0.t
+vredmax.vs v4, v8, v8, v0.t
+vredminu.vs v4, v8, v8, v0.t
+vredmin.vs v4, v8, v8, v0.t
+vredand.vs v4, v8, v12, v0.t
+vredor.vs v4, v8, v12, v0.t
+vredxor.vs v4, v8, v12, v0.t
+
+vwredsumu.vs v4, v8, v12
+vwredsum.vs v4, v8, v12
+vwredsumu.vs v4, v8, v12, v0.t
+vwredsum.vs v4, v8, v12, v0.t
+
+vfredosum.vs v4, v8, v12
+vfredsum.vs v4, v8, v12
+vfredmax.vs v4, v8, v12
+vfredmin.vs v4, v8, v12
+vfredosum.vs v4, v8, v12, v0.t
+vfredsum.vs v4, v8, v12, v0.t
+vfredmax.vs v4, v8, v12, v0.t
+vfredmin.vs v4, v8, v12, v0.t
+
+vfwredosum.vs v4, v8, v12
+vfwredsum.vs v4, v8, v12
+vfwredosum.vs v4, v8, v12, v0.t
+vfwredsum.vs v4, v8, v12, v0.t
+
+# TODO: rvv 0.7.1
+# Aliases
+# vmcpy.m v4, v8
+# vmclr.m v4
+# vmset.m v4
+# vmnot.m v4, v8
+
+vmand.mm v4, v8, v12
+vmnand.mm v4, v8, v12
+vmandnot.mm v4, v8, v12
+vmxor.mm v4, v8, v12
+vmor.mm v4, v8, v12
+vmnor.mm v4, v8, v12
+vmornot.mm v4, v8, v12
+vmxnor.mm v4, v8, v12
+
+vmpopc.m a0, v12
+vmfirst.m a0, v12
+vmsbf.m v4, v8
+vmsif.m v4, v8
+vmsof.m v4, v8
+viota.m v4, v8
+vid.v v4
+vmpopc.m a0, v12, v0.t
+vmfirst.m a0, v12, v0.t
+vmsbf.m v4, v8, v0.t
+vmsif.m v4, v8, v0.t
+vmsof.m v4, v8, v0.t
+viota.m v4, v8, v0.t
+vid.v v4, v0.t
+
+# TODO: rvv 0.7.1
+# Alias
+# vmv.x.s a0, v12
+
+vext.x.v a0, v12, a2
+vmv.s.x v4, a0
+
+vfmv.f.s fa0, v8
+vfmv.s.f v4, fa1
+
+vslideup.vx v4, v8, a1
+vslideup.vi v4, v8, 0
+vslideup.vi v4, v8, 31
+vslidedown.vx v4, v8, a1
+vslidedown.vi v4, v8, 0
+vslidedown.vi v4, v8, 31
+vslideup.vx v4, v8, a1, v0.t
+vslideup.vi v4, v8, 0, v0.t
+vslideup.vi v4, v8, 31, v0.t
+vslidedown.vx v4, v8, a1, v0.t
+vslidedown.vi v4, v8, 0, v0.t
+vslidedown.vi v4, v8, 31, v0.t
+
+vslide1up.vx v4, v8, a1
+vslide1down.vx v4, v8, a1
+vslide1up.vx v4, v8, a1, v0.t
+vslide1down.vx v4, v8, a1, v0.t
+
+vrgather.vv v4, v8, v12
+vrgather.vx v4, v8, a1
+vrgather.vi v4, v8, 0
+vrgather.vi v4, v8, 31
+vrgather.vv v4, v8, v12, v0.t
+vrgather.vx v4, v8, a1, v0.t
+vrgather.vi v4, v8, 0, v0.t
+vrgather.vi v4, v8, 31, v0.t
+
+vcompress.vm v4, v8, v12
+
+csrr a0, vstart
+csrr a0, vxsat
+csrr a0, vxrm
+csrr a0, vl
+csrr a0, vtype


### PR DESCRIPTION
This PR adapted rvv 0.7.1 assembler tests from [binutils-gdb](https://github.com/riscvarchive/riscv-binutils-gdb/blob/rvv-0.7.1/gas/testsuite/gas/riscv/vector-insns.d).

Running the test reveals that `Vamo` instructions, some pseudo-instructions, and macros are not implemented, which will be addressed in future PRs.