### PR TITLE
[Clang][RVV 0.7.1] add some intrinsics to figure out how it worked

### DIFF
--- a/clang/include/clang/Basic/BuiltinsRISCVVector.def
+++ b/clang/include/clang/Basic/BuiltinsRISCVVector.def
@@ -17,6 +17,7 @@
 
 #include "clang/Basic/riscv_vector_builtins.inc"
 #include "clang/Basic/riscv_sifive_vector_builtins.inc"
+#include "clang/Basic/riscv_xtheadv_builtins.inc"
 
 #undef BUILTIN
 #undef TARGET_BUILTIN

--- a/clang/include/clang/Basic/CMakeLists.txt
+++ b/clang/include/clang/Basic/CMakeLists.txt
@@ -117,3 +117,12 @@ clang_tablegen(riscv_sifive_vector_builtin_cg.inc -gen-riscv-sifive-vector-built
 clang_tablegen(riscv_sifive_vector_builtin_sema.inc -gen-riscv-sifive-vector-builtin-sema
   SOURCE riscv_sifive_vector.td
   TARGET ClangRISCVSiFiveVectorBuiltinSema)
+clang_tablegen(riscv_xtheadv_builtins.inc -gen-riscv-xtheadv-builtins
+  SOURCE riscv_vector_xtheadv.td
+  TARGET ClangRISCVXTHeadVBuiltins)
+clang_tablegen(riscv_xtheadv_builtin_cg.inc -gen-riscv-xtheadv-builtin-codegen
+  SOURCE riscv_vector_xtheadv.td
+  TARGET ClangRISCVXTHeadVBuiltinCG)
+clang_tablegen(riscv_xtheadv_builtin_sema.inc -gen-riscv-xtheadv-builtin-sema
+  SOURCE riscv_vector_xtheadv.td
+  TARGET ClangRISCVXTHeadVBuiltinSema)

--- a/clang/include/clang/Basic/riscv_vector_xtheadv.td
+++ b/clang/include/clang/Basic/riscv_vector_xtheadv.td
@@ -13,3 +13,62 @@
 //===----------------------------------------------------------------------===//
 
 include "riscv_vector_common.td"
+
+multiclass RVVBuiltinSet<string intrinsic_name, string type_range,
+                         list<list<string>> suffixes_prototypes,
+                         list<int> intrinsic_types> {
+  let IRName = intrinsic_name, MaskedIRName = intrinsic_name # "_mask",
+      IntrinsicTypes = intrinsic_types in {
+    foreach s_p = suffixes_prototypes in {
+      let Name = NAME # "_" # s_p[0] in {
+        defvar suffix = s_p[1];
+        defvar prototype = s_p[2];
+        def : RVVBuiltin<suffix, prototype, type_range>;
+      }
+    }
+  }
+}
+
+// IntrinsicTypes is output, op1 [-1, 1]
+multiclass RVVOutOp1BuiltinSet<string intrinsic_name, string type_range,
+                               list<list<string>> suffixes_prototypes>
+    : RVVBuiltinSet<intrinsic_name, type_range, suffixes_prototypes, [-1, 1]>;
+
+multiclass RVVSignedBinBuiltinSet
+    : RVVOutOp1BuiltinSet<NAME, "csil",
+                          [["vv", "v", "vvv"],
+                           ["vx", "v", "vve"]]>;
+
+multiclass RVVUnsignedBinBuiltinSet
+    : RVVOutOp1BuiltinSet<NAME, "csil",
+                          [["vv", "Uv", "UvUvUv"],
+                           ["vx", "Uv", "UvUvUe"]]>;
+
+multiclass RVVIntBinBuiltinSet
+    : RVVSignedBinBuiltinSet,
+      RVVUnsignedBinBuiltinSet;
+
+
+// 6. Configuration-Setting Instructions
+// 6.1. vsetvli/vsetvl instructions
+
+let HasBuiltinAlias = false,
+    HasVL = false,
+    HasMasked = false,
+    MaskedPolicyScheme = NonePolicy,
+    Log2LMUL = [0],
+    ManualCodegen = [{IntrinsicTypes = {ResultType};}] in // Set XLEN type
+{
+  def xvsetvli : RVVBuiltin<"", "zzKzKz", "i">;
+  def xvsetvlimax : RVVBuiltin<"", "zKzKz", "i">;
+}
+
+// 12. Vector Integer Arithmetic Instructions
+// 12.1. Vector Single-Width Integer Add and Subtract
+let UnMaskedPolicyScheme = HasPassthruOperand in {
+defm xvadd : RVVIntBinBuiltinSet;
+defm xvsub : RVVIntBinBuiltinSet;
+defm xvrsub : RVVOutOp1BuiltinSet<"vrsub", "csil",
+                                 [["vx", "v", "vve"],
+                                  ["vx", "Uv", "UvUvUe"]]>;
+}

--- a/clang/include/clang/Basic/riscv_vector_xtheadv.td
+++ b/clang/include/clang/Basic/riscv_vector_xtheadv.td
@@ -14,6 +14,11 @@
 
 include "riscv_vector_common.td"
 
+class XRVVBuiltin<string suffix, string prototype, string type_range,
+                  string overloaded_suffix = "">
+    : RVVBuiltin<suffix, prototype, type_range, overloaded_suffix> {
+}
+
 multiclass RVVBuiltinSet<string intrinsic_name, string type_range,
                          list<list<string>> suffixes_prototypes,
                          list<int> intrinsic_types> {
@@ -23,7 +28,7 @@ multiclass RVVBuiltinSet<string intrinsic_name, string type_range,
       let Name = NAME # "_" # s_p[0] in {
         defvar suffix = s_p[1];
         defvar prototype = s_p[2];
-        def : RVVBuiltin<suffix, prototype, type_range>;
+        def : XRVVBuiltin<suffix, prototype, type_range>;
       }
     }
   }

--- a/clang/include/clang/Basic/riscv_vector_xtheadv.td
+++ b/clang/include/clang/Basic/riscv_vector_xtheadv.td
@@ -1,4 +1,4 @@
-//==--- riscv_vector.td - RISC-V V-ext Builtin function list --------------===//
+//==--- riscv_vector_xtheadv.td - RISC-V V-ext Builtin function list ------===//
 //
 //  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 //  See https://llvm.org/LICENSE.txt for license information.
@@ -8,7 +8,7 @@
 //
 // This file defines the builtins for RISC-V V-extension. See:
 //
-//     https://github.com/riscv/rvv-intrinsic-doc
+//     https://github.com/riscv-non-isa/rvv-intrinsic-doc/tree/v0.7.1
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Basic/riscv_vector_xtheadv.td
+++ b/clang/include/clang/Basic/riscv_vector_xtheadv.td
@@ -1,0 +1,15 @@
+//==--- riscv_vector.td - RISC-V V-ext Builtin function list --------------===//
+//
+//  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//  See https://llvm.org/LICENSE.txt for license information.
+//  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the builtins for RISC-V V-extension. See:
+//
+//     https://github.com/riscv/rvv-intrinsic-doc
+//
+//===----------------------------------------------------------------------===//
+
+include "riscv_vector_common.td"

--- a/clang/include/clang/Basic/riscv_vector_xtheadv.td
+++ b/clang/include/clang/Basic/riscv_vector_xtheadv.td
@@ -49,8 +49,9 @@ multiclass RVVIntBinBuiltinSet
       RVVUnsignedBinBuiltinSet;
 
 
+//===----------------------------------------------------------------------===//
 // 6. Configuration-Setting Instructions
-// 6.1. vsetvli/vsetvl instructions
+//===----------------------------------------------------------------------===//
 
 let HasBuiltinAlias = false,
     HasVL = false,
@@ -63,11 +64,10 @@ let HasBuiltinAlias = false,
   def xvsetvlmax : RVVBuiltin<"", "zKzKz", "i">;
 }
 
+//===----------------------------------------------------------------------===//
 // 12. Vector Integer Arithmetic Instructions
-// 12.1. Vector Single-Width Integer Add and Subtract
+//===----------------------------------------------------------------------===//
 
-// TODO: add correspoinding llvm intrinsics for them, currently they exist here
-// only for avoiding assertion error in cmake task `ClangRISCVXTHeadVBuiltinSema`.
 let UnMaskedPolicyScheme = HasPassthruOperand in {
-defm xvadd : RVVIntBinBuiltinSet;
+  defm xvadd : RVVIntBinBuiltinSet;
 }

