### PR TITLE
[LLVM] [RVV 0.7.1] add `vsetvl` and `vsetvlmax` intrinsic

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsRISCV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCV.td
@@ -1841,3 +1841,4 @@ def int_riscv_sm3p1      : ScalarCryptoGprIntrinsic32;
 //===----------------------------------------------------------------------===//
 include "llvm/IR/IntrinsicsRISCVXTHead.td"
 include "llvm/IR/IntrinsicsRISCVXsf.td"
+include "llvm/IR/IntrinsicsRISCVXTHeadV.td"

--- a/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
@@ -14,28 +14,34 @@
 // Vectors version 0.7.1
 
 let TargetPrefix = "riscv" in {
+  def int_riscv_xvsetvl  : Intrinsic<[llvm_i64_ty],
+                                     [llvm_i64_ty, llvm_i64_ty],
+                                     [IntrNoMem]>;
+  def int_riscv_xvsetvli : Intrinsic<[llvm_i64_ty],
+                                     [llvm_i64_ty, llvm_i64_ty],
+                                     [IntrNoMem]>;
 
-  defm xvadd : RISCVBinaryAAX;
-  defm xvsub : RISCVBinaryAAX;
-  defm xvrsub : RISCVBinaryAAX;
-
-  defm xvand : RISCVBinaryAAX;
-  defm xvor : RISCVBinaryAAX;
-  defm xvxor : RISCVBinaryAAX;
-
-  defm xvminu : RISCVBinaryAAX;
-  defm xvmin : RISCVBinaryAAX;
-  defm xvmaxu : RISCVBinaryAAX;
-  defm xvmax : RISCVBinaryAAX;
-
-  defm xvmul : RISCVBinaryAAX;
-  defm xvmulh : RISCVBinaryAAX;
-  defm xvmulhu : RISCVBinaryAAX;
-  defm xvmulhsu : RISCVBinaryAAX;
-
-  defm xvdivu : RISCVBinaryAAX;
-  defm xvdiv : RISCVBinaryAAX;
-  defm xvremu : RISCVBinaryAAX;
-  defm xvrem : RISCVBinaryAAX;
+//  defm xvadd : RISCVBinaryAAX;
+//  defm xvsub : RISCVBinaryAAX;
+//  defm xvrsub : RISCVBinaryAAX;
+//
+//  defm xvand : RISCVBinaryAAX;
+//  defm xvor : RISCVBinaryAAX;
+//  defm xvxor : RISCVBinaryAAX;
+//
+//  defm xvminu : RISCVBinaryAAX;
+//  defm xvmin : RISCVBinaryAAX;
+//  defm xvmaxu : RISCVBinaryAAX;
+//  defm xvmax : RISCVBinaryAAX;
+//
+//  defm xvmul : RISCVBinaryAAX;
+//  defm xvmulh : RISCVBinaryAAX;
+//  defm xvmulhu : RISCVBinaryAAX;
+//  defm xvmulhsu : RISCVBinaryAAX;
+//
+//  defm xvdivu : RISCVBinaryAAX;
+//  defm xvdiv : RISCVBinaryAAX;
+//  defm xvremu : RISCVBinaryAAX;
+//  defm xvrem : RISCVBinaryAAX;
 
 } // TargetPrefix = "riscv"

--- a/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
@@ -14,12 +14,13 @@
 // Vectors version 0.7.1
 
 let TargetPrefix = "riscv" in {
-  def int_riscv_xvsetvl  : Intrinsic<[llvm_i64_ty],
-                                     [llvm_i64_ty, llvm_i64_ty],
-                                     [IntrNoMem]>;
-  def int_riscv_xvsetvli : Intrinsic<[llvm_i64_ty],
-                                     [llvm_i64_ty, llvm_i64_ty],
-                                     [IntrNoMem]>;
+  // 6.1. vsetvli/vsetvl instructions
+  def int_riscv_xvsetvl    : Intrinsic<[llvm_i64_ty],
+                                       [/* AVL */ llvm_i64_ty, /* vtype */ llvm_i64_ty],
+                                       [IntrNoMem]>;
+  def int_riscv_xvsetvlmax : Intrinsic<[llvm_i64_ty],
+                                       [/* vtype */ llvm_i64_ty],
+                                       [IntrNoMem]>;
 
 //  defm xvadd : RISCVBinaryAAX;
 //  defm xvsub : RISCVBinaryAAX;

--- a/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
@@ -1,0 +1,41 @@
+//===- IntrinsicsRISCVXTHeadV.td - RVV 0.7.1 intrinsics ----*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines all of RISC-V Vector Extension version 0.7.1 intrinsics.
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Vectors version 0.7.1
+
+let TargetPrefix = "riscv" in {
+
+  defm xvadd : RISCVBinaryAAX;
+  defm xvsub : RISCVBinaryAAX;
+  defm xvrsub : RISCVBinaryAAX;
+
+  defm xvand : RISCVBinaryAAX;
+  defm xvor : RISCVBinaryAAX;
+  defm xvxor : RISCVBinaryAAX;
+
+  defm xvminu : RISCVBinaryAAX;
+  defm xvmin : RISCVBinaryAAX;
+  defm xvmaxu : RISCVBinaryAAX;
+  defm xvmax : RISCVBinaryAAX;
+
+  defm xvmul : RISCVBinaryAAX;
+  defm xvmulh : RISCVBinaryAAX;
+  defm xvmulhu : RISCVBinaryAAX;
+  defm xvmulhsu : RISCVBinaryAAX;
+
+  defm xvdivu : RISCVBinaryAAX;
+  defm xvdiv : RISCVBinaryAAX;
+  defm xvremu : RISCVBinaryAAX;
+  defm xvrem : RISCVBinaryAAX;
+
+} // TargetPrefix = "riscv"

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadV.td
@@ -889,3 +889,8 @@ def : InstAlias<"vmnot.m $vd, $vs",
 } // Predicates = [HasVendorXTHeadV]
 } // AsmVariantName = "RVV0p71"
 
