### PR TITLE
[LLVM] [RVV 0.7.1] Implement RVV 0.7.1 unit-strided load/store intrinsics.

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
@@ -37,6 +37,79 @@ let TargetPrefix = "riscv" in {
 
 } // TargetPrefix = "riscv"
 
+let TargetPrefix = "riscv" in {
+  // 7. Vector Loads and Stores
+
+  // 7.4 Vector Unit-Strided Instructions
+  // For unit stride load
+  // Input: (passthru, pointer, vl)
+  class XVUSLoad
+        : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
+                    [LLVMMatchType<0>, llvm_ptr_ty, llvm_anyint_ty],
+                    [NoCapture<ArgIndex<1>>, IntrReadMem]>, RISCVVIntrinsic {
+    let VLOperand = 2;
+  }
+
+  // For unit stride mask load
+  // Input: (passthru, pointer, vl)
+  class XVUSLoadMasked
+        : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
+                    [LLVMMatchType<0>, llvm_ptr_ty,
+                     LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
+                     llvm_anyint_ty],
+                    [NoCapture<ArgIndex<1>>, IntrReadMem]>,
+                    RISCVVIntrinsic {
+    let VLOperand = 3;
+  }
+
+  // For unit stride store
+  // Input: (vector_in, pointer, vl)
+  class XVUSStore
+        : DefaultAttrsIntrinsic<[],
+                    [llvm_anyvector_ty, llvm_ptr_ty, llvm_anyint_ty],
+                    [NoCapture<ArgIndex<1>>, IntrWriteMem]>, RISCVVIntrinsic {
+    let VLOperand = 2;
+  }
+
+  // For unit stride store with mask
+  // Input: (vector_in, pointer, mask, vl)
+  class XVUSStoreMasked
+        : DefaultAttrsIntrinsic<[],
+                    [llvm_anyvector_ty, llvm_ptr_ty,
+                     LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
+                     llvm_anyint_ty],
+                    [NoCapture<ArgIndex<1>>, IntrWriteMem]>, RISCVVIntrinsic {
+    let VLOperand = 3;
+  }
+
+  // We define vlx (e.g. vlb), vlxu (e.g. vlbu) and vle
+  // seperately here because otherwise we cannot distinguish
+  // which intrinsic the user actually calls when lowering pseudos.
+  def int_riscv_xvlb : XVUSLoad;
+  def int_riscv_xvlh : XVUSLoad;
+  def int_riscv_xvlw : XVUSLoad;
+  def int_riscv_xvle : XVUSLoad;
+  def int_riscv_xvlbu : XVUSLoad;
+  def int_riscv_xvlhu : XVUSLoad;
+  def int_riscv_xvlwu : XVUSLoad;
+  def int_riscv_xvlb_mask : XVUSLoadMasked;
+  def int_riscv_xvlh_mask : XVUSLoadMasked;
+  def int_riscv_xvlw_mask : XVUSLoadMasked;
+  def int_riscv_xvle_mask : XVUSLoadMasked;
+  def int_riscv_xvlbu_mask : XVUSLoadMasked;
+  def int_riscv_xvlhu_mask : XVUSLoadMasked;
+  def int_riscv_xvlwu_mask : XVUSLoadMasked;
+
+  def int_riscv_xvsb : XVUSStore;
+  def int_riscv_xvsh : XVUSStore;
+  def int_riscv_xvsw : XVUSStore;
+  def int_riscv_xvse : XVUSStore;
+  def int_riscv_xvsb_mask : XVUSStoreMasked;
+  def int_riscv_xvsh_mask : XVUSStoreMasked;
+  def int_riscv_xvsw_mask : XVUSStoreMasked;
+  def int_riscv_xvse_mask : XVUSStoreMasked;
+} // TargetPrefix = "riscv"
+
 // let TargetPrefix = "riscv" in {
 //   // 8. Vector AMO Operations (Zvamo)
 

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
@@ -147,7 +147,14 @@ public:
                                   bool IsMasked, bool IsStridedOrIndexed,
                                   SmallVectorImpl<SDValue> &Operands,
                                   bool IsLoad = false, MVT *IndexVT = nullptr);