--- a/clang/include/clang/Basic/riscv_vector_xtheadv.td
+++ b/clang/include/clang/Basic/riscv_vector_xtheadv.td
@@ -59,16 +59,15 @@ let HasBuiltinAlias = false,
     Log2LMUL = [0],
     ManualCodegen = [{IntrinsicTypes = {ResultType};}] in // Set XLEN type
 {
-  def xvsetvli : RVVBuiltin<"", "zzKzKz", "i">;
-  def xvsetvlimax : RVVBuiltin<"", "zKzKz", "i">;
+  def xvsetvl : RVVBuiltin<"", "zzKzKz", "i">;
+  def xvsetvlmax : RVVBuiltin<"", "zKzKz", "i">;
 }
 
 // 12. Vector Integer Arithmetic Instructions
 // 12.1. Vector Single-Width Integer Add and Subtract
+
+// TODO: add correspoinding llvm intrinsics for them, currently they exist here
+// only for avoiding assertion error in cmake task `ClangRISCVXTHeadVBuiltinSema`.
 let UnMaskedPolicyScheme = HasPassthruOperand in {
 defm xvadd : RVVIntBinBuiltinSet;
-defm xvsub : RVVIntBinBuiltinSet;
-defm xvrsub : RVVOutOp1BuiltinSet<"vrsub", "csil",
-                                 [["vx", "v", "vve"],
-                                  ["vx", "Uv", "UvUvUe"]]>;
 }

--- a/clang/include/clang/Basic/riscv_vector_xtheadv.td
+++ b/clang/include/clang/Basic/riscv_vector_xtheadv.td
@@ -58,6 +58,57 @@ multiclass RVVIntBinBuiltinSet
 // 6. Configuration-Setting Instructions
 //===----------------------------------------------------------------------===//
 
+// vsetvl/vsetvlmax are a macro because they require constant integers in SEW
+// and LMUL.
+let HeaderCode =
+[{
+#define __riscv_vsetvl_e8m1(avl) __builtin_rvv_xvsetvl((size_t)(avl), 0, 0)
+#define __riscv_vsetvl_e8m2(avl) __builtin_rvv_xvsetvl((size_t)(avl), 0, 1)
+#define __riscv_vsetvl_e8m4(avl) __builtin_rvv_xvsetvl((size_t)(avl), 0, 2)
+#define __riscv_vsetvl_e8m8(avl) __builtin_rvv_xvsetvl((size_t)(avl), 0, 3)
+
+#define __riscv_vsetvl_e16m1(avl) __builtin_rvv_xvsetvl((size_t)(avl), 1, 0)
+#define __riscv_vsetvl_e16m2(avl) __builtin_rvv_xvsetvl((size_t)(avl), 1, 1)
+#define __riscv_vsetvl_e16m4(avl) __builtin_rvv_xvsetvl((size_t)(avl), 1, 2)
+#define __riscv_vsetvl_e16m8(avl) __builtin_rvv_xvsetvl((size_t)(avl), 1, 3)
+
+#define __riscv_vsetvl_e32m1(avl) __builtin_rvv_xvsetvl((size_t)(avl), 2, 0)
+#define __riscv_vsetvl_e32m2(avl) __builtin_rvv_xvsetvl((size_t)(avl), 2, 1)
+#define __riscv_vsetvl_e32m4(avl) __builtin_rvv_xvsetvl((size_t)(avl), 2, 2)
+#define __riscv_vsetvl_e32m8(avl) __builtin_rvv_xvsetvl((size_t)(avl), 2, 3)
+
+#if __riscv_v_elen >= 64
+#define __riscv_vsetvl_e64m1(avl) __builtin_rvv_xvsetvl((size_t)(avl), 3, 0)
+#define __riscv_vsetvl_e64m2(avl) __builtin_rvv_xvsetvl((size_t)(avl), 3, 1)
+#define __riscv_vsetvl_e64m4(avl) __builtin_rvv_xvsetvl((size_t)(avl), 3, 2)
+#define __riscv_vsetvl_e64m8(avl) __builtin_rvv_xvsetvl((size_t)(avl), 3, 3)
+#endif
+
+#define __riscv_vsetvlmax_e8m1() __builtin_rvv_xvsetvlmax(0, 0)
+#define __riscv_vsetvlmax_e8m2() __builtin_rvv_xvsetvlmax(0, 1)
+#define __riscv_vsetvlmax_e8m4() __builtin_rvv_xvsetvlmax(0, 2)
+#define __riscv_vsetvlmax_e8m8() __builtin_rvv_xvsetvlmax(0, 3)
+
+#define __riscv_vsetvlmax_e16m1() __builtin_rvv_xvsetvlmax(1, 0)
+#define __riscv_vsetvlmax_e16m2() __builtin_rvv_xvsetvlmax(1, 1)
+#define __riscv_vsetvlmax_e16m4() __builtin_rvv_xvsetvlmax(1, 2)
+#define __riscv_vsetvlmax_e16m8() __builtin_rvv_xvsetvlmax(1, 3)
+
+#define __riscv_vsetvlmax_e32m1() __builtin_rvv_xvsetvlmax(2, 0)
+#define __riscv_vsetvlmax_e32m2() __builtin_rvv_xvsetvlmax(2, 1)
+#define __riscv_vsetvlmax_e32m4() __builtin_rvv_xvsetvlmax(2, 2)
+#define __riscv_vsetvlmax_e32m8() __builtin_rvv_xvsetvlmax(2, 3)
+
+#if __riscv_v_elen >= 64
+#define __riscv_vsetvlmax_e64m1() __builtin_rvv_xvsetvlmax(3, 0)
+#define __riscv_vsetvlmax_e64m2() __builtin_rvv_xvsetvlmax(3, 1)
+#define __riscv_vsetvlmax_e64m4() __builtin_rvv_xvsetvlmax(3, 2)
+#define __riscv_vsetvlmax_e64m8() __builtin_rvv_xvsetvlmax(3, 3)
+#endif
+
+}] in
+def xvsetvl_macro: RVVHeader;
+
 let HasBuiltinAlias = false,
     HasVL = false,
     HasMasked = false,

