### PR TITLE
[LLVM] [RVV 0.7.1] Add vamo intrinsics.

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
@@ -25,3 +25,37 @@ let TargetPrefix = "riscv" in {
   defm xvadd : RISCVBinaryAAX;
 
 } // TargetPrefix = "riscv"
+
+let TargetPrefix = "riscv" in {
+  // 8. Vector AMO Operations (Zvamo)
+
+  // For atomic operations without mask
+  // Input: (base pointer, index, value, vl)
+  class XVAMONoMask
+        : Intrinsic<[llvm_anyvector_ty],
+                    [llvm_ptr_ty, llvm_anyvector_ty, LLVMMatchType<0>,
+                     llvm_anyint_ty],
+                    [NoCapture<ArgIndex<0>>]>, RISCVVIntrinsic;
+  // For atomic operations with mask
+  // Input: (base pointer, index, value, mask, vl)
+  class XVAMOMask
+        : Intrinsic<[llvm_anyvector_ty],
+                    [llvm_ptr_ty, llvm_anyvector_ty, LLVMMatchType<0>,
+                     LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>, llvm_anyint_ty],
+                    [NoCapture<ArgIndex<0>>]>, RISCVVIntrinsic;
+
+  multiclass XIntrinsicVAMO {
+    def "int_riscv_" # NAME           : XVAMONoMask;
+    def "int_riscv_" # NAME # "_mask" : XVAMOMask;
+  }
+
+  defm xvamoswap : XIntrinsicVAMO;
+  defm xvamoadd  : XIntrinsicVAMO;
+  defm xvamoxor  : XIntrinsicVAMO;
+  defm xvamoand  : XIntrinsicVAMO;
+  defm xvamoor   : XIntrinsicVAMO;
+  defm xvamomin  : XIntrinsicVAMO;
+  defm xvamomax  : XIntrinsicVAMO;
+  defm xvamominu : XIntrinsicVAMO;
+  defm xvamomaxu : XIntrinsicVAMO;
+} // TargetPrefix = "riscv"

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadV.td
@@ -251,8 +251,8 @@ class XVAMONoWd<bits<5> amoop, bits<3> width, string opcodestr>
 } // hasSideEffects = 0, mayLoad = 1, mayStore = 1
 
 multiclass XVAMO<bits<5> amoop, bits<3> width, string opcodestr> {
-  def _WD : XVAMOWd<amoop, width, opcodestr>;
-  def _UNWD : XVAMONoWd<amoop, width, opcodestr>;
+  def _WD_V : XVAMOWd<amoop, width, opcodestr>;
+  def _UNWD_V : XVAMONoWd<amoop, width, opcodestr>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -376,35 +376,35 @@ foreach nf=2-8 in {
 
 let Predicates = [HasVendorXTHeadV, HasVendorXTHeadVamo, HasStdExtA] in {
   // Vector AMO Instruction
-  defm XVAMO_SWAPW_V : XVAMO<0b00001, 0b110, "vamoswapw.v">;
-  defm XVAMO_ADDW_V : XVAMO<0b00000, 0b110, "vamoaddw.v">;
-  defm XVAMO_XORW_V : XVAMO<0b00100, 0b110, "vamoxorw.v">;
-  defm XVAMO_ANDW_V : XVAMO<0b01100, 0b110, "vamoandw.v">;
-  defm XVAMO_ORW_V : XVAMO<0b01000, 0b110, "vamoorw.v">;
-  defm XVAMO_MINW_V : XVAMO<0b10000, 0b110, "vamominw.v">;
-  defm XVAMO_MAXW_V : XVAMO<0b10100, 0b110, "vamomaxw.v">;
-  defm XVAMO_MINUW_V : XVAMO<0b11000, 0b110, "vamominuw.v">;
-  defm XVAMO_MAXUW_V : XVAMO<0b11100, 0b110, "vamomaxuw.v">;
+  defm XVAMOSWAPW : XVAMO<0b00001, 0b110, "vamoswapw.v">;
+  defm XVAMOADDW : XVAMO<0b00000, 0b110, "vamoaddw.v">;
+  defm XVAMOXORW : XVAMO<0b00100, 0b110, "vamoxorw.v">;
+  defm XVAMOANDW : XVAMO<0b01100, 0b110, "vamoandw.v">;
+  defm XVAMOORW : XVAMO<0b01000, 0b110, "vamoorw.v">;
+  defm XVAMOMINW : XVAMO<0b10000, 0b110, "vamominw.v">;
+  defm XVAMOMAXW : XVAMO<0b10100, 0b110, "vamomaxw.v">;
+  defm XVAMOMINUW : XVAMO<0b11000, 0b110, "vamominuw.v">;
+  defm XVAMOMAXUW : XVAMO<0b11100, 0b110, "vamomaxuw.v">;
 
-  defm XVAMO_SWAPD_V : XVAMO<0b00001, 0b111, "vamoswapd.v">;
-  defm XVAMO_ADDD_V : XVAMO<0b00000, 0b111, "vamoaddd.v">;
-  defm XVAMO_XORD_V : XVAMO<0b00100, 0b111, "vamoxord.v">;
-  defm XVAMO_ANDD_V : XVAMO<0b01100, 0b111, "vamoandd.v">;
-  defm XVAMO_ORD_V : XVAMO<0b01000, 0b111, "vamoord.v">;
-  defm XVAMO_MIND_V : XVAMO<0b10000, 0b111, "vamomind.v">;
-  defm XVAMO_MAXD_V : XVAMO<0b10100, 0b111, "vamomaxd.v">;
-  defm XVAMO_MINUD_V : XVAMO<0b11000, 0b111, "vamominud.v">;
-  defm XVAMO_MAXUD_V : XVAMO<0b11100, 0b111, "vamomaxud.v">;
+  defm XVAMOSWAPD : XVAMO<0b00001, 0b111, "vamoswapd.v">;
+  defm XVAMOADDD : XVAMO<0b00000, 0b111, "vamoaddd.v">;
+  defm XVAMOXORD : XVAMO<0b00100, 0b111, "vamoxord.v">;
+  defm XVAMOANDD : XVAMO<0b01100, 0b111, "vamoandd.v">;
+  defm XVAMOORD : XVAMO<0b01000, 0b111, "vamoord.v">;
+  defm XVAMOMIND : XVAMO<0b10000, 0b111, "vamomind.v">;
+  defm XVAMOMAXD : XVAMO<0b10100, 0b111, "vamomaxd.v">;
+  defm XVAMOMINUD : XVAMO<0b11000, 0b111, "vamominud.v">;
+  defm XVAMOMAXUD : XVAMO<0b11100, 0b111, "vamomaxud.v">;
 
-  defm XVAMO_SWAPQ_V : XVAMO<0b00001, 0b000, "vamoswapq.v">;
-  defm XVAMO_ADDQ_V : XVAMO<0b00000, 0b000, "vamoaddq.v">;
-  defm XVAMO_XORQ_V : XVAMO<0b00100, 0b000, "vamoxorq.v">;
-  defm XVAMO_ANDQ_V : XVAMO<0b01100, 0b000, "vamoandq.v">;
-  defm XVAMO_ORQ_V : XVAMO<0b01000, 0b000, "vamoorq.v">;
-  defm XVAMO_MINQ_V : XVAMO<0b10000, 0b000, "vamominq.v">;
-  defm XVAMO_MAXQ_V : XVAMO<0b10100, 0b000, "vamomaxq.v">;
-  defm XVAMO_MINUQ_V : XVAMO<0b11000, 0b000, "vamominuq.v">;
-  defm XVAMO_MAXUQ_V : XVAMO<0b11100, 0b000, "vamomaxuq.v">;
+  defm XVAMOSWAPQ : XVAMO<0b00001, 0b000, "vamoswapq.v">;
+  defm XVAMOADDQ : XVAMO<0b00000, 0b000, "vamoaddq.v">;
+  defm XVAMOXORQ : XVAMO<0b00100, 0b000, "vamoxorq.v">;
+  defm XVAMOANDQ : XVAMO<0b01100, 0b000, "vamoandq.v">;
+  defm XVAMOORQ : XVAMO<0b01000, 0b000, "vamoorq.v">;
+  defm XVAMOMINQ : XVAMO<0b10000, 0b000, "vamominq.v">;
+  defm XVAMOMAXQ : XVAMO<0b10100, 0b000, "vamomaxq.v">;
+  defm XVAMOMINUQ : XVAMO<0b11000, 0b000, "vamominuq.v">;
+  defm XVAMOMAXUQ : XVAMO<0b11100, 0b000, "vamomaxuq.v">;
 } // Predicates = [HasVendorXTHeadV, HasVendorXTHeadVamo, HasStdExtA]
 
 let Predicates = [HasVendorXTHeadV] in {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -88,6 +88,82 @@ let hasSideEffects = 1, mayLoad = 0, mayStore = 0, Defs = [VL, VTYPE] in {
 }
 
 //===----------------------------------------------------------------------===//
+// 8. Vector AMO Operations
+//===----------------------------------------------------------------------===//
+
+// Pseudo base class for unmasked vamo instructions
+class XVPseudoAMOWDNoMask<VReg RetClass,
+                          VReg Op1Class> :
+        Pseudo<(outs GetVRegNoV0<RetClass>.R:$vd_wd),
+               (ins Op1Class:$vs2,
+                    GPR:$rs1,
+                    GetVRegNoV0<RetClass>.R:$vd,
+                    AVL:$vl, ixlenimm:$sew), []>,
+        RISCVVPseudo {
+  let mayLoad = 1;
+  let mayStore = 1;
+  let hasSideEffects = 1;
+  let Constraints = "$vd_wd = $vd";
+  let HasVLOp = 1;
+  let HasSEWOp = 1;
+  let BaseInstr = !cast<Instruction>(PseudoToVInst<NAME>.VInst # "_V");
+}
+
+// Pseudo base class for masked vamo instructions
+class XVPseudoAMOWDMask<VReg RetClass,
+                        VReg Op1Class> :
+        Pseudo<(outs GetVRegNoV0<RetClass>.R:$vd_wd),
+               (ins Op1Class:$vs2,
+                    GPR:$rs1,
+                    GetVRegNoV0<RetClass>.R:$vd,
+                    VMaskOp:$vm, AVL:$vl, ixlenimm:$sew), []>,
+        RISCVVPseudo {
+  let mayLoad = 1;
+  let mayStore = 1;
+  let hasSideEffects = 1;
+  let Constraints = "$vd_wd = $vd";
+  let HasVLOp = 1;
+  let HasSEWOp = 1;
+  let BaseInstr = !cast<Instruction>(PseudoToVInst<NAME>.VInst # "_V");
+}
+
+multiclass XVPseudoAMOMem<int mem> {
+  // VAMO in RVV 0.7.1 supports 32, 64, and 128 Mem data bits, and in
+  // the base vector "V" extension, only SEW up to ELEN = max(XLEN, FLEN)
+  // are required to be supported, therefore only [32, 64] is allowed here.
+  foreach sew = [32, 64] in {
+    foreach lmul = [V_M1, V_M2, V_M4, V_M8] in {
+      defvar octuple_lmul = lmul.octuple;
+      // Calculate emul = sew * lmul / mem
+      defvar octuple_emul = !srl(!mul(sew, octuple_lmul), !logtwo(mem));
+      if !and(!ge(octuple_emul, 8), !le(octuple_emul, 64)) then {
+        defvar emulMX = octuple_to_str<octuple_emul>.ret;
+        defvar emul = !cast<LMULInfo>("V_" # emulMX);
+        let VLMul = lmul.value in {
+          def "_WD_" # lmul.MX # "_" # emulMX : XVPseudoAMOWDNoMask<lmul.vrclass, emul.vrclass>;
+          def "_WD_" # lmul.MX # "_" # emulMX # "_MASK" : XVPseudoAMOWDMask<lmul.vrclass, emul.vrclass>;
+        }
+      }
+    }
+  }
+}
+
+multiclass XVPseudoAMO {
+  defm "W" : XVPseudoAMOMem<32>;
+  defm "D" : XVPseudoAMOMem<64>;
+}
+
+defm PseudoXVAMOSWAP : XVPseudoAMO;
+defm PseudoXVAMOADD  : XVPseudoAMO;
+defm PseudoXVAMOXOR  : XVPseudoAMO;
+defm PseudoXVAMOAND  : XVPseudoAMO;
+defm PseudoXVAMOOR   : XVPseudoAMO;
+defm PseudoXVAMOMIN  : XVPseudoAMO;
+defm PseudoXVAMOMAX  : XVPseudoAMO;
+defm PseudoXVAMOMINU : XVPseudoAMO;
+defm PseudoXVAMOMAXU : XVPseudoAMO;
+
+//===----------------------------------------------------------------------===//
 // 12. Vector Integer Arithmetic Instructions
 //===----------------------------------------------------------------------===//
 defm PseudoXVADD   : VPseudoVALU_VV_VX_VI;
@@ -97,3 +173,91 @@ defm PseudoXVADD   : VPseudoVALU_VV_VX_VI;
 //===----------------------------------------------------------------------===//
 
 defm : VPatBinaryV_VV_VX_VI<"int_riscv_xvadd", "PseudoXVADD", AllIntegerXVectors>;
+
+// Patterns for vamo intrinsics.
+class XVPatAMOWDNoMask<string intrinsic_name,
+                    string inst,
+                    ValueType result_type,
+                    ValueType op1_type,
+                    int sew,
+                    LMULInfo vlmul,
+                    LMULInfo emul,
+                    VReg op1_reg_class> :
+  Pat<(result_type (!cast<Intrinsic>(intrinsic_name)
+                    GPR:$rs1,
+                    (op1_type op1_reg_class:$vs2),
+                    (result_type vlmul.vrclass:$vd),
+                    VLOpFrag)),
+                   (!cast<Instruction>(inst # "_WD_" # vlmul.MX # "_" # emul.MX)
+                    $vs2, $rs1, $vd,
+                    GPR:$vl, sew)>;
+
+class XVPatAMOWDMask<string intrinsic_name,
+                    string inst,
+                    ValueType result_type,
+                    ValueType op1_type,
+                    ValueType mask_type,
+                    int sew,
+                    LMULInfo vlmul,
+                    LMULInfo emul,
+                    VReg op1_reg_class> :
+  Pat<(result_type (!cast<Intrinsic>(intrinsic_name # "_mask")
+                    GPR:$rs1,
+                    (op1_type op1_reg_class:$vs2),
+                    (result_type vlmul.vrclass:$vd),
+                    (mask_type V0),
+                    VLOpFrag)),
+                  (!cast<Instruction>(inst # "_WD_" # vlmul.MX # "_" # emul.MX # "_MASK")
+                    $vs2, $rs1, $vd,
+                    (mask_type V0), GPR:$vl, sew)>;
+
+multiclass XVPatAMOWD<string intrinsic,
+                     string inst,
+                     ValueType result_type,
+                     ValueType offset_type,
+                     ValueType mask_type,
+                     int sew,
+                     LMULInfo vlmul,
+                     LMULInfo emul,
+                     VReg op1_reg_class> {
+  def : XVPatAMOWDNoMask<intrinsic, inst, result_type, offset_type,
+                        sew, vlmul, emul, op1_reg_class>;
+  def : XVPatAMOWDMask<intrinsic, inst, result_type, offset_type,
+                      mask_type, sew, vlmul, emul, op1_reg_class>;
+}
+
+multiclass XVPatAMOV_WD<string intrinsic,
+                       string inst,
+                       list<VTypeInfo> vtilist> {
+  foreach eew = [32, 64] in {
+    foreach vti = vtilist in {
+      if !or(!eq(vti.SEW, 32), !eq(vti.SEW, 64)) then {
+        defvar octuple_lmul = vti.LMul.octuple;
+        // Calculate emul = eew * lmul / sew
+        defvar octuple_emul = !srl(!mul(eew, octuple_lmul), vti.Log2SEW);
+        // emul must be in range 8 - 64, since rvv 0.7.1 does not
+        // allow fractional lmul
+        if !and(!ge(octuple_emul, 8), !le(octuple_emul, 64)) then {
+          defvar emulMX = octuple_to_str<octuple_emul>.ret;
+          defvar offsetVti = !cast<VTypeInfo>("XVI" # eew # emulMX);
+          defvar inst_tag = inst # !cond(!eq(vti.SEW, 32) : "W", !eq(vti.SEW, 64) : "D");
+          defm : XVPatAMOWD<intrinsic, inst_tag,
+                           vti.Vector, offsetVti.Vector,
+                           vti.Mask, vti.Log2SEW, vti.LMul, offsetVti.LMul, offsetVti.RegClass>;
+        }
+      }
+    }
+  }
+}
+
+let Predicates = [HasVendorXTHeadV, HasVendorXTHeadVamo, HasStdExtA] in {
+  defm : XVPatAMOV_WD<"int_riscv_xvamoswap", "PseudoXVAMOSWAP", AllIntegerXVectors>;
+  defm : XVPatAMOV_WD<"int_riscv_xvamoadd", "PseudoXVAMOADD", AllIntegerXVectors>;
+  defm : XVPatAMOV_WD<"int_riscv_xvamoxor", "PseudoXVAMOXOR", AllIntegerXVectors>;
+  defm : XVPatAMOV_WD<"int_riscv_xvamoand", "PseudoXVAMOAND", AllIntegerXVectors>;
+  defm : XVPatAMOV_WD<"int_riscv_xvamoor", "PseudoXVAMOOR", AllIntegerXVectors>;
+  defm : XVPatAMOV_WD<"int_riscv_xvamomin", "PseudoXVAMOMIN", AllIntegerXVectors>;
+  defm : XVPatAMOV_WD<"int_riscv_xvamomax", "PseudoXVAMOMAX", AllIntegerXVectors>;
+  defm : XVPatAMOV_WD<"int_riscv_xvamominu", "PseudoXVAMOMINU", AllIntegerXVectors>;
+  defm : XVPatAMOV_WD<"int_riscv_xvamomaxu", "PseudoXVAMOMAXU", AllIntegerXVectors>;
+} // Predicates = [HasVendorXTHeadV, HasVendorXTHeadVamo, HasStdExtA]

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vamoadd.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vamoadd.ll
@@ -1,0 +1,705 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoadd.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoadd_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoaddw.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoadd.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoadd.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoadd_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoaddw.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoadd.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoadd.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoadd_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoaddw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoadd.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoadd.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoadd_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoaddw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoadd.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoadd.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoadd_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoaddw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoadd.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoadd.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoadd_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoaddw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoadd.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamoadd.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamoadd_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamoaddw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamoadd.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamoadd.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamoadd_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamoaddw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamoadd.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoadd.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoadd_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoaddd.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoadd.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoadd.mask.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoadd_mask_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_mask_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoaddd.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoadd.mask.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoadd.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoadd_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoaddd.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoadd.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoadd.mask.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoadd_mask_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_mask_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoaddd.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoadd.mask.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoadd.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoadd_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoaddd.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoadd.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoadd.mask.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoadd_mask_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_mask_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoaddd.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoadd.mask.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoadd.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoadd_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoaddw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoadd.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoadd.mask.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoadd_mask_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_mask_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoaddw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoadd.mask.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoadd.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoadd_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoaddw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoadd.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoadd.mask.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoadd_mask_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_mask_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoaddw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoadd.mask.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoadd.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoadd_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoaddw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoadd.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoadd.mask.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoadd_mask_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_mask_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoaddw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoadd.mask.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamoadd.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamoadd_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamoaddd.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamoadd.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamoadd.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamoadd_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamoaddd.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamoadd.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoadd.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoadd_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoaddd.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoadd.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoadd.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoadd_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoaddd.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoadd.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoadd.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoadd_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoaddd.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoadd.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoadd.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoadd_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoaddd.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoadd.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoadd.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoadd_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoaddd.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoadd.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoadd.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoadd_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoadd_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoaddd.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoadd.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vamoand.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vamoand.ll
@@ -1,0 +1,705 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoand.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoand_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoandw.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoand.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoand.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoand_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoandw.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoand.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoand.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoand_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoandw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoand.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoand.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoand_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoandw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoand.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoand.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoand_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoandw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoand.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoand.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoand_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoandw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoand.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamoand.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamoand_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamoandw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamoand.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamoand.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamoand_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamoandw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamoand.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoand.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoand_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoandd.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoand.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoand.mask.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoand_mask_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_mask_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoandd.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoand.mask.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoand.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoand_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoandd.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoand.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoand.mask.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoand_mask_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_mask_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoandd.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoand.mask.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoand.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoand_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoandd.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoand.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoand.mask.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoand_mask_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_mask_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoandd.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoand.mask.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoand.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoand_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoandw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoand.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoand.mask.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoand_mask_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_mask_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoandw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoand.mask.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoand.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoand_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoandw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoand.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoand.mask.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoand_mask_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_mask_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoandw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoand.mask.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoand.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoand_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoandw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoand.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoand.mask.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoand_mask_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_mask_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoandw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoand.mask.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamoand.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamoand_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamoandd.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamoand.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamoand.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamoand_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamoandd.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamoand.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoand.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoand_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoandd.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoand.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoand.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoand_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoandd.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoand.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoand.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoand_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoandd.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoand.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoand.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoand_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoandd.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoand.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoand.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoand_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoandd.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoand.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoand.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoand_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoand_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoandd.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoand.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vamomax.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vamomax.ll
@@ -1,0 +1,705 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamomax.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamomax_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamomaxw.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamomax.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamomax.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamomax_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamomaxw.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamomax.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamomax.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamomax_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamomaxw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamomax.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamomax.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamomax_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamomaxw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamomax.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamomax.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamomax_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamomaxw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamomax.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamomax.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamomax_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamomaxw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamomax.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamomax.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamomax_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamomaxw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamomax.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamomax.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamomax_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamomaxw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamomax.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamomax.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamomax_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamomaxd.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamomax.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamomax.mask.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamomax_mask_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_mask_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamomaxd.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamomax.mask.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamomax.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamomax_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamomaxd.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamomax.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamomax.mask.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamomax_mask_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_mask_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamomaxd.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamomax.mask.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamomax.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamomax_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamomaxd.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamomax.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamomax.mask.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamomax_mask_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_mask_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamomaxd.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamomax.mask.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamomax.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamomax_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamomaxw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamomax.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamomax.mask.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamomax_mask_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_mask_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamomaxw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamomax.mask.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamomax.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamomax_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamomaxw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamomax.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamomax.mask.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamomax_mask_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_mask_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamomaxw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamomax.mask.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamomax.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamomax_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamomaxw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamomax.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamomax.mask.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamomax_mask_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_mask_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamomaxw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamomax.mask.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamomax.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamomax_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamomaxd.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamomax.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamomax.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamomax_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamomaxd.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamomax.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamomax.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamomax_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamomaxd.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamomax.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamomax.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamomax_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamomaxd.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamomax.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamomax.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamomax_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamomaxd.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamomax.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamomax.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamomax_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamomaxd.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamomax.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamomax.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamomax_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamomaxd.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamomax.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamomax.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamomax_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomax_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamomaxd.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamomax.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vamomaxu.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vamomaxu.ll
@@ -1,0 +1,705 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamomaxu.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamomaxu_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamomaxuw.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamomaxu.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamomaxu.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamomaxu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamomaxuw.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamomaxu.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamomaxu.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamomaxu_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamomaxuw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamomaxu.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamomaxu.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamomaxu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamomaxuw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamomaxu.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamomaxu.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamomaxu_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamomaxuw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamomaxu.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamomaxu.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamomaxu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamomaxuw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamomaxu.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamomaxu.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamomaxu_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamomaxuw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamomaxu.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamomaxu.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamomaxu_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamomaxuw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamomaxu.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamomaxu.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamomaxu_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamomaxud.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamomaxu.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamomaxu.mask.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamomaxu_mask_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_mask_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamomaxud.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamomaxu.mask.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamomaxu.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamomaxu_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamomaxud.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamomaxu.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamomaxu.mask.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamomaxu_mask_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_mask_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamomaxud.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamomaxu.mask.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamomaxu.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamomaxu_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamomaxud.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamomaxu.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamomaxu.mask.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamomaxu_mask_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_mask_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamomaxud.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamomaxu.mask.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamomaxu.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamomaxu_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamomaxuw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamomaxu.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamomaxu.mask.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamomaxu_mask_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_mask_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamomaxuw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamomaxu.mask.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamomaxu.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamomaxu_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamomaxuw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamomaxu.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamomaxu.mask.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamomaxu_mask_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_mask_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamomaxuw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamomaxu.mask.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamomaxu.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamomaxu_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamomaxuw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamomaxu.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamomaxu.mask.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamomaxu_mask_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_mask_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamomaxuw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamomaxu.mask.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamomaxu.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamomaxu_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamomaxud.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamomaxu.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamomaxu.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamomaxu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamomaxud.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamomaxu.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamomaxu.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamomaxu_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamomaxud.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamomaxu.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamomaxu.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamomaxu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamomaxud.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamomaxu.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamomaxu.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamomaxu_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamomaxud.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamomaxu.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamomaxu.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamomaxu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamomaxud.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamomaxu.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamomaxu.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamomaxu_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamomaxud.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamomaxu.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamomaxu.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamomaxu_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomaxu_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamomaxud.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamomaxu.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vamomin.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vamomin.ll
@@ -1,0 +1,705 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamomin.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamomin_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamominw.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamomin.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamomin.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamomin_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamominw.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamomin.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamomin.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamomin_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamominw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamomin.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamomin.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamomin_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamominw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamomin.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamomin.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamomin_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamominw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamomin.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamomin.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamomin_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamominw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamomin.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamomin.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamomin_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamominw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamomin.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamomin.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamomin_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamominw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamomin.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamomin.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamomin_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamomind.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamomin.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamomin.mask.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamomin_mask_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_mask_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamomind.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamomin.mask.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamomin.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamomin_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamomind.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamomin.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamomin.mask.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamomin_mask_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_mask_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamomind.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamomin.mask.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamomin.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamomin_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamomind.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamomin.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamomin.mask.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamomin_mask_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_mask_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamomind.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamomin.mask.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamomin.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamomin_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamominw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamomin.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamomin.mask.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamomin_mask_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_mask_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamominw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamomin.mask.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamomin.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamomin_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamominw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamomin.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamomin.mask.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamomin_mask_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_mask_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamominw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamomin.mask.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamomin.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamomin_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamominw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamomin.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamomin.mask.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamomin_mask_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_mask_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamominw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamomin.mask.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamomin.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamomin_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamomind.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamomin.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamomin.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamomin_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamomind.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamomin.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamomin.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamomin_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamomind.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamomin.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamomin.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamomin_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamomind.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamomin.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamomin.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamomin_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamomind.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamomin.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamomin.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamomin_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamomind.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamomin.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamomin.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamomin_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamomind.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamomin.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamomin.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamomin_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamomin_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamomind.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamomin.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vamominu.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vamominu.ll
@@ -1,0 +1,705 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamominu.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamominu_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamominuw.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamominu.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamominu.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamominu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamominuw.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamominu.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamominu.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamominu_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamominuw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamominu.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamominu.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamominu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamominuw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamominu.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamominu.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamominu_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamominuw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamominu.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamominu.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamominu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamominuw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamominu.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamominu.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamominu_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamominuw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamominu.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamominu.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamominu_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamominuw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamominu.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamominu.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamominu_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamominud.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamominu.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamominu.mask.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamominu_mask_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_mask_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamominud.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamominu.mask.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamominu.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamominu_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamominud.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamominu.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamominu.mask.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamominu_mask_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_mask_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamominud.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamominu.mask.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamominu.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamominu_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamominud.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamominu.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamominu.mask.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamominu_mask_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_mask_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamominud.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamominu.mask.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamominu.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamominu_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamominuw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamominu.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamominu.mask.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamominu_mask_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_mask_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamominuw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamominu.mask.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamominu.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamominu_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamominuw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamominu.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamominu.mask.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamominu_mask_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_mask_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamominuw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamominu.mask.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamominu.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamominu_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamominuw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamominu.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamominu.mask.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamominu_mask_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_mask_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamominuw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamominu.mask.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamominu.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamominu_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamominud.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamominu.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamominu.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamominu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamominud.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamominu.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamominu.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamominu_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamominud.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamominu.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamominu.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamominu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamominud.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamominu.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamominu.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamominu_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamominud.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamominu.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamominu.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamominu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamominud.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamominu.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamominu.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamominu_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamominud.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamominu.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamominu.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamominu_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamominu_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamominud.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamominu.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vamoor.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vamoor.ll
@@ -1,0 +1,705 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoor.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoor_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoorw.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoor.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoor.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoor_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoorw.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoor.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoor.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoor_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoorw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoor.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoor.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoor_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoorw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoor.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoor.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoor_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoorw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoor.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoor.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoor_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoorw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoor.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamoor.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamoor_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamoorw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamoor.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamoor.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamoor_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamoorw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamoor.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoor.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoor_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoord.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoor.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoor.mask.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoor_mask_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_mask_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoord.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoor.mask.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoor.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoor_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoord.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoor.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoor.mask.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoor_mask_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_mask_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoord.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoor.mask.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoor.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoor_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoord.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoor.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoor.mask.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoor_mask_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_mask_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoord.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoor.mask.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoor.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoor_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoorw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoor.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoor.mask.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoor_mask_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_mask_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoorw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoor.mask.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoor.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoor_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoorw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoor.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoor.mask.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoor_mask_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_mask_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoorw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoor.mask.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoor.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoor_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoorw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoor.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoor.mask.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoor_mask_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_mask_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoorw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoor.mask.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamoor.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamoor_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamoord.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamoor.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamoor.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamoor_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamoord.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamoor.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoor.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoor_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoord.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoor.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoor.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoor_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoord.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoor.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoor.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoor_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoord.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoor.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoor.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoor_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoord.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoor.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoor.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoor_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoord.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoor.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoor.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoor_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoor_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoord.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoor.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vamoswap.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vamoswap.ll
@@ -1,0 +1,705 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoswap.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoswap_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoswapw.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoswap.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoswap.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoswap_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoswapw.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoswap.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoswap.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoswap_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoswapw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoswap.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoswap.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoswap_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoswapw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoswap.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoswap.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoswap_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoswapw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoswap.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoswap.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoswap_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoswapw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoswap.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamoswap.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamoswap_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamoswapw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamoswap.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamoswap.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamoswap_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamoswapw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamoswap.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoswap.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoswap_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoswapd.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoswap.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoswap.mask.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoswap_mask_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_mask_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoswapd.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoswap.mask.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoswap.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoswap_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoswapd.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoswap.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoswap.mask.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoswap_mask_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_mask_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoswapd.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoswap.mask.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoswap.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoswap_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoswapd.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoswap.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoswap.mask.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoswap_mask_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_mask_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoswapd.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoswap.mask.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoswap.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoswap_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoswapw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoswap.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoswap.mask.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoswap_mask_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_mask_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoswapw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoswap.mask.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoswap.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoswap_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoswapw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoswap.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoswap.mask.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoswap_mask_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_mask_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoswapw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoswap.mask.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoswap.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoswap_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoswapw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoswap.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoswap.mask.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoswap_mask_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_mask_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoswapw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoswap.mask.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamoswap.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamoswap_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamoswapd.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamoswap.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamoswap.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamoswap_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamoswapd.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamoswap.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoswap.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoswap_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoswapd.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoswap.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoswap.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoswap_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoswapd.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoswap.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoswap.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoswap_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoswapd.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoswap.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoswap.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoswap_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoswapd.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoswap.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoswap.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoswap_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoswapd.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoswap.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoswap.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoswap_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoswap_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoswapd.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoswap.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vamoxor.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vamoxor.ll
@@ -1,0 +1,705 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+a,+xtheadv,+xtheadvamo \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoxor.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoxor_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoxorw.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoxor.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoxor.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoxor_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoxorw.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoxor.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoxor.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoxor_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoxorw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoxor.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoxor.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoxor_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoxorw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoxor.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoxor.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoxor_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoxorw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoxor.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoxor.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoxor_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoxorw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoxor.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamoxor.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamoxor_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamoxorw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamoxor.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvamoxor.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvamoxor_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vamoxorw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvamoxor.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoxor.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoxor_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoxord.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoxor.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoxor.mask.nxv2i64.nxv2i32(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoxor_mask_v_nxv2i64_nxv2i32(<vscale x 2 x i64>* %0, <vscale x 2 x i32> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_mask_v_nxv2i64_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoxord.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoxor.mask.nxv2i64.nxv2i32(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoxor.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoxor_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoxord.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoxor.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoxor.mask.nxv4i64.nxv4i32(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoxor_mask_v_nxv4i64_nxv4i32(<vscale x 4 x i64>* %0, <vscale x 4 x i32> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_mask_v_nxv4i64_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoxord.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoxor.mask.nxv4i64.nxv4i32(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoxor.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoxor_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoxord.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoxor.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoxor.mask.nxv8i64.nxv8i32(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoxor_mask_v_nxv8i64_nxv8i32(<vscale x 8 x i64>* %0, <vscale x 8 x i32> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_mask_v_nxv8i64_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoxord.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoxor.mask.nxv8i64.nxv8i32(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoxor.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoxor_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoxorw.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoxor.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvamoxor.mask.nxv2i32.nxv2i64(
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvamoxor_mask_v_nxv2i32_nxv2i64(<vscale x 2 x i32>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_mask_v_nxv2i32_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vamoxorw.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvamoxor.mask.nxv2i32.nxv2i64(
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoxor.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoxor_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoxorw.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoxor.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvamoxor.mask.nxv4i32.nxv4i64(
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvamoxor_mask_v_nxv4i32_nxv4i64(<vscale x 4 x i32>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_mask_v_nxv4i32_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vamoxorw.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvamoxor.mask.nxv4i32.nxv4i64(
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoxor.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoxor_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoxorw.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoxor.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvamoxor.mask.nxv8i32.nxv8i64(
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvamoxor_mask_v_nxv8i32_nxv8i64(<vscale x 8 x i32>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_mask_v_nxv8i32_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vamoxorw.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvamoxor.mask.nxv8i32.nxv8i64(
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamoxor.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamoxor_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamoxord.v v9, v8, (a0), v9
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamoxor.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvamoxor.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvamoxor_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vamoxord.v v9, v8, (a0), v9, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvamoxor.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoxor.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoxor_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoxord.v v10, v8, (a0), v10
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoxor.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvamoxor.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvamoxor_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vamoxord.v v10, v8, (a0), v10, v0.t
+; CHECK-NEXT:    vmv2r.v v8, v10
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvamoxor.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoxor.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoxor_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoxord.v v12, v8, (a0), v12
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoxor.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvamoxor.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvamoxor_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vamoxord.v v12, v8, (a0), v12, v0.t
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvamoxor.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoxor.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoxor_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoxord.v v16, v8, (a0), v16
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoxor.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvamoxor.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvamoxor_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvamoxor_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vamoxord.v v16, v8, (a0), v16, v0.t
+; CHECK-NEXT:    vmv8r.v v8, v16
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvamoxor.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+


### PR DESCRIPTION
This PR contains support for intrinsics of vamo instructions. Here's an overview of this PR:

- Name of classes representing vamo instructions (namely, XVAMO classes in RISCVInstrInfoXTHeadV.td) are updated to get a consistent naming style with other classes in that file, and to make life easier when writing pseudos.
- Define intrinsics, pats and pseudos.
- Finally, test all these intrinsics. The tests are generated by the script [here](https://gist.github.com/AinsleySnow/3ca1445de334669794f8bfadee280bc5).