### PR TITLE
[LLVM][RVV 0.7.1] Make intrinsics overloaded and try to reuse some intrinsics from the 1.0 version

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
@@ -15,12 +15,23 @@
 
 let TargetPrefix = "riscv" in {
   // 6. Configuration-Setting and Utility
-  def int_riscv_xvsetvl    : Intrinsic<[llvm_i64_ty],
-                                       [/* AVL */ llvm_i64_ty, /* SEW */ llvm_i64_ty, /* LMUL */ llvm_i64_ty],
-                                       [IntrNoMem]>;
-  def int_riscv_xvsetvlmax : Intrinsic<[llvm_i64_ty],
-                                       [/* SEW */ llvm_i64_ty, /* LMUL */ llvm_i64_ty],
-                                       [IntrNoMem]>;
+  def int_riscv_xvsetvl    : Intrinsic<[llvm_anyint_ty],
+                                       [/* AVL */ LLVMMatchType<0>,
+                                        /* SEW */ LLVMMatchType<0>,
+                                        /* LMUL */ LLVMMatchType<0>
+                                       ],
+                                       [IntrNoMem,
+                                        ImmArg<ArgIndex<1>>,
+                                        ImmArg<ArgIndex<2>>
+                                       ]>;
+  def int_riscv_xvsetvlmax : Intrinsic<[llvm_anyint_ty],
+                                       [/* SEW */ LLVMMatchType<0>,
+                                        /* LMUL */ LLVMMatchType<0>
+                                       ],
+                                       [IntrNoMem,
+                                        ImmArg<ArgIndex<0>>,
+                                        ImmArg<ArgIndex<1>>
+                                       ]>;
 
   defm xvadd : RISCVBinaryAAX;
 

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -924,3 +924,17 @@ def FeatureVendorXTHeadVediv
 def HasVendorXTHeadVediv : Predicate<"Subtarget->hasVendorXTHeadVediv()">,
                                      AssemblerPredicate<(all_of FeatureVendorXTHeadVediv),
                                      "'xtheadvediv' (T-Head Divided Element Extension)">;
+
+// Predicates for reusing instructions/intrinsics in both RVV 1.0 and 0.7
+def HasStdVOrXTHeadV    : Predicate<"Subtarget->hasVInstructions()">,
+      AssemblerPredicate<
+          (any_of FeatureStdExtZve32x, FeatureVendorXTHeadV),
+          "'V' (Vector Extension for Application Processors), 'Zve32x', "
+          "'Zve64x' (Vector Extensions for Embedded Processors) or"
+          "'XTHeadV' (Vector Extension for T-Head)">;
+def HasStdVOrXTHeadVI64 : Predicate<"Subtarget->hasVInstructionsI64()">,
+      AssemblerPredicate<
+          (any_of FeatureStdExtZve64x, FeatureVendorXTHeadV),
+          "'V' (Vector Extension for Application Processors), 'Zve64x' "
+          "(Vector Extensions for Embedded Processors) or"
+          "'XTHeadV' (Vector Extension for T-Head)">;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
@@ -6176,7 +6176,7 @@ multiclass VPatCompare_VI<string intrinsic, string inst,
 // Pseudo instructions
 //===----------------------------------------------------------------------===//
 
-let Predicates = [HasVInstructions] in {
+let Predicates = [HasStdVOrXTHeadV] in {
 
 //===----------------------------------------------------------------------===//
 // Pseudo Instructions for CodeGen
@@ -6188,6 +6188,10 @@ let hasSideEffects = 0, mayLoad = 0, mayStore = 0, isCodeGenOnly = 1 in {
                         PseudoInstExpansion<(CSRRS GPR:$rd, SysRegVLENB.Encoding, X0)>,
                         Sched<[WriteRdVLENB]>;
 }
+
+} // Predicates = [HasStdVOrXTHeadV]
+
+let Predicates = [HasVInstructions] in {
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0, isCodeGenOnly = 1,
     Uses = [VL] in

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -80,12 +80,15 @@ defset list<VTypeInfo> AllXVectors = {
 // 6. Configuration-Setting Instructions
 //===----------------------------------------------------------------------===//
 
-let hasSideEffects = 1, mayLoad = 0, mayStore = 0, Defs = [VL, VTYPE] in {
-  def PseudoXVSETVLI : Pseudo<(outs GPR:$rd), (ins GPRNoX0:$rs1, XTHeadVTypeI:$vtypei), []>,
-                       Sched<[WriteVSETVLI, ReadVSETVLI]>;
-  def PseudoXVSETVLIX0 : Pseudo<(outs GPR:$rd), (ins GPRX0:$rs1, XTHeadVTypeI:$vtypei), []>,
+// These can't be reused, since the vtypei in rvv 0.7 differs from the one in rvv 1.0
+let Predicates = [HasVendorXTHeadV] in {
+  let hasSideEffects = 1, mayLoad = 0, mayStore = 0, Defs = [VL, VTYPE] in {
+    def PseudoXVSETVLI : Pseudo<(outs GPR:$rd), (ins GPRNoX0:$rs1, XTHeadVTypeI:$vtypei), []>,
                          Sched<[WriteVSETVLI, ReadVSETVLI]>;
-}
+    def PseudoXVSETVLIX0 : Pseudo<(outs GPR:$rd), (ins GPRX0:$rs1, XTHeadVTypeI:$vtypei), []>,
+                           Sched<[WriteVSETVLI, ReadVSETVLI]>;
+  }
+} // Predicates = [HasVendorXTHeadV]
 
 //===----------------------------------------------------------------------===//
 // 8. Vector AMO Operations
@@ -153,26 +156,33 @@ multiclass XVPseudoAMO {
   defm "D" : XVPseudoAMOMem<64>;
 }
 
-defm PseudoXVAMOSWAP : XVPseudoAMO;
-defm PseudoXVAMOADD  : XVPseudoAMO;
-defm PseudoXVAMOXOR  : XVPseudoAMO;
-defm PseudoXVAMOAND  : XVPseudoAMO;
-defm PseudoXVAMOOR   : XVPseudoAMO;
-defm PseudoXVAMOMIN  : XVPseudoAMO;
-defm PseudoXVAMOMAX  : XVPseudoAMO;
-defm PseudoXVAMOMINU : XVPseudoAMO;
-defm PseudoXVAMOMAXU : XVPseudoAMO;
+let Predicates = [HasVendorXTHeadV, HasVendorXTHeadVamo, HasStdExtA] in {
+  defm PseudoXVAMOSWAP : XVPseudoAMO;
+  defm PseudoXVAMOADD  : XVPseudoAMO;
+  defm PseudoXVAMOXOR  : XVPseudoAMO;
+  defm PseudoXVAMOAND  : XVPseudoAMO;
+  defm PseudoXVAMOOR   : XVPseudoAMO;
+  defm PseudoXVAMOMIN  : XVPseudoAMO;
+  defm PseudoXVAMOMAX  : XVPseudoAMO;
+  defm PseudoXVAMOMINU : XVPseudoAMO;
+  defm PseudoXVAMOMAXU : XVPseudoAMO;
+} // Predicates = [HasVendorXTHeadV, HasVendorXTHeadVamo, HasStdExtA]
 
+// TODO: try to reuse them from RISCVInstrInfoVPseudos.td, see the `HasStdVOrXTHeadV` predicate
 //===----------------------------------------------------------------------===//
 // 12. Vector Integer Arithmetic Instructions
 //===----------------------------------------------------------------------===//
-defm PseudoXVADD   : VPseudoVALU_VV_VX_VI;
+let Predicates = [HasVendorXTHeadV] in {
+  defm PseudoXVADD   : VPseudoVALU_VV_VX_VI;
+} // Predicates = [HasVendorXTHeadV]
 
 //===----------------------------------------------------------------------===//
 // Patterns. Enabling code generation from intrinsics to pseudos, then to asms.
 //===----------------------------------------------------------------------===//
 
-defm : VPatBinaryV_VV_VX_VI<"int_riscv_xvadd", "PseudoXVADD", AllIntegerXVectors>;
+let Predicates = [HasVendorXTHeadV] in {
+  defm : VPatBinaryV_VV_VX_VI<"int_riscv_xvadd", "PseudoXVADD", AllIntegerXVectors>;
+} // Predicates = [HasVendorXTHeadV]
 
 // Patterns for vamo intrinsics.
 class XVPatAMOWDNoMask<string intrinsic_name,

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vsetvl.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vsetvl.ll
@@ -1,4 +1,7 @@
-; RUN: llc -mtriple=riscv64 -mattr=+xtheadv < %s | FileCheck -check-prefix=CHECK %s
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s
 
 ; https://github.com/riscv-non-isa/rvv-intrinsic-doc/blob/v0.7.1/rvv_intrinsic_funcs/01_configuration-setting_and_utility_functions.md
 
@@ -13,133 +16,133 @@
 ; -----------------------------------
 ; In intrinsic, ediv is always 0 for ASM name `d1`
 
-declare i64 @llvm.riscv.xvsetvl   (i64 %avl, i64 %sew, i64 %lmul);
-declare i64 @llvm.riscv.xvsetvlmax(          i64 %sew, i64 %lmul);
+declare iXLen @llvm.riscv.xvsetvl.iXLen   (iXLen %avl, iXLen %sew, iXLen %lmul);
+declare iXLen @llvm.riscv.xvsetvlmax.iXLen(            iXLen %sew, iXLen %lmul);
 
 
-define i64 @intrinsic_xvsetvl_e8m1(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e8m1(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e8m1
 ; CHECK: vsetvli a0, a0, e8, m1, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 0, i64 0)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 0, iXLen 0)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e8m2(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e8m2(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e8m2
 ; CHECK: vsetvli a0, a0, e8, m2, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 0, i64 1)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 0, iXLen 1)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e8m4(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e8m4(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e8m4
 ; CHECK: vsetvli a0, a0, e8, m4, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 0, i64 2)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 0, iXLen 2)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e8m8(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e8m8(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e8m8
 ; CHECK: vsetvli a0, a0, e8, m8, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 0, i64 3)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 0, iXLen 3)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e16m1(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e16m1(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e16m1
 ; CHECK: vsetvli a0, a0, e16, m1, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 1, i64 0)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 1, iXLen 0)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e16m2(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e16m2(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e16m2
 ; CHECK: vsetvli a0, a0, e16, m2, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 1, i64 1)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 1, iXLen 1)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e16m4(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e16m4(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e16m4
 ; CHECK: vsetvli a0, a0, e16, m4, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 1, i64 2)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 1, iXLen 2)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e16m8(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e16m8(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e16m8
 ; CHECK: vsetvli a0, a0, e16, m8, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 1, i64 3)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 1, iXLen 3)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e32m1(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e32m1(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e32m1
 ; CHECK: vsetvli a0, a0, e32, m1, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 2, i64 0)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 2, iXLen 0)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e32m2(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e32m2(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e32m2
 ; CHECK: vsetvli a0, a0, e32, m2, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 2, i64 1)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 2, iXLen 1)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e32m4(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e32m4(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e32m4
 ; CHECK: vsetvli a0, a0, e32, m4, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 2, i64 2)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 2, iXLen 2)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e32m8(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e32m8(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e32m8
 ; CHECK: vsetvli a0, a0, e32, m8, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 2, i64 3)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 2, iXLen 3)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e64m1(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e64m1(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e64m1
 ; CHECK: vsetvli a0, a0, e64, m1, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 3, i64 0)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 3, iXLen 0)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e64m2(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e64m2(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e64m2
 ; CHECK: vsetvli a0, a0, e64, m2, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 3, i64 1)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 3, iXLen 1)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e64m4(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e64m4(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e64m4
 ; CHECK: vsetvli a0, a0, e64, m4, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 3, i64 2)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 3, iXLen 2)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvl_e64m8(i64 %avl) {
+define iXLen @intrinsic_xvsetvl_e64m8(iXLen %avl) {
 ; CHECK-LABEL: intrinsic_xvsetvl_e64m8
 ; CHECK: vsetvli a0, a0, e64, m8, d1
-  %v = call i64 @llvm.riscv.xvsetvl(i64 %avl, i64 3, i64 3)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvl.iXLen(iXLen %avl, iXLen 3, iXLen 3)
+  ret iXLen %v
 }

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vsetvlmax.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vsetvlmax.ll
@@ -1,4 +1,7 @@
-; RUN: llc -mtriple=riscv64 -mattr=+xtheadv < %s | FileCheck -check-prefix=CHECK %s
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s
 
 ; https://github.com/riscv-non-isa/rvv-intrinsic-doc/blob/v0.7.1/rvv_intrinsic_funcs/01_configuration-setting_and_utility_functions.md
 
@@ -13,149 +16,149 @@
 ; -----------------------------------
 ; In intrinsic, ediv is always 0 for ASM name `d1`
 
-declare i64 @llvm.riscv.xvsetvl   (i64 %sew, i64 %lmul);
-declare i64 @llvm.riscv.xvsetvlmax(          i64 %sew, i64 %lmul);
+declare iXLen @llvm.riscv.xvsetvl.iXLen   (iXLen %avl, iXLen %sew, iXLen %lmul);
+declare iXLen @llvm.riscv.xvsetvlmax.iXLen(            iXLen %sew, iXLen %lmul);
 
 
-define i64 @intrinsic_xvsetvlmax_e8m1() {
+define iXLen @intrinsic_xvsetvlmax_e8m1() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e8m1
 ; CHECK: vsetvli a0, zero, e8, m1, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 0, i64 0)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 0, iXLen 0)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e8m2() {
+define iXLen @intrinsic_xvsetvlmax_e8m2() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e8m2
 ; CHECK: vsetvli a0, zero, e8, m2, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 0, i64 1)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 0, iXLen 1)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e8m4() {
+define iXLen @intrinsic_xvsetvlmax_e8m4() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e8m4
 ; CHECK: vsetvli a0, zero, e8, m4, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 0, i64 2)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 0, iXLen 2)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e8m8() {
+define iXLen @intrinsic_xvsetvlmax_e8m8() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e8m8
 ; CHECK: vsetvli a0, zero, e8, m8, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 0, i64 3)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 0, iXLen 3)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e16m1() {
+define iXLen @intrinsic_xvsetvlmax_e16m1() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e16m1
 ; CHECK: vsetvli a0, zero, e16, m1, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 1, i64 0)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 1, iXLen 0)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e16m2() {
+define iXLen @intrinsic_xvsetvlmax_e16m2() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e16m2
 ; CHECK: vsetvli a0, zero, e16, m2, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 1, i64 1)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 1, iXLen 1)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e16m4() {
+define iXLen @intrinsic_xvsetvlmax_e16m4() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e16m4
 ; CHECK: vsetvli a0, zero, e16, m4, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 1, i64 2)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 1, iXLen 2)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e16m8() {
+define iXLen @intrinsic_xvsetvlmax_e16m8() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e16m8
 ; CHECK: vsetvli a0, zero, e16, m8, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 1, i64 3)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 1, iXLen 3)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e32m1() {
+define iXLen @intrinsic_xvsetvlmax_e32m1() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e32m1
 ; CHECK: vsetvli a0, zero, e32, m1, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 2, i64 0)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 2, iXLen 0)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e32m2() {
+define iXLen @intrinsic_xvsetvlmax_e32m2() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e32m2
 ; CHECK: vsetvli a0, zero, e32, m2, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 2, i64 1)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 2, iXLen 1)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e32m4() {
+define iXLen @intrinsic_xvsetvlmax_e32m4() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e32m4
 ; CHECK: vsetvli a0, zero, e32, m4, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 2, i64 2)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 2, iXLen 2)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e32m8() {
+define iXLen @intrinsic_xvsetvlmax_e32m8() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e32m8
 ; CHECK: vsetvli a0, zero, e32, m8, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 2, i64 3)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 2, iXLen 3)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e64m1() {
+define iXLen @intrinsic_xvsetvlmax_e64m1() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e64m1
 ; CHECK: vsetvli a0, zero, e64, m1, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 3, i64 0)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 3, iXLen 0)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e64m2() {
+define iXLen @intrinsic_xvsetvlmax_e64m2() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e64m2
 ; CHECK: vsetvli a0, zero, e64, m2, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 3, i64 1)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 3, iXLen 1)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e64m4() {
+define iXLen @intrinsic_xvsetvlmax_e64m4() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e64m4
 ; CHECK: vsetvli a0, zero, e64, m4, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 3, i64 2)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 3, iXLen 2)
+  ret iXLen %v
 }
 
 
-define i64 @intrinsic_xvsetvlmax_e64m8() {
+define iXLen @intrinsic_xvsetvlmax_e64m8() {
 entry:
 ; CHECK-LABEL: intrinsic_xvsetvlmax_e64m8
 ; CHECK: vsetvli a0, zero, e64, m8, d1
-  %v = call i64 @llvm.riscv.xvsetvlmax(i64 3, i64 3)
-  ret i64 %v
+  %v = call iXLen @llvm.riscv.xvsetvlmax.iXLen(iXLen 3, iXLen 3)
+  ret iXLen %v
 }


### PR DESCRIPTION
Thie PR is cherry-picked from #14 to simplify review.

- Fixed the bug that the LLVM intrinsic `xvsetvl` is not overloaded. Discovered in #14 
- Added TableGen predicate `HasStdVOrXTHeadV` to reuse similar or identical instructions from 1.0
- Updated tests