--- a/clang/include/clang/Sema/RISCVIntrinsicManager.h
+++ b/clang/include/clang/Sema/RISCVIntrinsicManager.h
@@ -24,7 +24,7 @@ class Preprocessor;
 namespace sema {
 class RISCVIntrinsicManager {
 public:
-  enum class IntrinsicKind : uint8_t { RVV, SIFIVE_VECTOR };
+  enum class IntrinsicKind : uint8_t { RVV, SIFIVE_VECTOR, XTHEADV_VECTOR };
 
   virtual ~RISCVIntrinsicManager() = default;
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1646,7 +1646,7 @@ public:
   bool DeclareRISCVSiFiveVectorBuiltins = false;
 
   /// Indicate RISC-V vector 0.7.1 builtin functions enabled or not.
-  bool DeclareRISCVV0p7Builtins = false;
+  bool DeclareRISCVXTHeadVBuiltins = false;
 
 private:
   std::unique_ptr<sema::RISCVIntrinsicManager> RVIntrinsicManager;

--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -200,6 +200,14 @@ void RISCVTargetInfo::getTargetDefines(const LangOptions &Opts,
     Builder.defineMacro("__riscv_v_intrinsic", Twine(getVersionValue(0, 11)));
   }
 
+  if (ISAInfo->hasExtension("xtheadv")) {
+    // TODO: should we define __riscv_vector here?
+    Builder.defineMacro("__riscv_vector");
+    Builder.defineMacro("__riscv_vector_xtheadv");
+    // TODO: which intrinsic version? reuse the v0.11 for now.
+    Builder.defineMacro("__riscv_v_intrinsic", Twine(getVersionValue(0, 11)));
+  }
+
   auto VScale = getVScaleRange(Opts);
   if (VScale && VScale->first && VScale->first == VScale->second)
     Builder.defineMacro("__riscv_v_fixed_vlen",

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -20408,6 +20408,8 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
 #include "clang/Basic/riscv_vector_builtin_cg.inc"
   // SiFive Vector builtins are handled from here.
 #include "clang/Basic/riscv_sifive_vector_builtin_cg.inc"
+  // XTHeadV builtins are handled from here.
+#include "clang/Basic/riscv_xtheadv_builtin_cg.inc"
   }
 
   assert(ID != Intrinsic::not_intrinsic);

--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -387,7 +387,7 @@ endif()
 if(RISCV IN_LIST LLVM_TARGETS_TO_BUILD)
   # Generate riscv_vector.h and riscv_vector_xtheadv.h
   clang_generate_header(-gen-riscv-vector-header riscv_vector.td riscv_vector.h)
-  clang_generate_header(-gen-riscv-vector-header riscv_vector_xtheadv.td riscv_vector_xtheadv.h)
+  clang_generate_header(-gen-riscv-xtheadv-header riscv_vector_xtheadv.td riscv_vector_xtheadv.h)
   list(APPEND riscv_generated_files
     "${CMAKE_CURRENT_BINARY_DIR}/riscv_vector.h"
     "${CMAKE_CURRENT_BINARY_DIR}/riscv_vector_xtheadv.h"

--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -385,10 +385,12 @@ if(ARM IN_LIST LLVM_TARGETS_TO_BUILD OR AArch64 IN_LIST LLVM_TARGETS_TO_BUILD)
     )
 endif()
 if(RISCV IN_LIST LLVM_TARGETS_TO_BUILD)
-  # Generate riscv_vector.h
+  # Generate riscv_vector.h and riscv_vector_xtheadv.h
   clang_generate_header(-gen-riscv-vector-header riscv_vector.td riscv_vector.h)
+  clang_generate_header(-gen-riscv-vector-header riscv_vector_xtheadv.td riscv_vector_xtheadv.h)
   list(APPEND riscv_generated_files
     "${CMAKE_CURRENT_BINARY_DIR}/riscv_vector.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/riscv_vector_xtheadv.h"
     )
 endif()
 

--- a/clang/lib/Parse/ParsePragma.cpp
+++ b/clang/lib/Parse/ParsePragma.cpp
@@ -4026,7 +4026,8 @@ void PragmaMaxTokensTotalHandler::HandlePragma(Preprocessor &PP,
 }
 
 // Handle '#pragma clang riscv intrinsic vector'.
-//        '#pragma clang riscv intrinsic sifive_vector'.
+//        '#pragma clang riscv intrinsic sifive_vector'
+//        '#pragma clang riscv intrinsic xtheadv_vector'.
 void PragmaRISCVHandler::HandlePragma(Preprocessor &PP,
                                       PragmaIntroducer Introducer,
                                       Token &FirstToken) {
@@ -4043,10 +4044,10 @@ void PragmaRISCVHandler::HandlePragma(Preprocessor &PP,
   PP.Lex(Tok);
   II = Tok.getIdentifierInfo();
   if (!II || !(II->isStr("vector") || II->isStr("sifive_vector") ||
-               II->isStr("vector0p7"))) {
+               II->isStr("xtheadv_vector"))) {
     PP.Diag(Tok.getLocation(), diag::warn_pragma_invalid_argument)
         << PP.getSpelling(Tok) << "riscv" << /*Expected=*/true
-        << "'vector', 'sifive_vector' or 'vector0p7'";
+        << "'vector', 'sifive_vector' or 'xtheadv_vector'";
     return;
   }
 
@@ -4061,6 +4062,6 @@ void PragmaRISCVHandler::HandlePragma(Preprocessor &PP,
     Actions.DeclareRISCVVBuiltins = true;
   else if (II->isStr("sifive_vector"))
     Actions.DeclareRISCVSiFiveVectorBuiltins = true;
-  else if (II->isStr("vector0p7"))
-    Actions.DeclareRISCVV0p7Builtins = true;
+  else if (II->isStr("xtheadv_vector"))
+    Actions.DeclareRISCVXTHeadVBuiltins = true;
 }

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -5402,24 +5402,28 @@ bool Sema::CheckWebAssemblyBuiltinFunctionCall(const TargetInfo &TI,
 
 void Sema::checkRVVTypeSupport(QualType Ty, SourceLocation Loc, ValueDecl *D) {
   const TargetInfo &TI = Context.getTargetInfo();
+  // TODO[RVV 0.7.1]: better error message
+  // Note: RVV 0.7.1 contains everything.
+
   // (ELEN, LMUL) pairs of (8, mf8), (16, mf4), (32, mf2), (64, m1) requires at
   // least zve64x
   if ((Ty->isRVVType(/* Bitwidth */ 64, /* IsFloat */ false) ||
        Ty->isRVVType(/* ElementCount */ 1)) &&
-      !TI.hasFeature("zve64x"))
+      (!TI.hasFeature("zve64x") &&
+       !TI.hasFeature("xtheadv")))
     Diag(Loc, diag::err_riscv_type_requires_extension, D) << Ty << "zve64x";
   if (Ty->isRVVType(/* Bitwidth */ 16, /* IsFloat */ true) &&
-      !TI.hasFeature("zvfh"))
+      (!TI.hasFeature("zvfh") && !TI.hasFeature("xtheadv")))
     Diag(Loc, diag::err_riscv_type_requires_extension, D) << Ty << "zvfh";
   if (Ty->isRVVType(/* Bitwidth */ 32, /* IsFloat */ true) &&
-      !TI.hasFeature("zve32f"))
+      (!TI.hasFeature("zve32f") && !TI.hasFeature("xtheadv")))
     Diag(Loc, diag::err_riscv_type_requires_extension, D) << Ty << "zve32f";
   if (Ty->isRVVType(/* Bitwidth */ 64, /* IsFloat */ true) &&
-      !TI.hasFeature("zve64d"))
+      (!TI.hasFeature("zve64d") && !TI.hasFeature("xtheadv")))
     Diag(Loc, diag::err_riscv_type_requires_extension, D) << Ty << "zve64d";
   // Given that caller already checked isRVVType() before calling this function,
   // if we don't have at least zve32x supported, then we need to emit error.
-  if (!TI.hasFeature("zve32x"))
+  if (!TI.hasFeature("zve32x") && !TI.hasFeature("xtheadv"))
     Diag(Loc, diag::err_riscv_type_requires_extension, D) << Ty << "zve32x";
 }
 