+  void addXTHeadVLoadStoreOperands(SDNode *Node, unsigned SEWImm,
+                                  const SDLoc &DL, unsigned CurOp,
+                                  bool IsMasked, SmallVectorImpl<SDValue> &Operands);
 
+  void selectXVL(SDNode *Node, const SDLoc& DL, unsigned IntNo,
+                 bool IsUnsigned, bool IsMasked, bool IsE);
+  void selectXVS(SDNode *Node, const SDLoc& DL, unsigned IntNo,
+                 bool IsMasked, bool IsE);
   void selectVLSEG(SDNode *Node, bool IsMasked, bool IsStrided);
   void selectVLSEGFF(SDNode *Node, bool IsMasked);
   void selectVLXSEG(SDNode *Node, bool IsMasked, bool IsOrdered);
@@ -239,9 +246,28 @@ struct VLEPseudo {
   uint16_t Pseudo;
 };
 
+struct XVLPseudo {
+  uint16_t Masked : 1;
+  uint16_t Unsigned : 1;
+  uint16_t IsE : 1;
+  uint16_t Log2MEM : 3;
+  uint16_t Log2SEW : 3;
+  uint16_t LMUL : 3;
+  uint16_t Pseudo;
+};
+
 struct VSEPseudo {
   uint16_t Masked :1;
   uint16_t Strided : 1;
+  uint16_t Log2SEW : 3;
+  uint16_t LMUL : 3;
+  uint16_t Pseudo;
+};
+
+struct XVSPseudo {
+  uint16_t Masked : 1;
+  uint16_t IsE : 1;
+  uint16_t Log2MEM : 3;
   uint16_t Log2SEW : 3;
   uint16_t LMUL : 3;
   uint16_t Pseudo;
@@ -271,6 +297,9 @@ struct RISCVMaskedPseudoInfo {
 #define GET_RISCVVLXTable_DECL
 #define GET_RISCVVSXTable_DECL
 #define GET_RISCVMaskedPseudosTable_DECL
+
+#define GET_XTHeadVVLTable_DECL
+#define GET_XTHeadVVSTable_DECL
 #include "RISCVGenSearchableTables.inc"
 } // namespace RISCV
 

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -1322,8 +1322,40 @@ bool RISCVTargetLowering::getTgtMemIntrinsic(IntrinsicInfo &Info,
     return SetRVVLoadStoreInfo(/*PtrOp*/ 1,
                                /*IsStore*/ false,
                                /*IsUnitStrided*/ true);
+  case Intrinsic::riscv_xvlb:
+  case Intrinsic::riscv_xvlbu:
+  case Intrinsic::riscv_xvlb_mask:
+  case Intrinsic::riscv_xvlbu_mask:
+  case Intrinsic::riscv_xvlh:
+  case Intrinsic::riscv_xvlhu:
+  case Intrinsic::riscv_xvlh_mask:
+  case Intrinsic::riscv_xvlhu_mask:
+  case Intrinsic::riscv_xvlw:
+  case Intrinsic::riscv_xvlwu:
+  case Intrinsic::riscv_xvlw_mask:
+  case Intrinsic::riscv_xvlwu_mask:
+  case Intrinsic::riscv_xvle:
+  case Intrinsic::riscv_xvle_mask:
+    if (!Subtarget.hasVendorXTHeadV())
+      return false;
+    return SetRVVLoadStoreInfo(/*PtrOp*/ 1,
+                               /*IsStore*/ false,
+                               /*IsUnitStrided*/ true);
   case Intrinsic::riscv_vse:
   case Intrinsic::riscv_vse_mask:
+    return SetRVVLoadStoreInfo(/*PtrOp*/ 1,
+                               /*IsStore*/ true,
+                               /*IsUnitStrided*/ true);
+  case Intrinsic::riscv_xvsb:
+  case Intrinsic::riscv_xvsh:
+  case Intrinsic::riscv_xvsw:
+  case Intrinsic::riscv_xvse:
+  case Intrinsic::riscv_xvsb_mask:
+  case Intrinsic::riscv_xvsh_mask:
+  case Intrinsic::riscv_xvsw_mask:
+  case Intrinsic::riscv_xvse_mask:
+    if (!Subtarget.hasVendorXTHeadV())
+      return false;
     return SetRVVLoadStoreInfo(/*PtrOp*/ 1,
                                /*IsStore*/ true,
                                /*IsUnitStrided*/ true);

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -72,6 +72,41 @@ defset list<VTypeInfo> AllXVectors = {
   }
 }
 
+class XTHeadVVL<bit M, bit U, bit E, bits<3> ME, bits<3> S, bits<3> L> {
+  bits<1> Masked = M;
+  bits<1> Unsigned = U;
+  bits<1> IsE = E;
+  bits<3> Log2MEM = ME;
+  bits<3> Log2SEW = S;
+  bits<3> LMUL = L;
+  Pseudo Pseudo = !cast<Pseudo>(NAME);
+}
+
+def XTHeadVVLTable : GenericTable {
+  let FilterClass = "XTHeadVVL";
+  let CppTypeName = "XVLPseudo";
+  let Fields = ["Masked", "Unsigned", "IsE", "Log2MEM", "Log2SEW", "LMUL", "Pseudo"];
+  let PrimaryKey = ["Masked", "Unsigned", "IsE", "Log2MEM", "Log2SEW", "LMUL"];
+  let PrimaryKeyName = "getXVLPseudo";
+}
+
+class XTHeadVVS<bit M, bit E, bits<3> ME, bits<3> S, bits<3> L> {
+  bits<1> Masked = M;
+  bits<1> IsE = E;
+  bits<3> Log2MEM = ME;
+  bits<3> Log2SEW = S;
+  bits<3> LMUL = L;
+  Pseudo Pseudo = !cast<Pseudo>(NAME);
+}
+
+def XTHeadVVSTable : GenericTable {
+  let FilterClass = "XTHeadVVS";
+  let CppTypeName = "XVSPseudo";
+  let Fields = ["Masked", "IsE", "Log2MEM", "Log2SEW", "LMUL", "Pseudo"];
+  let PrimaryKey = ["Masked", "IsE", "Log2MEM", "Log2SEW", "LMUL"];
+  let PrimaryKeyName = "getXVSPseudo";
+}
+
 //===----------------------------------------------------------------------===//
 // Pseudos. These are used internally during code generation.
 //===----------------------------------------------------------------------===//
@@ -88,6 +123,161 @@ let Predicates = [HasVendorXTHeadV] in {
     def PseudoXVSETVLIX0 : Pseudo<(outs GPR:$rd), (ins GPRX0:$rs1, XTHeadVTypeI:$vtypei), []>,
                            Sched<[WriteVSETVLI, ReadVSETVLI]>;
   }
+} // Predicates = [HasVendorXTHeadV]
+
+//===----------------------------------------------------------------------===//
+// 7. Vector Loads and Stores
+//===----------------------------------------------------------------------===//
+
+class MemBitsToTag<int mem> {
+  string ret = !cond(!eq(mem, 8)  : "B",
+                     !eq(mem, 16) : "H",
+                     !eq(mem, 32) : "W",
+                     true         : "E");
+}
+
+// 7.4 Vector Unit-Stride Instructions
+class XVPseudoUSLoadNoMask<VReg RetClass, int MEM, int REG, bit unsigned, bit e> :
+      Pseudo<(outs RetClass:$rd),
+             (ins RetClass:$dest, GPRMem:$rs1, AVL:$vl, ixlenimm:$sew),[]>,
+      RISCVVPseudo,
+      XTHeadVVL</*Masked*/0, unsigned, e,
+                !logtwo(MEM), !logtwo(REG), VLMul> {
+  let mayLoad = 1;
+  let mayStore = 0;
+  let hasSideEffects = 0;
+  let HasVLOp = 1;
+  let HasSEWOp = 1;
+  let Constraints = "$rd = $dest";
+}
+
+class XVPseudoUSLoadMask<VReg RetClass, int MEM, int REG, bit unsigned, bit e> :
+      Pseudo<(outs GetVRegNoV0<RetClass>.R:$rd),
+              (ins GetVRegNoV0<RetClass>.R:$merge,
+                   GPRMem:$rs1,
+                   VMaskOp:$vm, AVL:$vl, ixlenimm:$sew),[]>,
+      RISCVVPseudo,
+      XTHeadVVL</*Masked*/1, unsigned, e,
+                !logtwo(MEM), !logtwo(REG), VLMul> {
+  let mayLoad = 1;
+  let mayStore = 0;
+  let hasSideEffects = 0;
+  let Constraints = "$rd = $merge";
+  let HasVLOp = 1;
+  let HasSEWOp = 1;
+}
+
+class XVPseudoUSStoreNoMask<VReg StClass, int MEM, int REG, bit e>:
+      Pseudo<(outs),
+              (ins StClass:$rd, GPRMem:$rs1, AVL:$vl, ixlenimm:$sew),[]>,
+      RISCVVPseudo,
+      XTHeadVVS</*Masked*/0, e, !logtwo(MEM), !logtwo(REG), VLMul> {
+  let mayLoad = 0;
+  let mayStore = 1;
+  let hasSideEffects = 0;
+  let HasVLOp = 1;
+  let HasSEWOp = 1;
+}
+
+class XVPseudoUSStoreMask<VReg StClass, int MEM, int REG, int e>:
+      Pseudo<(outs),
+              (ins StClass:$rd, GPRMem:$rs1, VMaskOp:$vm, AVL:$vl, ixlenimm:$sew),[]>,
+      RISCVVPseudo,
+      XTHeadVVS</*Masked*/1, e, !logtwo(MEM), !logtwo(REG), VLMul> {
+  let mayLoad = 0;
+  let mayStore = 1;
+  let hasSideEffects = 0;
+  let HasVLOp = 1;
+  let HasSEWOp = 1;
+}
+
+multiclass XVPseudoUSLoad {
+  foreach mem = [8, 16, 32] in {
+    foreach lmul = [V_M1, V_M2, V_M4, V_M8] in {
+      defvar LInfo = lmul.MX;
+      defvar vreg = lmul.vrclass;
+      defvar tag = MemBitsToTag<mem>.ret;
+      foreach reg = EEWList in {
+        if !ge(reg, mem) then {
+          // The destination register element must be wider
+          // than the memory element (7.3 in RVV spec 0.7.1).
+          let VLMul = lmul.value, SEW = mem in {
+            def tag # "_V_E" # reg # "_" # LInfo :
+              XVPseudoUSLoadNoMask<vreg, mem, reg, 0, 0>,
+              VLESched<LInfo>;
+            def tag # "U_V_E" # reg # "_" # LInfo :
+              XVPseudoUSLoadNoMask<vreg, mem, reg, 1, 0>,
+              VLESched<LInfo>;
+            def tag # "_V_E" # reg # "_" # LInfo # "_MASK" :
+              XVPseudoUSLoadMask<vreg, mem, reg, 0, 0>,
+              RISCVMaskedPseudo<MaskIdx=2>,
+              VLESched<LInfo>;
+            def tag # "U_V_E" # reg # "_" # LInfo # "_MASK" :
+              XVPseudoUSLoadMask<vreg, mem, reg, 1, 0>,
+              RISCVMaskedPseudo<MaskIdx=2>,
+              VLESched<LInfo>;
+          }
+        }
+      }
+    }
+  }
+  // For VLE, whose mem bits and reg bits is both SEW
+  foreach eew = EEWList in {
+    foreach lmul = [V_M1, V_M2, V_M4, V_M8] in {
+      defvar LInfo = lmul.MX;
+      defvar vreg = lmul.vrclass;
+      let VLMul = lmul.value, SEW = eew in {
+        def "E_V_E" # eew # "_" # LInfo :
+          XVPseudoUSLoadNoMask<vreg, eew, eew, 0, 1>,
+          VLESched<LInfo>;
+        def "E_V_E" # eew # "_" # LInfo # "_MASK" :
+          XVPseudoUSLoadMask<vreg, eew, eew, 0, 1>,
+          RISCVMaskedPseudo<MaskIdx=2>,
+          VLESched<LInfo>;
+      }
+    }
+  }
+}
+
+multiclass XVPseudoUSStore {
+  foreach mem = [8, 16, 32] in {
+    foreach lmul = [V_M1, V_M2, V_M4, V_M8] in {
+      defvar LInfo = lmul.MX;
+      defvar vreg = lmul.vrclass;
+      defvar tag = MemBitsToTag<mem>.ret;
+      foreach sew = EEWList in {
+        let VLMul = lmul.value, SEW = mem in {
+          // There is no 'unsigned store' in RVV 0.7.1
+          def tag # "_V_E" # sew # "_" # LInfo :
+            XVPseudoUSStoreNoMask<vreg, mem, sew, 0>,
+            VSESched<LInfo>;
+          def tag # "_V_E" # sew # "_" # LInfo # "_MASK" :
+            XVPseudoUSStoreMask<vreg, mem, sew, 0>,
+            VSESched<LInfo>;
+        }
+      }
+    }
+  }
+  // For VSE, whose mem bits and reg bits is both SEW
+  foreach eew = EEWList in {
+    foreach lmul = [V_M1, V_M2, V_M4, V_M8] in {
+      defvar LInfo = lmul.MX;
+      defvar vreg = lmul.vrclass;
+      let VLMul = lmul.value, SEW = eew in {
+        def "E_V_E" # eew # "_" # LInfo :
+          XVPseudoUSStoreNoMask<vreg, eew, eew, 1>,
+          VSESched<LInfo>;
+        def "E_V_E" # eew # "_" # LInfo # "_MASK" :
+          XVPseudoUSStoreMask<vreg, eew, eew, 1>,
+          VSESched<LInfo>;
+      }
+    }
+  }
+}
+
+let Predicates = [HasVendorXTHeadV] in {
+  defm PseudoXVL : XVPseudoUSLoad;
+  defm PseudoXVS : XVPseudoUSStore;
 } // Predicates = [HasVendorXTHeadV]
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vl.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vl.ll
@@ -1,0 +1,2292 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlb.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlb_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlb.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlb.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlb_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlb.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlb.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlb_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlb.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlb.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlb_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlb.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlb.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlb_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlb.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    iXLen %1)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlb.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlb_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, <vscale x 32 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlb.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    <vscale x 32 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlb.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlb_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlb.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    iXLen %1)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlb.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlb_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, <vscale x 64 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlb.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    <vscale x 64 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlb.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlb_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlb.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlb.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlb_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlb.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlb.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlb_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlb.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlb.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlb_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlb.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlb.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlb_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlb.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlb.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlb_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlb.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlb.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlb_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlb.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlb.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlb_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, <vscale x 32 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlb.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    <vscale x 32 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlb.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlb_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlb.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlb.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlb_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlb.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlb.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlb_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlb.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlb.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlb_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlb.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlb.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlb_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlb.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlb.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlb_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlb.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlb.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlb_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlb.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlb.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlb_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlb.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlb.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlb_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlb.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlb.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlb_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlb.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlb.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlb_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlb.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlb.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlb_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlb.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlb.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlb_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlb.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlb.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlb_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlb.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlb.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlb_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlb.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlb.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlb_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlb_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlb.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlh.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlh_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlh.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlh.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlh_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlh.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlh.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlh_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlh.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlh.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlh_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlh.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlh.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlh_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlh.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlh.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlh_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlh.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlh.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlh_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlh.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlh.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlh_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, <vscale x 32 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlh.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    <vscale x 32 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlh.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlh_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlh.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlh.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlh_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlh.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlh.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlh_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlh.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlh.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlh_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlh.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlh.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlh_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlh.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlh.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlh_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlh.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlh.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlh_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlh.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlh.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlh_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlh.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlh.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlh_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlh.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlh.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlh_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlh.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlh.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlh_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlh.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlh.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlh_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlh.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlh.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlh_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlh.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlh.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlh_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlh.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlh.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlh_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlh.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlh.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlh_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlh_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlh.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlw.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlw_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlw.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlw.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlw.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlw_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlw.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlw.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlw.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlw_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlw.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlw.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlw.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlw_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlw.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlw.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlw.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlw_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlw.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlw.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlw.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlw_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlw.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlw.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlw.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlw_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlw.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlw.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlw.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlw_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlw.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlw.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlw.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlw_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlw.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlw.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlw.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlw_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlw.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlw.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlw.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlw_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlw.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlw.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlw.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlw_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlw.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlw.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlw.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlw_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlw.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlw.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlw.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlw_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlw.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlw.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlw.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlw_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlw.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlw.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlw.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlw_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlw_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlw.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlw.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i8> @llvm.riscv.xvle.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvle_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvle.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 8 x i8> @llvm.riscv.xvle.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvle_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvle.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvle.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvle_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvle.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvle.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvle_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvle.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvle.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvle_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvle.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    iXLen %1)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvle.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvle_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, <vscale x 32 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvle.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    <vscale x 32 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvle.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvle_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvle.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    iXLen %1)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvle.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvle_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, <vscale x 64 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvle.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    <vscale x 64 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvle.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvle_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvle.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvle.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvle_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvle.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvle.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvle_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvle.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvle.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvle_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvle.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvle.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvle_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvle.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvle.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvle_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvle.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvle.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvle_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvle.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvle.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvle_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, <vscale x 32 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvle.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    <vscale x 32 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvle.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvle_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvle.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvle.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvle_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvle.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvle.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvle_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvle.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvle.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvle_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvle.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvle.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvle_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvle.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvle.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvle_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvle.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvle.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvle_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvle.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvle.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvle_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvle.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvle.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvle_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvle.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvle.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvle_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvle.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvle.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvle_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvle.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvle.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvle_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvle.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvle.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvle_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvle.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvle.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvle_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvle.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvle.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvle_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvle.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvle.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvle_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvle.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vlu.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vlu.ll
@@ -1,0 +1,1589 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlbu.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlbu_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlbu.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlbu.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlbu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlbu.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlbu.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlbu_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlbu.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlbu.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlbu_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlbu.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlbu.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlbu_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlbu.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    iXLen %1)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlbu.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlbu_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, <vscale x 32 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlbu.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    <vscale x 32 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlbu.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlbu_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlbu.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    iXLen %1)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlbu.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlbu_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, <vscale x 64 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlbu.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    <vscale x 64 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlbu.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlbu_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlbu.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlbu.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlbu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlbu.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlbu.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlbu_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlbu.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlbu.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlbu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlbu.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlbu.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlbu_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlbu.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlbu.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlbu_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlbu.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlbu.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlbu_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlbu.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlbu.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlbu_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, <vscale x 32 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlbu.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    <vscale x 32 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlbu.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlbu_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlbu.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlbu.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlbu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlbu.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlbu.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlbu_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlbu.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlbu.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlbu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlbu.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlbu.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlbu_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlbu.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlbu.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlbu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlbu.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlbu.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlbu_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlbu.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlbu.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlbu_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlbu.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlbu.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlbu_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlbu.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlbu.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlbu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlbu.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlbu.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlbu_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlbu.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlbu.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlbu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlbu.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlbu.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlbu_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlbu.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlbu.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlbu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlbu.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlbu.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlbu_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlbu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlbu.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlbu.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlbu_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlbu_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlbu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlbu.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlhu.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlhu_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlhu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlhu.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlhu.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlhu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlhu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlhu.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlhu.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlhu_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlhu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlhu.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlhu.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlhu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlhu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlhu.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlhu.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlhu_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlhu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlhu.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlhu.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlhu_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlhu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlhu.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlhu.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlhu_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlhu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlhu.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    iXLen %1)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlhu.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlhu_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, <vscale x 32 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlhu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlhu.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    <vscale x 32 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlhu.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlhu_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlhu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlhu.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlhu.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlhu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlhu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlhu.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlhu.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlhu_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlhu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlhu.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlhu.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlhu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlhu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlhu.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlhu.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlhu_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlhu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlhu.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlhu.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlhu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlhu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlhu.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlhu.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlhu_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlhu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlhu.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlhu.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlhu_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlhu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlhu.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlhu.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlhu_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlhu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlhu.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlhu.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlhu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlhu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlhu.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlhu.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlhu_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlhu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlhu.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlhu.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlhu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlhu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlhu.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlhu.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlhu_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlhu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlhu.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlhu.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlhu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlhu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlhu.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlhu.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlhu_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlhu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlhu.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlhu.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlhu_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlhu_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlhu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlhu.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlwu.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlwu_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlwu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlwu.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlwu.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlwu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlwu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlwu.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlwu.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlwu_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlwu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlwu.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlwu.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlwu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlwu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlwu.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlwu.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlwu_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlwu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlwu.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlwu.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlwu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlwu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlwu.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlwu.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlwu_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlwu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlwu.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlwu.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlwu_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlwu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlwu.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlwu.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlwu_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlwu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlwu.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlwu.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlwu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlwu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlwu.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlwu.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlwu_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlwu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlwu.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlwu.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlwu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlwu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlwu.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlwu.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlwu_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlwu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlwu.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlwu.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlwu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlwu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlwu.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlwu.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlwu_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlwu.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlwu.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlwu.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlwu_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvlwu_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlwu.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlwu.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x i64> %a
+}
+

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vs.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vs.ll
@@ -1,0 +1,1236 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare void @llvm.riscv.xvsb.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen);
+
+define void @intrinsic_xvsb_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvsb_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vsb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsb.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsb.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsb_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvsb_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vsb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsb.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsb.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen);
+
+define void @intrinsic_xvsb_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvsb_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vsb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsb.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsb.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsb_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvsb_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vsb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsb.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsb.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen);
+
+define void @intrinsic_xvsb_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvsb_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vsb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsb.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsb.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsb_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, <vscale x 32 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvsb_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vsb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsb.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    <vscale x 32 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsb.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen);
+
+define void @intrinsic_xvsb_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvsb_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vsb.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsb.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsb.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsb_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, <vscale x 64 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvsb_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vsb.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsb.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    <vscale x 64 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsh.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen);
+
+define void @intrinsic_xvsh_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvsh_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vsh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsh.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsh.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsh_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvsh_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vsh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsh.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsh.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen);
+
+define void @intrinsic_xvsh_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvsh_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vsh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsh.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsh.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsh_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvsh_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vsh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsh.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsh.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen);
+
+define void @intrinsic_xvsh_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvsh_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vsh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsh.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsh.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsh_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvsh_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vsh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsh.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsh.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen);
+
+define void @intrinsic_xvsh_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvsh_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vsh.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsh.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsh.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsh_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, <vscale x 32 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvsh_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vsh.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsh.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    <vscale x 32 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsw.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen);
+
+define void @intrinsic_xvsw_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvsw_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vsw.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsw.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsw.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsw_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvsw_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vsw.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsw.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsw.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen);
+
+define void @intrinsic_xvsw_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvsw_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vsw.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsw.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsw.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsw_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvsw_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vsw.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsw.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsw.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen);
+
+define void @intrinsic_xvsw_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvsw_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vsw.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsw.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsw.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsw_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvsw_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vsw.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsw.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsw.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen);
+
+define void @intrinsic_xvsw_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvsw_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vsw.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsw.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsw.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsw_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvsw_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vsw.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsw.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, <vscale x 32 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    <vscale x 32 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, <vscale x 64 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    <vscale x 64 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, <vscale x 32 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    <vscale x 32 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret void
+}


