### PR TITLE
[Clang][RVV 0.7.1] Source-level compatibility with RVV 1.0 in `riscv_vector.h`

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11808,6 +11808,8 @@ def err_riscv_builtin_requires_extension : Error<
   "builtin requires%select{| at least one of the following extensions to be enabled}0: %1">;
 def err_riscv_builtin_invalid_lmul : Error<
   "LMUL argument must be in the range [0,3] or [5,7]">;
+def err_riscv_builtin_invalid_lmul_non_fractional : Error<
+  "LMUL argument must be in the range [0,3]">;
 def err_riscv_type_requires_extension : Error<
   "RISC-V type %0 requires the '%1' extension"
 >;

--- a/clang/include/clang/Basic/riscv_vector_xtheadv.td
+++ b/clang/include/clang/Basic/riscv_vector_xtheadv.td
@@ -58,6 +58,49 @@ multiclass RVVIntBinBuiltinSet
 // 6. Configuration-Setting Instructions
 //===----------------------------------------------------------------------===//
 
+// Define vread_csr&vwrite_csr described in RVV intrinsics doc.
+let HeaderCode =
+[{
+enum RVV_CSR {
+  RVV_VSTART = 0,
+  RVV_VXSAT,
+  RVV_VXRM,
+};
+
+static __inline__ __attribute__((__always_inline__, __nodebug__))
+unsigned long __riscv_vread_csr(enum RVV_CSR __csr) {
+  unsigned long __rv = 0;
+  switch (__csr) {
+    case RVV_VSTART:
+      __asm__ __volatile__ ("csrr\t%0, vstart" : "=r"(__rv) : : "memory");
+      break;
+    case RVV_VXSAT:
+      __asm__ __volatile__ ("csrr\t%0, vxsat" : "=r"(__rv) : : "memory");
+      break;
+    case RVV_VXRM:
+      __asm__ __volatile__ ("csrr\t%0, vxrm" : "=r"(__rv) : : "memory");
+      break;
+  }
+  return __rv;
+}
+
+static __inline__ __attribute__((__always_inline__, __nodebug__))
+void __riscv_vwrite_csr(enum RVV_CSR __csr, unsigned long __value) {
+  switch (__csr) {
+    case RVV_VSTART:
+      __asm__ __volatile__ ("csrw\tvstart, %z0" : : "rJ"(__value) : "memory");
+      break;
+    case RVV_VXSAT:
+      __asm__ __volatile__ ("csrw\tvxsat, %z0" : : "rJ"(__value) : "memory");
+      break;
+    case RVV_VXRM:
+      __asm__ __volatile__ ("csrw\tvxrm, %z0" : : "rJ"(__value) : "memory");
+      break;
+  }
+}
+}] in
+def xvread_xvwrite_csr: RVVHeader;
+
 // vsetvl/vsetvlmax are a macro because they require constant integers in SEW
 // and LMUL.
 let HeaderCode =