--- a/clang/lib/Sema/SemaLookup.cpp
+++ b/clang/lib/Sema/SemaLookup.cpp
@@ -934,7 +934,7 @@ bool Sema::LookupBuiltin(LookupResult &R) {
       }
 
       if (DeclareRISCVVBuiltins || DeclareRISCVSiFiveVectorBuiltins ||
-          DeclareRISCVV0p7Builtins) {
+          DeclareRISCVXTHeadVBuiltins) {
         if (!RVIntrinsicManager)
           RVIntrinsicManager = CreateRISCVIntrinsicManager(*this);
 

--- a/clang/lib/Sema/SemaRISCVVectorLookup.cpp
+++ b/clang/lib/Sema/SemaRISCVVectorLookup.cpp
@@ -66,6 +66,12 @@ static const PrototypeDescriptor RVSiFiveVectorSignatureTable[] = {
 #undef DECL_SIGNATURE_TABLE
 };
 
+static const PrototypeDescriptor RVXTHeadVSignatureTable[] = {
+#define DECL_SIGNATURE_TABLE
+#include "clang/Basic/riscv_xtheadv_builtin_sema.inc"
+#undef DECL_SIGNATURE_TABLE
+};
+
 static const RVVIntrinsicRecord RVVIntrinsicRecords[] = {
 #define DECL_INTRINSIC_RECORDS
 #include "clang/Basic/riscv_vector_builtin_sema.inc"
@@ -78,6 +84,12 @@ static const RVVIntrinsicRecord RVSiFiveVectorIntrinsicRecords[] = {
 #undef DECL_INTRINSIC_RECORDS
 };
 
+static const RVVIntrinsicRecord RVXTHeadVIntrinsicRecords[] = {
+#define DECL_INTRINSIC_RECORDS
+#include "clang/Basic/riscv_xtheadv_builtin_sema.inc"
+#undef DECL_INTRINSIC_RECORDS
+};
+
 // Get subsequence of signature table.
 static ArrayRef<PrototypeDescriptor>
 ProtoSeq2ArrayRef(IntrinsicKind K, uint16_t Index, uint8_t Length) {
@@ -86,6 +98,8 @@ ProtoSeq2ArrayRef(IntrinsicKind K, uint16_t Index, uint8_t Length) {
     return ArrayRef(&RVVSignatureTable[Index], Length);
   case IntrinsicKind::SIFIVE_VECTOR:
     return ArrayRef(&RVSiFiveVectorSignatureTable[Index], Length);
+  case IntrinsicKind::XTHEADV_VECTOR:
+    return ArrayRef(&RVXTHeadVSignatureTable[Index], Length);
   }
   llvm_unreachable("Unhandled IntrinsicKind");
 }
@@ -160,6 +174,7 @@ private:
   RVVTypeCache TypeCache;
   bool ConstructedRISCVVBuiltins;
   bool ConstructedRISCVSiFiveVectorBuiltins;
+  bool ConstructedRISCVXTHeadVBuiltins;
 
   // List of all RVV intrinsic.
   std::vector<RVVIntrinsicDef> IntrinsicList;
@@ -329,6 +344,11 @@ void RISCVIntrinsicManagerImpl::InitIntrinsicList() {
     ConstructedRISCVSiFiveVectorBuiltins = true;
     ConstructRVVIntrinsics(RVSiFiveVectorIntrinsicRecords,
                            IntrinsicKind::SIFIVE_VECTOR);
+  }
+  if (S.DeclareRISCVXTHeadVBuiltins && !ConstructedRISCVXTHeadVBuiltins) {
+    ConstructedRISCVXTHeadVBuiltins = true;
+    ConstructRVVIntrinsics(RVXTHeadVIntrinsicRecords,
+                           IntrinsicKind::XTHEADV_VECTOR);
   }
 }
 

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-error.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-error.c
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -triple riscv64 -target-feature +xtheadv -disable-O0-optnone -emit-llvm %s -o - | opt -S -passes=mem2reg | FileCheck --check-prefix=CHECK-RV64V %s
+// RUN: not %clang_cc1 -triple riscv64 -emit-llvm-only %s 2>&1 | FileCheck %s --check-prefix=CHECK-RV64-ERR
+
+// CHECK-RV64V-LABEL: @test(
+// CHECK-RV64V-NEXT:  entry:
+// CHECK-RV64V-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.xvsetvl.i64(i64 1, i64 0, i64 0)
+// CHECK-RV64V-NEXT:    [[CONV:%.*]] = trunc i64 [[TMP0]] to i32
+// CHECK-RV64V-NEXT:    ret i32 [[CONV]]
+//
+
+// CHECK-RV64-ERR: error: builtin requires at least one of the following extensions to be enabled: 'Xtheadv'
+
+int test() {
+  return __builtin_rvv_xvsetvl(1, 0, 0); // e8m1
+}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-intrinsic-datatypes.cpp
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-intrinsic-datatypes.cpp
@@ -1,0 +1,411 @@
+// RUN: %clang_cc1 -triple riscv64 -target-feature +xtheadv \
+// RUN: -O0 -emit-llvm %s -o - | FileCheck %s
+
+#include <riscv_vector_xtheadv.h>
+
+// This test case tests the typedef generated under riscv_vector_xtheadv.h
+
+// CHECK-LABEL: define dso_local void @_Z3foov
+// CHECK-SAME: () #[[ATTR0:[0-9]+]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[B64:%.*]] = alloca <vscale x 1 x i1>, align 1
+// CHECK-NEXT:    [[B32:%.*]] = alloca <vscale x 2 x i1>, align 1
+// CHECK-NEXT:    [[B16:%.*]] = alloca <vscale x 4 x i1>, align 1
+// CHECK-NEXT:    [[B8:%.*]] = alloca <vscale x 8 x i1>, align 1
+// CHECK-NEXT:    [[I8M1:%.*]] = alloca <vscale x 8 x i8>, align 1
+// CHECK-NEXT:    [[I8M2:%.*]] = alloca <vscale x 16 x i8>, align 1
+// CHECK-NEXT:    [[I8M4:%.*]] = alloca <vscale x 32 x i8>, align 1
+// CHECK-NEXT:    [[I8M8:%.*]] = alloca <vscale x 64 x i8>, align 1
+// CHECK-NEXT:    [[U8M1:%.*]] = alloca <vscale x 8 x i8>, align 1
+// CHECK-NEXT:    [[U8M2:%.*]] = alloca <vscale x 16 x i8>, align 1
+// CHECK-NEXT:    [[U8M4:%.*]] = alloca <vscale x 32 x i8>, align 1
+// CHECK-NEXT:    [[U8M8:%.*]] = alloca <vscale x 64 x i8>, align 1
+// CHECK-NEXT:    [[I16M1:%.*]] = alloca <vscale x 4 x i16>, align 2
+// CHECK-NEXT:    [[I16M2:%.*]] = alloca <vscale x 8 x i16>, align 2
+// CHECK-NEXT:    [[I16M4:%.*]] = alloca <vscale x 16 x i16>, align 2
+// CHECK-NEXT:    [[I16M8:%.*]] = alloca <vscale x 32 x i16>, align 2
+// CHECK-NEXT:    [[U16M1:%.*]] = alloca <vscale x 4 x i16>, align 2
+// CHECK-NEXT:    [[U16M2:%.*]] = alloca <vscale x 8 x i16>, align 2
+// CHECK-NEXT:    [[U16M4:%.*]] = alloca <vscale x 16 x i16>, align 2
+// CHECK-NEXT:    [[U16M8:%.*]] = alloca <vscale x 32 x i16>, align 2
+// CHECK-NEXT:    [[I32M1:%.*]] = alloca <vscale x 2 x i32>, align 4
+// CHECK-NEXT:    [[I32M2:%.*]] = alloca <vscale x 4 x i32>, align 4
+// CHECK-NEXT:    [[I32M4:%.*]] = alloca <vscale x 8 x i32>, align 4
+// CHECK-NEXT:    [[I32M8:%.*]] = alloca <vscale x 16 x i32>, align 4
+// CHECK-NEXT:    [[U32M1:%.*]] = alloca <vscale x 2 x i32>, align 4
+// CHECK-NEXT:    [[U32M2:%.*]] = alloca <vscale x 4 x i32>, align 4
+// CHECK-NEXT:    [[U32M4:%.*]] = alloca <vscale x 8 x i32>, align 4
+// CHECK-NEXT:    [[U32M8:%.*]] = alloca <vscale x 16 x i32>, align 4
+// CHECK-NEXT:    [[I64M1:%.*]] = alloca <vscale x 1 x i64>, align 8
+// CHECK-NEXT:    [[I64M2:%.*]] = alloca <vscale x 2 x i64>, align 8
+// CHECK-NEXT:    [[I64M4:%.*]] = alloca <vscale x 4 x i64>, align 8
+// CHECK-NEXT:    [[I64M8:%.*]] = alloca <vscale x 8 x i64>, align 8
+// CHECK-NEXT:    [[U64M1:%.*]] = alloca <vscale x 1 x i64>, align 8
+// CHECK-NEXT:    [[U64M2:%.*]] = alloca <vscale x 2 x i64>, align 8
+// CHECK-NEXT:    [[U64M4:%.*]] = alloca <vscale x 4 x i64>, align 8
+// CHECK-NEXT:    [[U64M8:%.*]] = alloca <vscale x 8 x i64>, align 8
+// CHECK-NEXT:    [[F16M1:%.*]] = alloca <vscale x 4 x half>, align 2
+// CHECK-NEXT:    [[F16M2:%.*]] = alloca <vscale x 8 x half>, align 2
+// CHECK-NEXT:    [[F16M4:%.*]] = alloca <vscale x 16 x half>, align 2
+// CHECK-NEXT:    [[F16M8:%.*]] = alloca <vscale x 32 x half>, align 2
+// CHECK-NEXT:    [[F32M1:%.*]] = alloca <vscale x 2 x float>, align 4
+// CHECK-NEXT:    [[F32M2:%.*]] = alloca <vscale x 4 x float>, align 4
+// CHECK-NEXT:    [[F32M4:%.*]] = alloca <vscale x 8 x float>, align 4
+// CHECK-NEXT:    [[F32M8:%.*]] = alloca <vscale x 16 x float>, align 4
+// CHECK-NEXT:    [[F64M1:%.*]] = alloca <vscale x 1 x double>, align 8
+// CHECK-NEXT:    [[F64M2:%.*]] = alloca <vscale x 2 x double>, align 8
+// CHECK-NEXT:    [[F64M4:%.*]] = alloca <vscale x 4 x double>, align 8
+// CHECK-NEXT:    [[F64M8:%.*]] = alloca <vscale x 8 x double>, align 8
+// CHECK-NEXT:    [[I8M1X2:%.*]] = alloca { <vscale x 8 x i8>, <vscale x 8 x i8> }, align 1
+// CHECK-NEXT:    [[I8M1X3:%.*]] = alloca { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> }, align 1
+// CHECK-NEXT:    [[I8M1X4:%.*]] = alloca { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> }, align 1
+// CHECK-NEXT:    [[I8M1X5:%.*]] = alloca { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> }, align 1
+// CHECK-NEXT:    [[I8M1X6:%.*]] = alloca { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> }, align 1
+// CHECK-NEXT:    [[I8M1X7:%.*]] = alloca { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> }, align 1
+// CHECK-NEXT:    [[I8M1X8:%.*]] = alloca { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> }, align 1
+// CHECK-NEXT:    [[I8M2X2:%.*]] = alloca { <vscale x 16 x i8>, <vscale x 16 x i8> }, align 1
+// CHECK-NEXT:    [[I8M2X3:%.*]] = alloca { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> }, align 1
+// CHECK-NEXT:    [[I8M2X4:%.*]] = alloca { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> }, align 1
+// CHECK-NEXT:    [[I8M4X2:%.*]] = alloca { <vscale x 32 x i8>, <vscale x 32 x i8> }, align 1
+// CHECK-NEXT:    [[U8M1X2:%.*]] = alloca { <vscale x 8 x i8>, <vscale x 8 x i8> }, align 1
+// CHECK-NEXT:    [[U8M1X3:%.*]] = alloca { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> }, align 1
+// CHECK-NEXT:    [[U8M1X4:%.*]] = alloca { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> }, align 1
+// CHECK-NEXT:    [[U8M1X5:%.*]] = alloca { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> }, align 1
+// CHECK-NEXT:    [[U8M1X6:%.*]] = alloca { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> }, align 1
+// CHECK-NEXT:    [[U8M1X7:%.*]] = alloca { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> }, align 1
+// CHECK-NEXT:    [[U8M1X8:%.*]] = alloca { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> }, align 1
+// CHECK-NEXT:    [[U8M2X2:%.*]] = alloca { <vscale x 16 x i8>, <vscale x 16 x i8> }, align 1
+// CHECK-NEXT:    [[U8M2X3:%.*]] = alloca { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> }, align 1
+// CHECK-NEXT:    [[U8M2X4:%.*]] = alloca { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> }, align 1
+// CHECK-NEXT:    [[U8M4X2:%.*]] = alloca { <vscale x 32 x i8>, <vscale x 32 x i8> }, align 1
+// CHECK-NEXT:    [[I16M1X2:%.*]] = alloca { <vscale x 4 x i16>, <vscale x 4 x i16> }, align 2
+// CHECK-NEXT:    [[I16M1X3:%.*]] = alloca { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> }, align 2
+// CHECK-NEXT:    [[I16M1X4:%.*]] = alloca { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> }, align 2
+// CHECK-NEXT:    [[I16M1X5:%.*]] = alloca { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> }, align 2
+// CHECK-NEXT:    [[I16M1X6:%.*]] = alloca { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> }, align 2
+// CHECK-NEXT:    [[I16M1X7:%.*]] = alloca { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> }, align 2
+// CHECK-NEXT:    [[I16M1X8:%.*]] = alloca { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> }, align 2
+// CHECK-NEXT:    [[I16M2X2:%.*]] = alloca { <vscale x 8 x i16>, <vscale x 8 x i16> }, align 2
+// CHECK-NEXT:    [[I16M2X3:%.*]] = alloca { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> }, align 2
+// CHECK-NEXT:    [[I16M2X4:%.*]] = alloca { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> }, align 2
+// CHECK-NEXT:    [[I16M4X2:%.*]] = alloca { <vscale x 16 x i16>, <vscale x 16 x i16> }, align 2
+// CHECK-NEXT:    [[U16M1X2:%.*]] = alloca { <vscale x 4 x i16>, <vscale x 4 x i16> }, align 2
+// CHECK-NEXT:    [[U16M1X3:%.*]] = alloca { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> }, align 2
+// CHECK-NEXT:    [[U16M1X4:%.*]] = alloca { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> }, align 2
+// CHECK-NEXT:    [[U16M1X5:%.*]] = alloca { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> }, align 2
+// CHECK-NEXT:    [[U16M1X6:%.*]] = alloca { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> }, align 2
+// CHECK-NEXT:    [[U16M1X7:%.*]] = alloca { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> }, align 2
+// CHECK-NEXT:    [[U16M1X8:%.*]] = alloca { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> }, align 2
+// CHECK-NEXT:    [[U16M2X2:%.*]] = alloca { <vscale x 8 x i16>, <vscale x 8 x i16> }, align 2
+// CHECK-NEXT:    [[U16M2X3:%.*]] = alloca { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> }, align 2
+// CHECK-NEXT:    [[U16M2X4:%.*]] = alloca { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> }, align 2
+// CHECK-NEXT:    [[U16M4X2:%.*]] = alloca { <vscale x 16 x i16>, <vscale x 16 x i16> }, align 2
+// CHECK-NEXT:    [[I32M1X2:%.*]] = alloca { <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+// CHECK-NEXT:    [[I32M1X3:%.*]] = alloca { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+// CHECK-NEXT:    [[I32M1X4:%.*]] = alloca { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+// CHECK-NEXT:    [[I32M1X5:%.*]] = alloca { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+// CHECK-NEXT:    [[I32M1X6:%.*]] = alloca { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+// CHECK-NEXT:    [[I32M1X7:%.*]] = alloca { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+// CHECK-NEXT:    [[I32M1X8:%.*]] = alloca { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+// CHECK-NEXT:    [[I32M2X2:%.*]] = alloca { <vscale x 4 x i32>, <vscale x 4 x i32> }, align 4
+// CHECK-NEXT:    [[I32M2X3:%.*]] = alloca { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> }, align 4
+// CHECK-NEXT:    [[I32M2X4:%.*]] = alloca { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> }, align 4
+// CHECK-NEXT:    [[I32M4X2:%.*]] = alloca { <vscale x 8 x i32>, <vscale x 8 x i32> }, align 4
+// CHECK-NEXT:    [[U32M1X2:%.*]] = alloca { <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+// CHECK-NEXT:    [[U32M1X3:%.*]] = alloca { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+// CHECK-NEXT:    [[U32M1X4:%.*]] = alloca { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+// CHECK-NEXT:    [[U32M1X5:%.*]] = alloca { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+// CHECK-NEXT:    [[U32M1X6:%.*]] = alloca { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+// CHECK-NEXT:    [[U32M1X7:%.*]] = alloca { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+// CHECK-NEXT:    [[U32M1X8:%.*]] = alloca { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+// CHECK-NEXT:    [[U32M2X2:%.*]] = alloca { <vscale x 4 x i32>, <vscale x 4 x i32> }, align 4
+// CHECK-NEXT:    [[U32M2X3:%.*]] = alloca { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> }, align 4
+// CHECK-NEXT:    [[U32M2X4:%.*]] = alloca { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> }, align 4
+// CHECK-NEXT:    [[U32M4X2:%.*]] = alloca { <vscale x 8 x i32>, <vscale x 8 x i32> }, align 4
+// CHECK-NEXT:    [[I64M1X2:%.*]] = alloca { <vscale x 1 x i64>, <vscale x 1 x i64> }, align 8
+// CHECK-NEXT:    [[I64M1X3:%.*]] = alloca { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> }, align 8
+// CHECK-NEXT:    [[I64M1X4:%.*]] = alloca { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> }, align 8
+// CHECK-NEXT:    [[I64M1X5:%.*]] = alloca { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> }, align 8
+// CHECK-NEXT:    [[I64M1X6:%.*]] = alloca { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> }, align 8
+// CHECK-NEXT:    [[I64M1X7:%.*]] = alloca { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> }, align 8
+// CHECK-NEXT:    [[I64M1X8:%.*]] = alloca { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> }, align 8
+// CHECK-NEXT:    [[I64M2X2:%.*]] = alloca { <vscale x 2 x i64>, <vscale x 2 x i64> }, align 8
+// CHECK-NEXT:    [[I64M2X3:%.*]] = alloca { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> }, align 8
+// CHECK-NEXT:    [[I64M2X4:%.*]] = alloca { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> }, align 8
+// CHECK-NEXT:    [[I64M4X2:%.*]] = alloca { <vscale x 4 x i64>, <vscale x 4 x i64> }, align 8
+// CHECK-NEXT:    [[U64M1X2:%.*]] = alloca { <vscale x 1 x i64>, <vscale x 1 x i64> }, align 8
+// CHECK-NEXT:    [[U64M1X3:%.*]] = alloca { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> }, align 8
+// CHECK-NEXT:    [[U64M1X4:%.*]] = alloca { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> }, align 8
+// CHECK-NEXT:    [[U64M1X5:%.*]] = alloca { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> }, align 8
+// CHECK-NEXT:    [[U64M1X6:%.*]] = alloca { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> }, align 8
+// CHECK-NEXT:    [[U64M1X7:%.*]] = alloca { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> }, align 8
+// CHECK-NEXT:    [[U64M1X8:%.*]] = alloca { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> }, align 8
+// CHECK-NEXT:    [[U64M2X2:%.*]] = alloca { <vscale x 2 x i64>, <vscale x 2 x i64> }, align 8
+// CHECK-NEXT:    [[U64M2X3:%.*]] = alloca { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> }, align 8
+// CHECK-NEXT:    [[U64M2X4:%.*]] = alloca { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> }, align 8
+// CHECK-NEXT:    [[U64M4X2:%.*]] = alloca { <vscale x 4 x i64>, <vscale x 4 x i64> }, align 8
+// CHECK-NEXT:    [[F16M1X2:%.*]] = alloca { <vscale x 4 x half>, <vscale x 4 x half> }, align 2
+// CHECK-NEXT:    [[F16M1X3:%.*]] = alloca { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> }, align 2
+// CHECK-NEXT:    [[F16M1X4:%.*]] = alloca { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> }, align 2
+// CHECK-NEXT:    [[F16M1X5:%.*]] = alloca { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> }, align 2
+// CHECK-NEXT:    [[F16M1X6:%.*]] = alloca { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> }, align 2
+// CHECK-NEXT:    [[F16M1X7:%.*]] = alloca { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> }, align 2
+// CHECK-NEXT:    [[F16M1X8:%.*]] = alloca { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> }, align 2
+// CHECK-NEXT:    [[F16M2X2:%.*]] = alloca { <vscale x 8 x half>, <vscale x 8 x half> }, align 2
+// CHECK-NEXT:    [[F16M2X3:%.*]] = alloca { <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half> }, align 2
+// CHECK-NEXT:    [[F16M2X4:%.*]] = alloca { <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half> }, align 2
+// CHECK-NEXT:    [[F16M4X2:%.*]] = alloca { <vscale x 16 x half>, <vscale x 16 x half> }, align 2
+// CHECK-NEXT:    [[F32M1X2:%.*]] = alloca { <vscale x 2 x float>, <vscale x 2 x float> }, align 4
+// CHECK-NEXT:    [[F32M1X3:%.*]] = alloca { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> }, align 4
+// CHECK-NEXT:    [[F32M1X4:%.*]] = alloca { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> }, align 4
+// CHECK-NEXT:    [[F32M1X5:%.*]] = alloca { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> }, align 4
+// CHECK-NEXT:    [[F32M1X6:%.*]] = alloca { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> }, align 4
+// CHECK-NEXT:    [[F32M1X7:%.*]] = alloca { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> }, align 4
+// CHECK-NEXT:    [[F32M1X8:%.*]] = alloca { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> }, align 4
+// CHECK-NEXT:    [[F32M2X2:%.*]] = alloca { <vscale x 4 x float>, <vscale x 4 x float> }, align 4
+// CHECK-NEXT:    [[F32M2X3:%.*]] = alloca { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> }, align 4
+// CHECK-NEXT:    [[F32M2X4:%.*]] = alloca { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> }, align 4
+// CHECK-NEXT:    [[F32M4X2:%.*]] = alloca { <vscale x 8 x float>, <vscale x 8 x float> }, align 4
+// CHECK-NEXT:    [[F64M1X2:%.*]] = alloca { <vscale x 1 x double>, <vscale x 1 x double> }, align 8
+// CHECK-NEXT:    [[F64M1X3:%.*]] = alloca { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> }, align 8
+// CHECK-NEXT:    [[F64M1X4:%.*]] = alloca { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> }, align 8
+// CHECK-NEXT:    [[F64M1X5:%.*]] = alloca { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> }, align 8
+// CHECK-NEXT:    [[F64M1X6:%.*]] = alloca { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> }, align 8
+// CHECK-NEXT:    [[F64M1X7:%.*]] = alloca { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> }, align 8
+// CHECK-NEXT:    [[F64M1X8:%.*]] = alloca { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> }, align 8
+// CHECK-NEXT:    [[F64M2X2:%.*]] = alloca { <vscale x 2 x double>, <vscale x 2 x double> }, align 8
+// CHECK-NEXT:    [[F64M2X3:%.*]] = alloca { <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double> }, align 8
+// CHECK-NEXT:    [[F64M2X4:%.*]] = alloca { <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double> }, align 8
+// CHECK-NEXT:    [[F64M4X2:%.*]] = alloca { <vscale x 4 x double>, <vscale x 4 x double> }, align 8
+// CHECK-NEXT:    ret void
+//
+void foo () {
+  // Mask Types
+  vbool64_t b64;
+  vbool32_t b32;
+  vbool16_t b16;
+  vbool8_t b8;
+
+  // Data Types
+  vint8m1_t i8m1;
+  vint8m2_t i8m2;
+  vint8m4_t i8m4;
+  vint8m8_t i8m8;
+
+  vuint8m1_t u8m1;
+  vuint8m2_t u8m2;
+  vuint8m4_t u8m4;
+  vuint8m8_t u8m8;
+
+  vint16m1_t i16m1;
+  vint16m2_t i16m2;
+  vint16m4_t i16m4;
+  vint16m8_t i16m8;
+
+  vuint16m1_t u16m1;
+  vuint16m2_t u16m2;
+  vuint16m4_t u16m4;
+  vuint16m8_t u16m8;
+
+  vint32m1_t i32m1;
+  vint32m2_t i32m2;
+  vint32m4_t i32m4;
+  vint32m8_t i32m8;
+
+  vuint32m1_t u32m1;
+  vuint32m2_t u32m2;
+  vuint32m4_t u32m4;
+  vuint32m8_t u32m8;
+
+  vint64m1_t i64m1;
+  vint64m2_t i64m2;
+  vint64m4_t i64m4;
+  vint64m8_t i64m8;
+
+  vuint64m1_t u64m1;
+  vuint64m2_t u64m2;
+  vuint64m4_t u64m4;
+  vuint64m8_t u64m8;
+
+  vfloat16m1_t f16m1;
+  vfloat16m2_t f16m2;
+  vfloat16m4_t f16m4;
+  vfloat16m8_t f16m8;
+
+  vfloat32m1_t f32m1;
+  vfloat32m2_t f32m2;
+  vfloat32m4_t f32m4;
+  vfloat32m8_t f32m8;
+
+  vfloat64m1_t f64m1;
+  vfloat64m2_t f64m2;
+  vfloat64m4_t f64m4;
+  vfloat64m8_t f64m8;
+
+  // Types for Segment Load/Store
+
+  // i8
+  vint8m1x2_t i8m1x2;
+  vint8m1x3_t i8m1x3;
+  vint8m1x4_t i8m1x4;
+  vint8m1x5_t i8m1x5;
+  vint8m1x6_t i8m1x6;
+  vint8m1x7_t i8m1x7;
+  vint8m1x8_t i8m1x8;
+
+  vint8m2x2_t i8m2x2;
+  vint8m2x3_t i8m2x3;
+  vint8m2x4_t i8m2x4;
+
+  vint8m4x2_t i8m4x2;
+
+  // u8
+  vuint8m1x2_t u8m1x2;
+  vuint8m1x3_t u8m1x3;
+  vuint8m1x4_t u8m1x4;
+  vuint8m1x5_t u8m1x5;
+  vuint8m1x6_t u8m1x6;
+  vuint8m1x7_t u8m1x7;
+  vuint8m1x8_t u8m1x8;
+
+  vuint8m2x2_t u8m2x2;
+  vuint8m2x3_t u8m2x3;
+  vuint8m2x4_t u8m2x4;
+
+  vuint8m4x2_t u8m4x2;
+
+  // i16
+  vint16m1x2_t i16m1x2;
+  vint16m1x3_t i16m1x3;
+  vint16m1x4_t i16m1x4;
+  vint16m1x5_t i16m1x5;
+  vint16m1x6_t i16m1x6;
+  vint16m1x7_t i16m1x7;
+  vint16m1x8_t i16m1x8;
+
+  vint16m2x2_t i16m2x2;
+  vint16m2x3_t i16m2x3;
+  vint16m2x4_t i16m2x4;
+
+  vint16m4x2_t i16m4x2;
+
+  // u16
+  vuint16m1x2_t u16m1x2;
+  vuint16m1x3_t u16m1x3;
+  vuint16m1x4_t u16m1x4;
+  vuint16m1x5_t u16m1x5;
+  vuint16m1x6_t u16m1x6;
+  vuint16m1x7_t u16m1x7;
+  vuint16m1x8_t u16m1x8;
+
+  vuint16m2x2_t u16m2x2;
+  vuint16m2x3_t u16m2x3;
+  vuint16m2x4_t u16m2x4;
+
+  vuint16m4x2_t u16m4x2;
+
+  // i32
+  vint32m1x2_t i32m1x2;
+  vint32m1x3_t i32m1x3;
+  vint32m1x4_t i32m1x4;
+  vint32m1x5_t i32m1x5;
+  vint32m1x6_t i32m1x6;
+  vint32m1x7_t i32m1x7;
+  vint32m1x8_t i32m1x8;
+
+  vint32m2x2_t i32m2x2;
+  vint32m2x3_t i32m2x3;
+  vint32m2x4_t i32m2x4;
+
+  vint32m4x2_t i32m4x2;
+
+  // u32
+  vuint32m1x2_t u32m1x2;
+  vuint32m1x3_t u32m1x3;
+  vuint32m1x4_t u32m1x4;
+  vuint32m1x5_t u32m1x5;
+  vuint32m1x6_t u32m1x6;
+  vuint32m1x7_t u32m1x7;
+  vuint32m1x8_t u32m1x8;
+
+  vuint32m2x2_t u32m2x2;
+  vuint32m2x3_t u32m2x3;
+  vuint32m2x4_t u32m2x4;
+
+  vuint32m4x2_t u32m4x2;
+
+  // i64
+  vint64m1x2_t i64m1x2;
+  vint64m1x3_t i64m1x3;
+  vint64m1x4_t i64m1x4;
+  vint64m1x5_t i64m1x5;
+  vint64m1x6_t i64m1x6;
+  vint64m1x7_t i64m1x7;
+  vint64m1x8_t i64m1x8;
+
+  vint64m2x2_t i64m2x2;
+  vint64m2x3_t i64m2x3;
+  vint64m2x4_t i64m2x4;
+
+  vint64m4x2_t i64m4x2;
+
+  // u64
+  vuint64m1x2_t u64m1x2;
+  vuint64m1x3_t u64m1x3;
+  vuint64m1x4_t u64m1x4;
+  vuint64m1x5_t u64m1x5;
+  vuint64m1x6_t u64m1x6;
+  vuint64m1x7_t u64m1x7;
+  vuint64m1x8_t u64m1x8;
+
+  vuint64m2x2_t u64m2x2;
+  vuint64m2x3_t u64m2x3;
+  vuint64m2x4_t u64m2x4;
+
+  vuint64m4x2_t u64m4x2;
+
+  // f16
+  vfloat16m1x2_t f16m1x2;
+  vfloat16m1x3_t f16m1x3;
+  vfloat16m1x4_t f16m1x4;
+  vfloat16m1x5_t f16m1x5;
+  vfloat16m1x6_t f16m1x6;
+  vfloat16m1x7_t f16m1x7;
+  vfloat16m1x8_t f16m1x8;
+
+  vfloat16m2x2_t f16m2x2;
+  vfloat16m2x3_t f16m2x3;
+  vfloat16m2x4_t f16m2x4;
+
+  vfloat16m4x2_t f16m4x2;
+
+  // f32
+  vfloat32m1x2_t f32m1x2;
+  vfloat32m1x3_t f32m1x3;
+  vfloat32m1x4_t f32m1x4;
+  vfloat32m1x5_t f32m1x5;
+  vfloat32m1x6_t f32m1x6;
+  vfloat32m1x7_t f32m1x7;
+  vfloat32m1x8_t f32m1x8;
+
+  vfloat32m2x2_t f32m2x2;
+  vfloat32m2x3_t f32m2x3;
+  vfloat32m2x4_t f32m2x4;
+
+  vfloat32m4x2_t f32m4x2;
+
+  //f64
+  vfloat64m1x2_t f64m1x2;
+  vfloat64m1x3_t f64m1x3;
+  vfloat64m1x4_t f64m1x4;
+  vfloat64m1x5_t f64m1x5;
+  vfloat64m1x6_t f64m1x6;
+  vfloat64m1x7_t f64m1x7;
+  vfloat64m1x8_t f64m1x8;
+
+  vfloat64m2x2_t f64m2x2;
+  vfloat64m2x3_t f64m2x3;
+  vfloat64m2x4_t f64m2x4;
+
+  vfloat64m4x2_t f64m4x2;
+}

--- a/clang/test/Sema/riscv-bad-intrinsic-pragma.c
+++ b/clang/test/Sema/riscv-bad-intrinsic-pragma.c
@@ -2,7 +2,7 @@
 // RUN:            2>&1 | FileCheck %s
 
 #pragma clang riscv intrinsic vvvv
-// CHECK:      warning: unexpected argument 'vvvv' to '#pragma riscv'; expected 'vector', 'sifive_vector' or 'vector0p7' [-Wignored-pragmas]
+// CHECK:      warning: unexpected argument 'vvvv' to '#pragma riscv'; expected 'vector', 'sifive_vector' or 'xtheadv_vector' [-Wignored-pragmas]
 
 #pragma clang riscv what + 3241
 // CHECK:      warning: unexpected argument 'what' to '#pragma riscv'; expected 'intrinsic' [-Wignored-pragmas]

--- a/clang/utils/TableGen/RISCVVEmitter.cpp
+++ b/clang/utils/TableGen/RISCVVEmitter.cpp
@@ -640,6 +640,8 @@ void RVVEmitter::createRVVIntrinsics(
     // riscv_vector.h
     if (Name == "vsetvli" || Name == "vsetvlimax")
       continue;
+    if (Name == "xvsetvl" || Name == "xvsetvlmax")
+      continue;
 
     if (!SemaRecords)
       continue;

--- a/clang/utils/TableGen/RISCVVEmitter.cpp
+++ b/clang/utils/TableGen/RISCVVEmitter.cpp
@@ -104,7 +104,7 @@ public:
   void createHeader(raw_ostream &o, clang::RVVHeaderType Type);
 
   /// Emit all the __builtin prototypes and code needed by Sema.
-  void createBuiltins(raw_ostream &o);
+  void createBuiltins(raw_ostream &o, clang::RVVHeaderType Type);
 
   /// Emit all the information needed to map builtin -> LLVM IR intrinsic.
   void createCodeGen(raw_ostream &o);
@@ -421,7 +421,7 @@ void RVVEmitter::createHeader(raw_ostream &OS, clang::RVVHeaderType Type) {
   OS << "#endif // __RISCV_VECTOR_H\n";
 }
 
-void RVVEmitter::createBuiltins(raw_ostream &OS) {
+void RVVEmitter::createBuiltins(raw_ostream &OS, clang::RVVHeaderType Type) {
   std::vector<std::unique_ptr<RVVIntrinsic>> Defs;
   createRVVIntrinsics(Defs);
 
@@ -430,7 +430,8 @@ void RVVEmitter::createBuiltins(raw_ostream &OS) {
 
   OS << "#if defined(TARGET_BUILTIN) && !defined(RISCVV_BUILTIN)\n";
   OS << "#define RISCVV_BUILTIN(ID, TYPE, ATTRS) TARGET_BUILTIN(ID, TYPE, "
-        "ATTRS, \"zve32x\")\n";
+        "ATTRS, \""
+     << (Type == clang::RVVHeaderType::RVV ? "zve32x" : "xtheadv") << "\")\n";
   OS << "#endif\n";
   for (auto &Def : Defs) {
     auto P =
@@ -762,8 +763,9 @@ void EmitRVVHeader(RecordKeeper &Records, raw_ostream &OS, RVVHeaderType Type) {
   RVVEmitter(Records).createHeader(OS, Type);
 }
 
-void EmitRVVBuiltins(RecordKeeper &Records, raw_ostream &OS) {
-  RVVEmitter(Records).createBuiltins(OS);
+void EmitRVVBuiltins(RecordKeeper &Records, raw_ostream &OS,
+                     RVVHeaderType Type) {
+  RVVEmitter(Records).createBuiltins(OS, Type);
 }
 
 void EmitRVVBuiltinCG(RecordKeeper &Records, raw_ostream &OS) {

--- a/clang/utils/TableGen/TableGen.cpp
+++ b/clang/utils/TableGen/TableGen.cpp
@@ -518,7 +518,7 @@ bool ClangTableGenMain(raw_ostream &OS, RecordKeeper &Records) {
     EmitRVVHeader(Records, OS, RVVHeaderType::XTHEADV_VECTOR);
     break;
   case GenRISCVVectorBuiltins:
-    EmitRVVBuiltins(Records, OS);
+    EmitRVVBuiltins(Records, OS, RVVHeaderType::RVV);
     break;
   case GenRISCVVectorBuiltinCG:
     EmitRVVBuiltinCG(Records, OS);
@@ -527,7 +527,7 @@ bool ClangTableGenMain(raw_ostream &OS, RecordKeeper &Records) {
     EmitRVVBuiltinSema(Records, OS);
     break;
   case GenRISCVSiFiveVectorBuiltins:
-    EmitRVVBuiltins(Records, OS);
+    EmitRVVBuiltins(Records, OS, RVVHeaderType::RVV);
     break;
   case GenRISCVSiFiveVectorBuiltinCG:
     EmitRVVBuiltinCG(Records, OS);
@@ -536,7 +536,7 @@ bool ClangTableGenMain(raw_ostream &OS, RecordKeeper &Records) {
     EmitRVVBuiltinSema(Records, OS);
     break;
   case GenRISCVXTHeadVBuiltins:
-    EmitRVVBuiltins(Records, OS);
+    EmitRVVBuiltins(Records, OS, RVVHeaderType::XTHEADV_VECTOR);
     break;
   case GenRISCVXTHeadVBuiltinCG:
     EmitRVVBuiltinCG(Records, OS);

--- a/clang/utils/TableGen/TableGen.cpp
+++ b/clang/utils/TableGen/TableGen.cpp
@@ -93,6 +93,7 @@ enum ActionType {
   GenArmCdeBuiltinCG,
   GenArmCdeBuiltinAliases,
   GenRISCVVectorHeader,
+  GenRISCVXTHeadVHeader,
   GenRISCVVectorBuiltins,
   GenRISCVVectorBuiltinCG,
   GenRISCVVectorBuiltinSema,
@@ -266,6 +267,8 @@ cl::opt<ActionType> Action(
                    "Generate list of valid ARM CDE builtin aliases for clang"),
         clEnumValN(GenRISCVVectorHeader, "gen-riscv-vector-header",
                    "Generate riscv_vector.h for clang"),
+        clEnumValN(GenRISCVXTHeadVHeader, "gen-riscv-xtheadv-header",
+                   "Generate riscv_vector.h for clang"),
         clEnumValN(GenRISCVVectorBuiltins, "gen-riscv-vector-builtins",
                    "Generate riscv_vector_builtins.inc for clang"),
         clEnumValN(GenRISCVVectorBuiltinCG, "gen-riscv-vector-builtin-codegen",
@@ -279,11 +282,11 @@ cl::opt<ActionType> Action(
         clEnumValN(GenRISCVSiFiveVectorBuiltinSema, "gen-riscv-sifive-vector-builtin-sema",
                    "Generate riscv_sifive_vector_builtin_sema.inc for clang"),
         clEnumValN(GenRISCVXTHeadVBuiltins, "gen-riscv-xtheadv-builtins",
-                   "Generate riscv_vector_builtins.inc for clang"),
+                   "Generate riscv_xtheadv_builtins.inc for clang"),
         clEnumValN(GenRISCVXTHeadVBuiltinCG, "gen-riscv-xtheadv-builtin-codegen",
-                   "Generate riscv_vector_builtin_cg.inc for clang"),
+                   "Generate riscv_xtheadv_builtin_cg.inc for clang"),
         clEnumValN(GenRISCVXTHeadVBuiltinSema, "gen-riscv-xtheadv-builtin-sema",
-                   "Generate riscv_vector_builtin_sema.inc for clang"),
+                   "Generate riscv_xtheadv_builtin_sema.inc for clang"),
         clEnumValN(GenAttrDocs, "gen-attr-docs",
                    "Generate attribute documentation"),
         clEnumValN(GenDiagDocs, "gen-diag-docs",
@@ -509,7 +512,10 @@ bool ClangTableGenMain(raw_ostream &OS, RecordKeeper &Records) {
     EmitCdeBuiltinAliases(Records, OS);
     break;
   case GenRISCVVectorHeader:
-    EmitRVVHeader(Records, OS);
+    EmitRVVHeader(Records, OS, RVVHeaderType::RVV);
+    break;
+  case GenRISCVXTHeadVHeader:
+    EmitRVVHeader(Records, OS, RVVHeaderType::XTHEADV_VECTOR);
     break;
   case GenRISCVVectorBuiltins:
     EmitRVVBuiltins(Records, OS);

--- a/clang/utils/TableGen/TableGen.cpp
+++ b/clang/utils/TableGen/TableGen.cpp
@@ -99,6 +99,9 @@ enum ActionType {
   GenRISCVSiFiveVectorBuiltins,
   GenRISCVSiFiveVectorBuiltinCG,
   GenRISCVSiFiveVectorBuiltinSema,
+  GenRISCVXTHeadVBuiltins,
+  GenRISCVXTHeadVBuiltinCG,
+  GenRISCVXTHeadVBuiltinSema,
   GenAttrDocs,
   GenDiagDocs,
   GenOptDocs,
@@ -275,6 +278,12 @@ cl::opt<ActionType> Action(
                    "Generate riscv_sifive_vector_builtin_cg.inc for clang"),
         clEnumValN(GenRISCVSiFiveVectorBuiltinSema, "gen-riscv-sifive-vector-builtin-sema",
                    "Generate riscv_sifive_vector_builtin_sema.inc for clang"),
+        clEnumValN(GenRISCVXTHeadVBuiltins, "gen-riscv-xtheadv-builtins",
+                   "Generate riscv_vector_builtins.inc for clang"),
+        clEnumValN(GenRISCVXTHeadVBuiltinCG, "gen-riscv-xtheadv-builtin-codegen",
+                   "Generate riscv_vector_builtin_cg.inc for clang"),
+        clEnumValN(GenRISCVXTHeadVBuiltinSema, "gen-riscv-xtheadv-builtin-sema",
+                   "Generate riscv_vector_builtin_sema.inc for clang"),
         clEnumValN(GenAttrDocs, "gen-attr-docs",
                    "Generate attribute documentation"),
         clEnumValN(GenDiagDocs, "gen-diag-docs",
@@ -518,6 +527,15 @@ bool ClangTableGenMain(raw_ostream &OS, RecordKeeper &Records) {
     EmitRVVBuiltinCG(Records, OS);
     break;
   case GenRISCVSiFiveVectorBuiltinSema:
+    EmitRVVBuiltinSema(Records, OS);
+    break;
+  case GenRISCVXTHeadVBuiltins:
+    EmitRVVBuiltins(Records, OS);
+    break;
+  case GenRISCVXTHeadVBuiltinCG:
+    EmitRVVBuiltinCG(Records, OS);
+    break;
+  case GenRISCVXTHeadVBuiltinSema:
     EmitRVVBuiltinSema(Records, OS);
     break;
   case GenAttrDocs:

--- a/clang/utils/TableGen/TableGenBackends.h
+++ b/clang/utils/TableGen/TableGenBackends.h
@@ -24,6 +24,13 @@ class RecordKeeper;
 
 namespace clang {
 
+// Decide whether to emit header code
+// `#pragma clang riscv intrinsic vector` for RVV 1.0 (the `RVV`),
+// or
+// `#pragma clang riscv intrinsic xtheadv_vector` for RVV 0.7.1 (the
+// `XTHEADV_VECTOR`).
+enum RVVHeaderType : uint8_t { RVV, XTHEADV_VECTOR };
+
 void EmitClangDeclContext(llvm::RecordKeeper &RK, llvm::raw_ostream &OS);
 void EmitClangASTNodes(llvm::RecordKeeper &RK, llvm::raw_ostream &OS,
                        const std::string &N, const std::string &S);
@@ -114,7 +121,8 @@ void EmitMveBuiltinSema(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
 void EmitMveBuiltinCG(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
 void EmitMveBuiltinAliases(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
 
-void EmitRVVHeader(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
+void EmitRVVHeader(llvm::RecordKeeper &Records, llvm::raw_ostream &OS,
+                   RVVHeaderType Type);
 void EmitRVVBuiltins(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
 void EmitRVVBuiltinCG(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
 void EmitRVVBuiltinSema(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);

--- a/clang/utils/TableGen/TableGenBackends.h
+++ b/clang/utils/TableGen/TableGenBackends.h
@@ -123,7 +123,8 @@ void EmitMveBuiltinAliases(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
 
 void EmitRVVHeader(llvm::RecordKeeper &Records, llvm::raw_ostream &OS,
                    RVVHeaderType Type);
-void EmitRVVBuiltins(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
+void EmitRVVBuiltins(llvm::RecordKeeper &Records, llvm::raw_ostream &OS,
+                     RVVHeaderType Type);
 void EmitRVVBuiltinCG(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
 void EmitRVVBuiltinSema(llvm::RecordKeeper &Records, llvm::raw_ostream &OS);
 


### PR DESCRIPTION
This PR should be merged after #17.

- Added TableGen file `riscv_vector_xtheadv.td`, and registered its output artifacts to the clang codebase.
- Supported the Type System in RVV C Intrinsic.
- Supported the initial clang builtin function `__builtin_rvv_xvsetvl` and `__builtin_rvv_xvsetvlmax`.
- Added `__riscv_vsetvl` and `__riscv_vsetvlmax` macro families to make the xtheadv extension compatible with the upstream 1.0 implementation.
- Added corresponding tests.

Future work:
- Try to eliminate the need of `#include <riscv_vector_xtheadv.h>`, instead, use `#include <riscv_vector.h>` everywhere for any RVV implementation.
- Generate tests from [here](https://github.com/riscv-non-isa/rvv-intrinsic-doc/tree/main/auto-generated).