### PR TITLE
[RVV 0.7.1] add vector integer compare, the vi case

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -165,6 +165,10 @@ class RISCVAsmParser : public MCTargetAsmParser {
   // Helper to emit pseudo vmsge{u}.vx instruction.
   void emitVMSGE(MCInst &Inst, unsigned Opcode, SMLoc IDLoc, MCStreamer &Out);
 
+  // Helper to emit pseudo vmsge{u}.vi instruction.
+  void emitVMSGE_VI(MCInst &Inst, unsigned Opcode, unsigned OpcodeImmIs0,
+                    SMLoc IDLoc, MCStreamer &Out, bool IsSigned);
+
   // Helper to emit pseudo vmsge{u}.vx instruction for XTHeadV extension.
   void emitXVMSGE(MCInst &Inst, unsigned Opcode, SMLoc IDLoc, MCStreamer &Out);
 
@@ -3378,6 +3382,38 @@ void RISCVAsmParser::emitXVMSGE(MCInst &Inst, unsigned Opcode, SMLoc IDLoc,
   }
 }
 
+void RISCVAsmParser::emitVMSGE_VI(MCInst &Inst, unsigned Opcode,
+                                  unsigned OpcodeImmIs0, SMLoc IDLoc,
+                                  MCStreamer &Out, bool IsSigned) {
+  int64_t Imm = Inst.getOperand(2).getImm();
+  if (IsSigned) {
+    // These instructions are signed and so is immediate so we can subtract one.
+    emitToStreamer(Out, MCInstBuilder(Opcode)
+                            .addOperand(Inst.getOperand(0))
+                            .addOperand(Inst.getOperand(1))
+                            .addImm(Imm - 1)
+                            .addOperand(Inst.getOperand(3)));
+  } else {
+    // Unsigned comparisons are tricky because the immediate is signed. If the
+    // immediate is 0 we can't just subtract one. vmsltu.vi v0, v1, 0 is always
+    // false, but vmsle.vi v0, v1, -1 is always true. Instead we use
+    // vmsne v0, v1, v1 which is always false.
+    if (Imm == 0) {
+      emitToStreamer(Out, MCInstBuilder(OpcodeImmIs0)
+                              .addOperand(Inst.getOperand(0))
+                              .addOperand(Inst.getOperand(1))
+                              .addOperand(Inst.getOperand(1))
+                              .addOperand(Inst.getOperand(3)));
+    } else {
+      // Other immediate values can subtract one like signed.
+      emitToStreamer(Out, MCInstBuilder(Opcode)
+                              .addOperand(Inst.getOperand(0))
+                              .addOperand(Inst.getOperand(1))
+                              .addImm(Imm - 1)
+                              .addOperand(Inst.getOperand(3)));
+    }
+  }
+}
 
 bool RISCVAsmParser::checkPseudoAddTPRel(MCInst &Inst,
                                          OperandVector &Operands) {
@@ -3661,49 +3697,17 @@ bool RISCVAsmParser::processInstruction(MCInst &Inst, SMLoc IDLoc,
     emitVMSGE(Inst, RISCV::VMSLT_VX, IDLoc, Out);
     return false;
   case RISCV::PseudoVMSGE_VI:
-  case RISCV::PseudoVMSLT_VI: {
-    // These instructions are signed and so is immediate so we can subtract one
-    // and change the opcode.
-    int64_t Imm = Inst.getOperand(2).getImm();
-    unsigned Opc = Inst.getOpcode() == RISCV::PseudoVMSGE_VI ? RISCV::VMSGT_VI
-                                                             : RISCV::VMSLE_VI;
-    emitToStreamer(Out, MCInstBuilder(Opc)
-                            .addOperand(Inst.getOperand(0))
-                            .addOperand(Inst.getOperand(1))
-                            .addImm(Imm - 1)
-                            .addOperand(Inst.getOperand(3)));
+    emitVMSGE_VI(Inst, RISCV::VMSGT_VI, RISCV::VMSGT_VI, IDLoc, Out, true);
     return false;
-  }
+  case RISCV::PseudoVMSLT_VI:
+    emitVMSGE_VI(Inst, RISCV::VMSLE_VI, RISCV::VMSLE_VI, IDLoc, Out, true);
+    return false;
   case RISCV::PseudoVMSGEU_VI:
-  case RISCV::PseudoVMSLTU_VI: {
-    int64_t Imm = Inst.getOperand(2).getImm();
-    // Unsigned comparisons are tricky because the immediate is signed. If the
-    // immediate is 0 we can't just subtract one. vmsltu.vi v0, v1, 0 is always
-    // false, but vmsle.vi v0, v1, -1 is always true. Instead we use
-    // vmsne v0, v1, v1 which is always false.
-    if (Imm == 0) {
-      unsigned Opc = Inst.getOpcode() == RISCV::PseudoVMSGEU_VI
-                         ? RISCV::VMSEQ_VV
-                         : RISCV::VMSNE_VV;
-      emitToStreamer(Out, MCInstBuilder(Opc)
-                              .addOperand(Inst.getOperand(0))
-                              .addOperand(Inst.getOperand(1))
-                              .addOperand(Inst.getOperand(1))
-                              .addOperand(Inst.getOperand(3)));
-    } else {
-      // Other immediate values can subtract one like signed.
-      unsigned Opc = Inst.getOpcode() == RISCV::PseudoVMSGEU_VI
-                         ? RISCV::VMSGTU_VI
-                         : RISCV::VMSLEU_VI;
-      emitToStreamer(Out, MCInstBuilder(Opc)
-                              .addOperand(Inst.getOperand(0))
-                              .addOperand(Inst.getOperand(1))
-                              .addImm(Imm - 1)
-                              .addOperand(Inst.getOperand(3)));
-    }
-
+    emitVMSGE_VI(Inst, RISCV::VMSGTU_VI, RISCV::VMSEQ_VV, IDLoc, Out, false);
     return false;
-  }
+  case RISCV::PseudoVMSLTU_VI:
+    emitVMSGE_VI(Inst, RISCV::VMSLEU_VI, RISCV::VMSNE_VV, IDLoc, Out, false);
+    return false;
   // for XTHeadV Extension
   case RISCV::PseudoXVMSGEU_VX:
   case RISCV::PseudoXVMSGEU_VX_M:

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -3719,6 +3719,18 @@ bool RISCVAsmParser::processInstruction(MCInst &Inst, SMLoc IDLoc,
   case RISCV::PseudoXVMSGE_VX_M_T:
     emitXVMSGE(Inst, RISCV::XVMSLT_VX, IDLoc, Out);
     return false;
+  case RISCV::PseudoXVMSGE_VI:
+    emitVMSGE_VI(Inst, RISCV::XVMSGT_VI, RISCV::XVMSGT_VI, IDLoc, Out, true);
+    return false;
+  case RISCV::PseudoXVMSLT_VI:
+    emitVMSGE_VI(Inst, RISCV::XVMSLE_VI, RISCV::XVMSLE_VI, IDLoc, Out, true);
+    return false;
+  case RISCV::PseudoXVMSGEU_VI:
+    emitVMSGE_VI(Inst, RISCV::XVMSGTU_VI, RISCV::XVMSEQ_VV, IDLoc, Out, false);
+    return false;
+  case RISCV::PseudoXVMSLTU_VI:
+    emitVMSGE_VI(Inst, RISCV::XVMSLEU_VI, RISCV::XVMSNE_VV, IDLoc, Out, false);
+    return false;
   }
 
   emitToStreamer(Out, Inst);

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadV.td
@@ -802,6 +802,29 @@ def : InstAlias<"vmsgeu.vv $vd, $va, $vb$vm",
 def : InstAlias<"vmsge.vv $vd, $va, $vb$vm",
                 (XVMSLE_VV VR:$vd, VR:$vb, VR:$va, VMaskOp:$vm), 0>;
 
+let isCodeGenOnly = 0, isAsmParserOnly = 1, hasSideEffects = 0, mayLoad = 0,
+    mayStore = 0 in {
+// For unsigned comparisons we need to special case 0 immediate to maintain
+// the always true/false semantics we would invert if we just decremented the
+// immediate like we do for signed. To match the GNU assembler we will use
+// vmseq/vmsne.vv with the same register for both operands which we can't do
+// from an InstAlias.
+def PseudoXVMSGEU_VI : Pseudo<(outs VR:$vd),
+                              (ins VR:$vs2, simm5_plus1:$imm, VMaskOp:$vm),
+                              [], "vmsgeu.vi", "$vd, $vs2, $imm$vm">;
+def PseudoXVMSLTU_VI : Pseudo<(outs VR:$vd),
+                              (ins VR:$vs2, simm5_plus1:$imm, VMaskOp:$vm),
+                              [], "vmsltu.vi", "$vd, $vs2, $imm$vm">;
+// Handle signed with pseudos as well for more consistency in the
+// implementation.
+def PseudoXVMSGE_VI : Pseudo<(outs VR:$vd),
+                             (ins VR:$vs2, simm5_plus1:$imm, VMaskOp:$vm),
+                             [], "vmsge.vi", "$vd, $vs2, $imm$vm">;
+def PseudoXVMSLT_VI : Pseudo<(outs VR:$vd),
+                             (ins VR:$vs2, simm5_plus1:$imm, VMaskOp:$vm),
+                             [], "vmslt.vi", "$vd, $vs2, $imm$vm">;
+}
+
 // These pseudos need to be handled in RISCVAsmParser.cpp
 let isCodeGenOnly = 0, isAsmParserOnly = 1, hasSideEffects = 0, mayLoad = 0,
     mayStore = 0 in {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadV.td
@@ -802,6 +802,7 @@ def : InstAlias<"vmsgeu.vv $vd, $va, $vb$vm",
 def : InstAlias<"vmsge.vv $vd, $va, $vb$vm",
                 (XVMSLE_VV VR:$vd, VR:$vb, VR:$va, VMaskOp:$vm), 0>;
 
+// These pseudos need to be handled in RISCVAsmParser::processInstruction
 let isCodeGenOnly = 0, isAsmParserOnly = 1, hasSideEffects = 0, mayLoad = 0,
     mayStore = 0 in {
 // For unsigned comparisons we need to special case 0 immediate to maintain
@@ -825,7 +826,7 @@ def PseudoXVMSLT_VI : Pseudo<(outs VR:$vd),
                              [], "vmslt.vi", "$vd, $vs2, $imm$vm">;
 }
 
-// These pseudos need to be handled in RISCVAsmParser.cpp
+// These pseudos need to be handled in RISCVAsmParser::processInstruction
 let isCodeGenOnly = 0, isAsmParserOnly = 1, hasSideEffects = 0, mayLoad = 0,
     mayStore = 0 in {
 def PseudoXVMSGEU_VX : Pseudo<(outs VR:$vd),

--- a/llvm/test/MC/RISCV/rvv0p71/vector-insns.s
+++ b/llvm/test/MC/RISCV/rvv0p71/vector-insns.s
@@ -4868,90 +4868,74 @@ vmsge.vx v4, v8, a1, v0.t, v12
 
 vmsgeu.vx v4, v8, a1, v0.t, v12
 # CHECK-INST: vmsltu.vx v12, v8, a1
-# TODO: GCC adds v0.t to the above vmslt.vx
+# TODO: GCC produces vmsltu.vx v12, v8, a1, v0.t
 # CHECK-ENCODING: [0x57,0xc6,0x85,0x6a]
 # CHECK-INST: vmandnot.mm v4, v4, v12
 # CHECK-ENCODING: [0x57,0x22,0x46,0x62]
 
-# TODO: rvv 0.7.1
-# vmslt.vi v4, v8, 16
-# CHECK-INST-TODO: vmsle.vi	v4, v8, 15
-# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x76]
+vmslt.vi v4, v8, 16
+# CHECK-INST: vmsle.vi	v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x76]
 
-# TODO: rvv 0.7.1
-# vmslt.vi v4, v8, -15
-# CHECK-INST-TODO: vmsle.vi	v4, v8, -16
-# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x76]
+vmslt.vi v4, v8, -15
+# CHECK-INST: vmsle.vi	v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x76]
 
-# TODO: rvv 0.7.1
-# vmsltu.vi v4, v8, 16
-# CHECK-INST-TODO: vmsleu.vi	v4, v8, 15
-# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x72]
+vmsltu.vi v4, v8, 16
+# CHECK-INST: vmsleu.vi	v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x72]
 
-# TODO: rvv 0.7.1
-# vmsltu.vi v4, v8, -15
-# CHECK-INST-TODO: vmsleu.vi	v4, v8, -16
-# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x72]
+vmsltu.vi v4, v8, -15
+# CHECK-INST: vmsleu.vi	v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x72]
 
-# TODO: rvv 0.7.1
-# vmsge.vi v4, v8, 16
-# CHECK-INST-TODO: vmsgt.vi	v4, v8, 15
-# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x7e]
+vmsge.vi v4, v8, 16
+# CHECK-INST: vmsgt.vi	v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x7e]
 
-# TODO: rvv 0.7.1
-# vmsge.vi v4, v8, -15
-# CHECK-INST-TODO: vmsgt.vi	v4, v8, -16
-# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x7e]
+vmsge.vi v4, v8, -15
+# CHECK-INST: vmsgt.vi	v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x7e]
 
-# TODO: rvv 0.7.1
-# vmsgeu.vi v4, v8, 16
-# CHECK-INST-TODO: vmsgtu.vi	v4, v8, 15
-# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x7a]
+vmsgeu.vi v4, v8, 16
+# CHECK-INST: vmsgtu.vi	v4, v8, 15
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x7a]
 
-# TODO: rvv 0.7.1
-# vmsgeu.vi v4, v8, -15
-# CHECK-INST-TODO: vmsgtu.vi	v4, v8, -16
-# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x7a]
+vmsgeu.vi v4, v8, -15
+# CHECK-INST: vmsgtu.vi	v4, v8, -16
+# CHECK-ENCODING: [0x57,0x32,0x88,0x7a]
 
-# TODO: rvv 0.7.1
-# vmslt.vi v4, v8, 16, v0.t
-# CHECK-INST-TODO: vmsle.vi	v4, v8, 15, v0.t
-# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x74]
+vmslt.vi v4, v8, 16, v0.t
+# CHECK-INST: vmsle.vi	v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x74]
 
-# TODO: rvv 0.7.1
-# vmslt.vi v4, v8, -15, v0.t
-# CHECK-INST-TODO: vmsle.vi	v4, v8, -16, v0.t
-# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x74]
+vmslt.vi v4, v8, -15, v0.t
+# CHECK-INST: vmsle.vi	v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x74]
 
-# TODO: rvv 0.7.1
-# vmsltu.vi v4, v8, 16, v0.t
-# CHECK-INST-TODO: vmsleu.vi	v4, v8, 15, v0.t
-# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x70]
+vmsltu.vi v4, v8, 16, v0.t
+# CHECK-INST: vmsleu.vi	v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x70]
 
-# TODO: rvv 0.7.1
-# vmsltu.vi v4, v8, -15, v0.t
-# CHECK-INST-TODO: vmsleu.vi	v4, v8, -16, v0.t
-# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x70]
+vmsltu.vi v4, v8, -15, v0.t
+# CHECK-INST: vmsleu.vi	v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x70]
 
-# TODO: rvv 0.7.1
-# vmsge.vi v4, v8, 16, v0.t
-# CHECK-INST-TODO: vmsgt.vi	v4, v8, 15, v0.t
-# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x7c]
+vmsge.vi v4, v8, 16, v0.t
+# CHECK-INST: vmsgt.vi	v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x7c]
 
-# TODO: rvv 0.7.1
-# vmsge.vi v4, v8, -15, v0.t
-# CHECK-INST-TODO: vmsgt.vi	v4, v8, -16, v0.t
-# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x7c]
+vmsge.vi v4, v8, -15, v0.t
+# CHECK-INST: vmsgt.vi	v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x7c]
 
-# TODO: rvv 0.7.1
-# vmsgeu.vi v4, v8, 16, v0.t
-# CHECK-INST-TODO: vmsgtu.vi	v4, v8, 15, v0.t
-# CHECK-ENCODING-TODO: [0x57,0xb2,0x87,0x78]
+vmsgeu.vi v4, v8, 16, v0.t
+# CHECK-INST: vmsgtu.vi	v4, v8, 15, v0.t
+# CHECK-ENCODING: [0x57,0xb2,0x87,0x78]
 
-# TODO: rvv 0.7.1
-# vmsgeu.vi v4, v8, -15, v0.t
-# CHECK-INST-TODO: vmsgtu.vi	v4, v8, -16, v0.t
-# CHECK-ENCODING-TODO: [0x57,0x32,0x88,0x78]
+vmsgeu.vi v4, v8, -15, v0.t
+# CHECK-INST: vmsgtu.vi	v4, v8, -16, v0.t
+# CHECK-ENCODING: [0x57,0x32,0x88,0x78]
 
 vmseq.vv v4, v8, v12
 # CHECK-INST: vmseq.vv	v4, v8, v12


### PR DESCRIPTION
Now all vector integer compare pseudo-instructions should be supported.