### PR DESCRIPTION
This PR implements unit-strided load/store intrinsics and should be merged after #21 .

- The intrinsic standard can be found [here](https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource/1836682/1638774209491/Xuantie+900+Series+RVV-0.7.1+Intrinsic+Manual.pdf) and unit-strided intrinsic can be found in page 42.
- Define intrinsic functions and pseudo nodes for intrinsic functions in the two TableGen files. I define intrinsic for vl{b, h, w} separately (similar for vs{b, h, w}) because otherwise we cannot tell which of the three instructions the user actually wants when lowering pseudos.
- While it is possible to define intrinsic name for vle like vle{8, 16, 32, 64}, I only defined "int_riscv_xvle" here and the eew can be inferred from parameter type. This avoids writing too many tags in the switch body [here](https://github.com/ruyisdk/llvm-project/pull/22/commits/a9791e52f10770b46fc2a2627f2b6b62795222ab#diff-1ab4bce12d1c6a1259aaf05d494de128634853a0cb71564a8a6d2cdf8f9b48d4R1932-R1935).
- RVV 1.0 uses custom ISel for selecting load/store intrinsics. I followed the style here. Related changes are in https://github.com/ruyisdk/llvm-project/pull/22/commits/a9791e52f10770b46fc2a2627f2b6b62795222ab.

I will implement other load/store intrinsic variants in the following patches.