### PR TITLE
[RVV 0.7.1] ensure `vmsge{u}.vx` does not use the same register for emporary and destination

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -3407,7 +3407,9 @@ bool RISCVAsmParser::validateInstruction(MCInst &Inst,
   unsigned Opcode = Inst.getOpcode();
 
   if (Opcode == RISCV::PseudoVMSGEU_VX_M_T ||
-      Opcode == RISCV::PseudoVMSGE_VX_M_T) {
+      Opcode == RISCV::PseudoVMSGE_VX_M_T ||
+      Opcode == RISCV::PseudoXVMSGEU_VX_M_T ||
+      Opcode == RISCV::PseudoXVMSGE_VX_M_T) {
     unsigned DestReg = Inst.getOperand(0).getReg();
     unsigned TempReg = Inst.getOperand(1).getReg();
     if (DestReg == TempReg) {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadV.td
@@ -789,7 +789,7 @@ defm XVCOMPRESS_V : VCPR_MV_Mask<"vcompress", 0b010111>;
 } // Predicates = [HasVendorXTHeadV]
 } // AsmVariantName = "RVV0p71", DecoderNamespace = "RVV0p71"
 
-// Pesudo instructions
+// Pseudo instructions
 let AsmVariantName = "RVV0p71" in {
 let Predicates = [HasVendorXTHeadV] in {
 // Vector Integer Comparison Instructions

--- a/llvm/test/MC/RISCV/rvv0p71/invalid.s
+++ b/llvm/test/MC/RISCV/rvv0p71/invalid.s
@@ -1,0 +1,14 @@
+# RUN: not llvm-mc -triple=riscv64 --mattr=+xtheadv %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+
+vmsge.vx v2, v4, a0, v0.t, v0
+# CHECK-ERROR: invalid operand for instruction
+
+vmsgeu.vx v2, v4, a0, v0.t, v0
+# CHECK-ERROR: invalid operand for instruction
+
+vmsge.vx v2, v4, a0, v0.t, v2
+# CHECK-ERROR: The temporary vector register cannot be the same as the destination register.
+
+vmsgeu.vx v2, v4, a0, v0.t, v2
+# CHECK-ERROR: The temporary vector register cannot be the same as the destination register.


### PR DESCRIPTION
Discovered by randomly fuzzing instructions from `llvm/test/MC/RISCV/rvv`