--- a/clang/include/clang/Basic/riscv_vector_xtheadv.td
+++ b/clang/include/clang/Basic/riscv_vector_xtheadv.td
@@ -62,6 +62,12 @@ multiclass RVVIntBinBuiltinSet
 // and LMUL.
 let HeaderCode =
 [{
+
+/* These two builtins comes from the 1.0 implementation, */
+/* for compatibility, we forward these calls to the the corresponding 0.7 builtins. */
+#define __builtin_rvv_vsetvli(avl, sew, lmul) __builtin_rvv_xvsetvl((size_t)(avl), sew, lmul)
+#define __builtin_rvv_vsetvlimax(sew, lmul)   __builtin_rvv_xvsetvlmax(sew, lmul)
+
 #define __riscv_vsetvl_e8m1(avl) __builtin_rvv_xvsetvl((size_t)(avl), 0, 0)
 #define __riscv_vsetvl_e8m2(avl) __builtin_rvv_xvsetvl((size_t)(avl), 0, 1)
 #define __riscv_vsetvl_e8m4(avl) __builtin_rvv_xvsetvl((size_t)(avl), 0, 2)

--- a/clang/include/clang/Basic/riscv_vector_xtheadv.td
+++ b/clang/include/clang/Basic/riscv_vector_xtheadv.td
@@ -107,7 +107,7 @@ let HeaderCode =
 [{
 
 /* These two builtins comes from the 1.0 implementation, */
-/* for compatibility, we forward these calls to the the corresponding 0.7 builtins. */
+/* for compatibility, we forward these calls to the corresponding 0.7 builtins. */
 #define __builtin_rvv_vsetvli(avl, sew, lmul) __builtin_rvv_xvsetvl((size_t)(avl), sew, lmul)
 #define __builtin_rvv_vsetvlimax(sew, lmul)   __builtin_rvv_xvsetvlmax(sew, lmul)
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -13629,7 +13629,7 @@ private:
   bool CheckPPCBuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
                                    CallExpr *TheCall);
   bool CheckAMDGCNBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall);
-  bool CheckRISCVLMUL(CallExpr *TheCall, unsigned ArgNum);
+  bool CheckRISCVLMUL(CallExpr *TheCall, unsigned ArgNum, bool AllowFractional);
   bool CheckRISCVBuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
                                      CallExpr *TheCall);
   void checkRVVTypeSupport(QualType Ty, SourceLocation Loc, ValueDecl *D);

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4457,7 +4457,7 @@ bool Sema::CheckAMDGCNBuiltinFunctionCall(unsigned BuiltinID,
   return false;
 }
 
-bool Sema::CheckRISCVLMUL(CallExpr *TheCall, unsigned ArgNum) {
+bool Sema::CheckRISCVLMUL(CallExpr *TheCall, unsigned ArgNum, bool AllowFractional) {
   llvm::APSInt Result;
 
   // We can't check the value of a dependent argument.
@@ -4470,10 +4470,13 @@ bool Sema::CheckRISCVLMUL(CallExpr *TheCall, unsigned ArgNum) {
     return true;
 
   int64_t Val = Result.getSExtValue();
-  if ((Val >= 0 && Val <= 3) || (Val >= 5 && Val <= 7))
+  if ((Val >= 0 && Val <= 3) || (AllowFractional && (Val >= 5 && Val <= 7)))
     return false;
 
-  return Diag(TheCall->getBeginLoc(), diag::err_riscv_builtin_invalid_lmul)
+  return Diag(TheCall->getBeginLoc(),
+              AllowFractional
+                  ? diag::err_riscv_builtin_invalid_lmul
+                  : diag::err_riscv_builtin_invalid_lmul_non_fractional)
          << Arg->getSourceRange();
 }
 
@@ -4601,10 +4604,16 @@ bool Sema::CheckRISCVBuiltinFunctionCall(const TargetInfo &TI,
   switch (BuiltinID) {
   case RISCVVector::BI__builtin_rvv_vsetvli:
     return SemaBuiltinConstantArgRange(TheCall, 1, 0, 3) ||
-           CheckRISCVLMUL(TheCall, 2);
+           CheckRISCVLMUL(TheCall, 2, true);
   case RISCVVector::BI__builtin_rvv_vsetvlimax:
     return SemaBuiltinConstantArgRange(TheCall, 0, 0, 3) ||
-           CheckRISCVLMUL(TheCall, 1);
+           CheckRISCVLMUL(TheCall, 1, true);
+  case RISCVVector::BI__builtin_rvv_xvsetvl:
+    return SemaBuiltinConstantArgRange(TheCall, 1, 0, 3) ||
+           CheckRISCVLMUL(TheCall, 2, false);
+  case RISCVVector::BI__builtin_rvv_xvsetvlmax:
+    return SemaBuiltinConstantArgRange(TheCall, 0, 0, 3) ||
+           CheckRISCVLMUL(TheCall, 1, false);
   case RISCVVector::BI__builtin_rvv_vget_v: {
     ASTContext::BuiltinVectorTypeInfo ResVecInfo =
         Context.getBuiltinVectorTypeInfo(cast<BuiltinType>(

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-error.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-error.c
@@ -10,6 +10,8 @@
 
 // CHECK-RV64-ERR: error: builtin requires at least one of the following extensions to be enabled: 'Xtheadv'
 
+#include <riscv_vector_xtheadv.h>
+
 int test() {
-  return __builtin_rvv_xvsetvl(1, 0, 0); // e8m1
+  return __builtin_rvv_vsetvli(1, 0, 0); // e8m1
 }

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-errors.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-errors.c
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 %s -triple=riscv64 -target-feature +xtheadv -fsyntax-only -verify
+
+void test(void) {
+  __builtin_rvv_xvsetvl(1, 7, 0); // expected-error {{argument value 7 is outside the valid range [0, 3]}}
+  __builtin_rvv_xvsetvlmax(-1, 0); // expected-error {{argument value 18446744073709551615 is outside the valid range [0, 3]}}
+  __builtin_rvv_xvsetvl(1, 0, 4); // expected-error {{LMUL argument must be in the range [0,3]}}
+  __builtin_rvv_xvsetvlmax(0, 4); // expected-error {{LMUL argument must be in the range [0,3]}}
+  __builtin_rvv_xvsetvl(1, 0, 8); // expected-error {{LMUL argument must be in the range [0,3]}}
+  __builtin_rvv_xvsetvlmax(0, -1); // expected-error {{LMUL argument must be in the range [0,3]}}
+}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-errors.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-errors.c
@@ -1,10 +1,12 @@
 // RUN: %clang_cc1 %s -triple=riscv64 -target-feature +xtheadv -fsyntax-only -verify
 
+#include <riscv_vector_xtheadv.h>
+
 void test(void) {
-  __builtin_rvv_xvsetvl(1, 7, 0); // expected-error {{argument value 7 is outside the valid range [0, 3]}}
-  __builtin_rvv_xvsetvlmax(-1, 0); // expected-error {{argument value 18446744073709551615 is outside the valid range [0, 3]}}
-  __builtin_rvv_xvsetvl(1, 0, 4); // expected-error {{LMUL argument must be in the range [0,3]}}
-  __builtin_rvv_xvsetvlmax(0, 4); // expected-error {{LMUL argument must be in the range [0,3]}}
-  __builtin_rvv_xvsetvl(1, 0, 8); // expected-error {{LMUL argument must be in the range [0,3]}}
-  __builtin_rvv_xvsetvlmax(0, -1); // expected-error {{LMUL argument must be in the range [0,3]}}
+  __builtin_rvv_vsetvli(1, 7, 0); // expected-error {{argument value 7 is outside the valid range [0, 3]}}
+  __builtin_rvv_vsetvlimax(-1, 0); // expected-error {{argument value 18446744073709551615 is outside the valid range [0, 3]}}
+  __builtin_rvv_vsetvli(1, 0, 4); // expected-error {{LMUL argument must be in the range [0,3]}}
+  __builtin_rvv_vsetvlimax(0, 4); // expected-error {{LMUL argument must be in the range [0,3]}}
+  __builtin_rvv_vsetvli(1, 0, 8); // expected-error {{LMUL argument must be in the range [0,3]}}
+  __builtin_rvv_vsetvlimax(0, -1); // expected-error {{LMUL argument must be in the range [0,3]}}
 }

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-errors.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-errors.c
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 %s -triple=riscv64 -target-feature +xtheadv -fsyntax-only -verify
 
-#include <riscv_vector_xtheadv.h>
+#include <riscv_vector.h>
 
 void test(void) {
   __builtin_rvv_vsetvli(1, 7, 0); // expected-error {{argument value 7 is outside the valid range [0, 3]}}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-intrinsic-datatypes.cpp
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-intrinsic-datatypes.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -triple riscv64 -target-feature +xtheadv \
 // RUN: -O0 -emit-llvm %s -o - | FileCheck %s
 
-#include <riscv_vector_xtheadv.h>
+#include <riscv_vector.h>
 
 // This test case tests the typedef generated under riscv_vector_xtheadv.h
 


### PR DESCRIPTION
This PR:

- Added missing semantic checking for `vsetvl` builtin functions in Clang.
- Made `riscv_vector.h` forward to `riscv_vector_xtheadv.h` when the macro `__riscv_vector_xtheadv` is defined. This enables source-level compatibility between programs using different RVV versions. See the test file [rvv-errors.c](https://github.com/imkiva/llvm-project/blob/5684b9ca3b2510d912613af10be0a6c6623bee3c/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/rvv-errors.c) for example.