+//===----------------------------------------------------------------------===//
+// Patterns.
+//===----------------------------------------------------------------------===//
+
+def : Pat<(int_riscv_xvsetvl GPR:$rs1, GPR:$rs2), (XVSETVL GPR:$rs1, GPR:$rs2)>;

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vsetvl.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vsetvl.ll
@@ -1,0 +1,11 @@
+; RUN: llc -mtriple=riscv64 -mattr=+xtheadv < %s | FileCheck -check-prefix=CHECK %s
+
+declare i64 @llvm.riscv.xvsetvl(i64, i64);
+define i64 @intrinsic_xvsetvl_e8m1(i64 %0) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e8m1
+; CHECK: vsetvl a0, a0, zero
+; CHECK: ret
+  %v = tail call i64 @llvm.riscv.xvsetvl(i64 %0, i64 0)
+  ret i64 %v
+}

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vsetvl.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vsetvl.ll
@@ -1,11 +1,160 @@
 ; RUN: llc -mtriple=riscv64 -mattr=+xtheadv < %s | FileCheck -check-prefix=CHECK %s
 
-declare i64 @llvm.riscv.xvsetvl(i64, i64);
-define i64 @intrinsic_xvsetvl_e8m1(i64 %0) {
+; https://github.com/riscv-non-isa/rvv-intrinsic-doc/blob/v0.7.1/rvv_intrinsic_funcs/01_configuration-setting_and_utility_functions.md
+
+; The spec allowed e128, but intrinsic only support e8, e16, e32, e64
+; vtype = ((ediv & 0b11) << 5) | ((sew & 0b111) << 2) | ((lmul & 0b11) << 0)
+; -------------------------------------------
+; | ASM name | e8  | e16 | e32 | e64 | e128 |
+; | SEW      | 0   | 1   | 2   | 3   | 4    |
+; | SEW bin  | 000 | 001 | 010 | 011 | 100  |
+; -------------------------------------------
+; | ASM name | m1 | m2  | m4  | m8  |
+; | LMUL     | 0  | 1   | 2   | 3   |
+; | LMUL bin | 00 | 01  | 10  | 11  |
+; -----------------------------------
+
+declare i64 @llvm.riscv.xvsetvl(i64 %avl, i64 %vtype);
+
+define i64 @intrinsic_xvsetvl_e8m1(i64 %avl) {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvl_e8m1
 ; CHECK: vsetvl a0, a0, zero
-; CHECK: ret
-  %v = tail call i64 @llvm.riscv.xvsetvl(i64 %0, i64 0)
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 0)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e8m2(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e8m2
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 1)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e8m4(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e8m4
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 2)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e8m8(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e8m8
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 3)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e16m1(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e16m1
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 4)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e16m2(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e16m2
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 5)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e16m4(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e16m4
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 6)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e16m8(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e16m8
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 7)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e32m1(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e32m1
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 8)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e32m2(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e32m2
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 9)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e32m4(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e32m4
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 10)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e32m8(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e32m8
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 11)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e64m1(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e64m1
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 12)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e64m2(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e64m2
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 13)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e64m4(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e64m4
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 14)
+  ret i64 %v
+}
+
+
+define i64 @intrinsic_xvsetvl_e64m8(i64 %avl) {
+entry:
+; CHECK-LABEL: intrinsic_xvsetvl_e64m8
+; CHECK: vsetvl a0, a0, a1
+  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 15)
   ret i64 %v
 }


### PR DESCRIPTION
- [Intrinsic docs](https://github.com/riscv-non-isa/rvv-intrinsic-doc/blob/v0.7.1/rvv_intrinsic_funcs/01_configuration-setting_and_utility_functions.md)

Currently no `mf2`, `mf4`, `mf8` support for `LMUL`