### PR TITLE
[LLVM][RVV 0.7.1] Emulate vector register whole load/store, and fix potential instruction selection bugs

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -11,6 +11,7 @@
 // the post-regalloc scheduling pass.
 //
 //===----------------------------------------------------------------------===//
+
 #include "RISCV.h"
 #include "RISCVInstrInfo.h"
 #include "RISCVTargetMachine.h"

--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -49,8 +49,6 @@ private:
                   MachineBasicBlock::iterator &NextMBBI);
   bool expandVSetVL(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI);
   bool expandXVSetVL(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI);
-  bool expandXWholeLoad(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI);
-  bool expandXWholeStore(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI);
   bool expandVMSET_VMCLR(MachineBasicBlock &MBB,
                          MachineBasicBlock::iterator MBBI, unsigned Opcode);
   bool expandRV32ZdinxStore(MachineBasicBlock &MBB,
@@ -129,28 +127,6 @@ bool RISCVExpandPseudo::expandMI(MachineBasicBlock &MBB,
   case RISCV::PseudoXVSETVLI:
   case RISCV::PseudoXVSETVLIX0:
     return expandXVSetVL(MBB, MBBI);
-  case RISCV::PseudoXVL1RE8_V:
-  case RISCV::PseudoXVL1RE16_V:
-  case RISCV::PseudoXVL1RE32_V:
-  case RISCV::PseudoXVL1RE64_V:
-  case RISCV::PseudoXVL2RE8_V:
-  case RISCV::PseudoXVL2RE16_V:
-  case RISCV::PseudoXVL2RE32_V:
-  case RISCV::PseudoXVL2RE64_V:
-  case RISCV::PseudoXVL4RE8_V:
-  case RISCV::PseudoXVL4RE16_V:
-  case RISCV::PseudoXVL4RE32_V:
-  case RISCV::PseudoXVL4RE64_V:
-  case RISCV::PseudoXVL8RE8_V:
-  case RISCV::PseudoXVL8RE16_V:
-  case RISCV::PseudoXVL8RE32_V:
-  case RISCV::PseudoXVL8RE64_V:
-    return expandXWholeLoad(MBB, MBBI);
-  case RISCV::PseudoXVS1R_V:
-  case RISCV::PseudoXVS2R_V:
-  case RISCV::PseudoXVS4R_V:
-  case RISCV::PseudoXVS8R_V:
-    return expandXWholeStore(MBB, MBBI);
   case RISCV::PseudoVMCLR_M_B1:
   case RISCV::PseudoVMCLR_M_B2:
   case RISCV::PseudoVMCLR_M_B4:
@@ -296,113 +272,6 @@ bool RISCVExpandPseudo::expandXVSetVL(MachineBasicBlock &MBB,
       .add(MBBI->getOperand(1))  // VL
       .add(MBBI->getOperand(2)); // VType
 
-  MBBI->eraseFromParent(); // The pseudo instruction is gone now.
-  return true;
-}
-
-bool RISCVExpandPseudo::expandXWholeLoad(MachineBasicBlock &MBB,
-                                         MachineBasicBlock::iterator MBBI) {
-  // Accepts: vl<LMUL>re<SEW>.v vd, offset(rs1)
-  assert(MBBI->getNumExplicitOperands() == 2 && MBBI->getNumOperands() == 2 &&
-         "Unexpected instruction format for XWholeLoad");
-
-  DebugLoc DL = MBBI->getDebugLoc();
-
-  assert((MBBI->getOpcode() == RISCV::PseudoXVL1RE8_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL1RE16_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL1RE32_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL1RE64_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL2RE8_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL2RE16_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL2RE32_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL2RE64_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL4RE8_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL4RE16_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL4RE32_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL4RE64_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL8RE8_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL8RE16_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL8RE32_V ||
-          MBBI->getOpcode() == RISCV::PseudoXVL8RE64_V) &&
-         "Unexpected pseudo instruction");
-
-  unsigned SEW;  // should be 8, 16, 32, 64
-  unsigned LMUL; // should be 1, 2, 4, 8
-
-  // `vl<LMUL>re<SEW>.v a, b` -> `vsetvli x0, x0, e<SEW>, m<LMUL>` + `vle.v a,
-  // b`
-#define CaseOp(SEW_val, LMUL_val)                                              \
-  case RISCV::PseudoXVL##LMUL_val##RE##SEW_val##_V:                            \
-    std::tie(SEW, LMUL) = std::make_pair(SEW_val, LMUL_val);                   \
-    break
-
-  switch (MBBI->getOpcode()) {
-    CaseOp(8, 1);
-    CaseOp(16, 1);
-    CaseOp(32, 1);
-    CaseOp(64, 1);
-    CaseOp(8, 2);
-    CaseOp(16, 2);
-    CaseOp(32, 2);
-    CaseOp(64, 2);
-    CaseOp(8, 4);
-    CaseOp(16, 4);
-    CaseOp(32, 4);
-    CaseOp(64, 4);
-    CaseOp(8, 8);
-    CaseOp(16, 8);
-    CaseOp(32, 8);
-    CaseOp(64, 8);
-  default:
-    llvm_unreachable("Unexpected opcode!");
-  }
-#undef CaseOp
-
-  // Backup vl, vtype
-  auto *MRI = &MBBI->getMF()->getRegInfo();
-  Register SavedVL = MRI->createVirtualRegister(&RISCV::GPRRegClass);
-  Register SavedVType = MRI->createVirtualRegister(&RISCV::GPRRegClass);
-  // Spec: The assembler pseudoinstruction to read a CSR, `CSRR rd, csr`, is
-  // encoded as `CSRRS rd, csr, x0`.
-  BuildMI(MBB, MBBI, DL, TII->get(RISCV::CSRRS), SavedVL)
-      .addImm(RISCVSysReg::lookupSysRegByName("VL")->Encoding)
-      .addReg(RISCV::X0);
-  BuildMI(MBB, MBBI, DL, TII->get(RISCV::CSRRS), SavedVType)
-      .addImm(RISCVSysReg::lookupSysRegByName("VTYPE")->Encoding)
-      .addReg(RISCV::X0);
-
-  // Generate `vsetvli x0, x0, e<SEW>, m<LMUL>`
-  auto VTypeI = RISCVVType::encodeXTHeadVTYPE(SEW, LMUL, 1); //
-  BuildMI(MBB, MBBI, DL, TII->get(RISCV::XVSETVLI))
-      .addReg(RISCV::X0, RegState::Define | RegState::Dead)
-      .addReg(RISCV::X0)
-      .addImm(VTypeI)
-      .addReg(RISCV::VL, RegState::Implicit);
-
-  // Generate `vle.v`
-  // From GCC: `vl<LMUL>re<SEW>.v vd, offset(rs1)` -> `vle.v vd, offset(rs1)`
-  BuildMI(MBB, MBBI, DL, TII->get(RISCV::XVLE_V))
-      .add(MBBI->getOperand(0))  // dst
-      .add(MBBI->getOperand(1)); // rs1(address)
-
-  // Restore vl, vtype
-  // Spec: The assembler pseudoinstruction to write a CSR, `CSRW csr, rs1`, is
-  // encoded as `CSRRW x0, csr, rs1`.
-  BuildMI(MBB, MBBI, DL, TII->get(RISCV::CSRRW))
-      .addReg(RISCV::X0, RegState::Define | RegState::Dead) // x0
-      .addImm(RISCVSysReg::lookupSysRegByName("VL")->Encoding)
-      .addReg(SavedVL, RegState::Kill); // rs1
-  BuildMI(MBB, MBBI, DL, TII->get(RISCV::CSRRW))
-      .addReg(RISCV::X0, RegState::Define | RegState::Dead) // x0
-      .addImm(RISCVSysReg::lookupSysRegByName("VTYPE")->Encoding)
-      .addReg(SavedVType, RegState::Kill); // rs1
-
-  MBBI->eraseFromParent(); // The pseudo instruction is gone now.
-  return true;
-}
-
-bool RISCVExpandPseudo::expandXWholeStore(MachineBasicBlock &MBB,
-                                          MachineBasicBlock::iterator MBBI) {
   MBBI->eraseFromParent(); // The pseudo instruction is gone now.
   return true;
 }

--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -50,6 +50,8 @@ private:
                   MachineBasicBlock::iterator &NextMBBI);
   bool expandVSetVL(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI);
   bool expandXVSetVL(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI);
+  bool expandXWholeLoad(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI);
+  bool expandXWholeStore(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI);
   bool expandVMSET_VMCLR(MachineBasicBlock &MBB,
                          MachineBasicBlock::iterator MBBI, unsigned Opcode);
   bool expandRV32ZdinxStore(MachineBasicBlock &MBB,
@@ -128,6 +130,28 @@ bool RISCVExpandPseudo::expandMI(MachineBasicBlock &MBB,
   case RISCV::PseudoXVSETVLI:
   case RISCV::PseudoXVSETVLIX0:
     return expandXVSetVL(MBB, MBBI);
+  case RISCV::PseudoXVL1RE8_V:
+  case RISCV::PseudoXVL1RE16_V:
+  case RISCV::PseudoXVL1RE32_V:
+  case RISCV::PseudoXVL1RE64_V:
+  case RISCV::PseudoXVL2RE8_V:
+  case RISCV::PseudoXVL2RE16_V:
+  case RISCV::PseudoXVL2RE32_V:
+  case RISCV::PseudoXVL2RE64_V:
+  case RISCV::PseudoXVL4RE8_V:
+  case RISCV::PseudoXVL4RE16_V:
+  case RISCV::PseudoXVL4RE32_V:
+  case RISCV::PseudoXVL4RE64_V:
+  case RISCV::PseudoXVL8RE8_V:
+  case RISCV::PseudoXVL8RE16_V:
+  case RISCV::PseudoXVL8RE32_V:
+  case RISCV::PseudoXVL8RE64_V:
+    return expandXWholeLoad(MBB, MBBI);
+  case RISCV::PseudoXVS1R_V:
+  case RISCV::PseudoXVS2R_V:
+  case RISCV::PseudoXVS4R_V:
+  case RISCV::PseudoXVS8R_V:
+    return expandXWholeStore(MBB, MBBI);
   case RISCV::PseudoVMCLR_M_B1:
   case RISCV::PseudoVMCLR_M_B2:
   case RISCV::PseudoVMCLR_M_B4:
@@ -273,6 +297,18 @@ bool RISCVExpandPseudo::expandXVSetVL(MachineBasicBlock &MBB,
       .add(MBBI->getOperand(1))  // VL
       .add(MBBI->getOperand(2)); // VType
 
+  MBBI->eraseFromParent(); // The pseudo instruction is gone now.
+  return true;
+}
+
+bool RISCVExpandPseudo::expandXWholeLoad(MachineBasicBlock &MBB,
+                                         MachineBasicBlock::iterator MBBI) {
+  MBBI->eraseFromParent(); // The pseudo instruction is gone now.
+  return true;
+}
+
+bool RISCVExpandPseudo::expandXWholeStore(MachineBasicBlock &MBB,
+                                          MachineBasicBlock::iterator MBBI) {
   MBBI->eraseFromParent(); // The pseudo instruction is gone now.
   return true;
 }

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -441,25 +441,25 @@ def FeatureStdExtV
                        "'V' (Vector Extension for Application Processors)",
                        [FeatureStdExtZvl128b, FeatureStdExtZve64d]>;
 
-def HasVInstructions    : Predicate<"Subtarget->hasVInstructions()">,
+def HasVInstructions    : Predicate<"Subtarget->hasOnlyStdV()">,
       AssemblerPredicate<
           (any_of FeatureStdExtZve32x),
           "'V' (Vector Extension for Application Processors), 'Zve32x' or "
           "'Zve64x' (Vector Extensions for Embedded Processors)">;
-def HasVInstructionsI64 : Predicate<"Subtarget->hasVInstructionsI64()">,
+def HasVInstructionsI64 : Predicate<"Subtarget->hasOnlyStdVI64()">,
       AssemblerPredicate<
           (any_of FeatureStdExtZve64x),
           "'V' (Vector Extension for Application Processors) or 'Zve64x' "
           "(Vector Extensions for Embedded Processors)">;
-def HasVInstructionsAnyF : Predicate<"Subtarget->hasVInstructionsAnyF()">,
+def HasVInstructionsAnyF : Predicate<"Subtarget->hasOnlyStdVAnyF()">,
       AssemblerPredicate<
           (any_of FeatureStdExtZve32f),
           "'V' (Vector Extension for Application Processors), 'Zve32f', "
           "'Zve64f' or 'Zve64d' (Vector Extensions for Embedded Processors)">;
 
-def HasVInstructionsF64 : Predicate<"Subtarget->hasVInstructionsF64()">;
+def HasVInstructionsF64 : Predicate<"Subtarget->hasOnlyStdVF64()">;
 
-def HasVInstructionsFullMultiply : Predicate<"Subtarget->hasVInstructionsFullMultiply()">;
+def HasVInstructionsFullMultiply : Predicate<"Subtarget->hasOnlyStdVFullMultiply()">;
 
 def FeatureStdExtZvfbfmin
     : SubtargetFeature<"experimental-zvfbfmin", "HasStdExtZvfbfmin", "true",
@@ -482,7 +482,7 @@ def FeatureStdExtZvfh
                        "'Zvfh' (Vector Half-Precision Floating-Point)",
                        [FeatureStdExtZve32f, FeatureStdExtZfhmin]>;
 
-def HasVInstructionsF16 : Predicate<"Subtarget->hasVInstructionsF16()">;
+def HasVInstructionsF16 : Predicate<"Subtarget->hasOnlyStdVF16()">;
 
 def HasStdExtZfhOrZvfh
     : Predicate<"Subtarget->hasStdExtZfh() || Subtarget->hasStdExtZvfh()">,
@@ -926,13 +926,13 @@ def HasVendorXTHeadVediv : Predicate<"Subtarget->hasVendorXTHeadVediv()">,
                                      "'xtheadvediv' (T-Head Divided Element Extension)">;
 
 // Predicates for reusing instructions/intrinsics in both RVV 1.0 and 0.7
-def HasStdVOrXTHeadV    : Predicate<"Subtarget->hasVInstructions()">,
+def HasStdVOrXTHeadV    : Predicate<"Subtarget->hasStdVOrXTHeadV()">,
       AssemblerPredicate<
           (any_of FeatureStdExtZve32x, FeatureVendorXTHeadV),
           "'V' (Vector Extension for Application Processors), 'Zve32x', "
           "'Zve64x' (Vector Extensions for Embedded Processors) or"
           "'XTHeadV' (Vector Extension for T-Head)">;
-def HasStdVOrXTHeadVI64 : Predicate<"Subtarget->hasVInstructionsI64()">,
+def HasStdVOrXTHeadVI64 : Predicate<"Subtarget->hasStdVOrXTHeadVI64()">,
       AssemblerPredicate<
           (any_of FeatureStdExtZve64x, FeatureVendorXTHeadV),
           "'V' (Vector Extension for Application Processors), 'Zve64x' "

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -14597,6 +14597,57 @@ static MachineBasicBlock *emitFROUND(MachineInstr &MI, MachineBasicBlock *MBB,
   return DoneMBB;
 }
 
+static MachineBasicBlock *emitXWholeLoad(MachineInstr &MI,
+                                         MachineBasicBlock *BB, unsigned SEW,
+                                         unsigned LMUL) {
+  DebugLoc DL = MI.getDebugLoc();
+
+  auto *TII = BB->getParent()->getSubtarget().getInstrInfo();
+  auto *MRI = &BB->getParent()->getRegInfo();
+
+  Register SavedVL = MRI->createVirtualRegister(&RISCV::GPRRegClass);
+  Register SavedVType = MRI->createVirtualRegister(&RISCV::GPRRegClass);
+
+  // Spec: The assembler pseudoinstruction to read a CSR, `CSRR rd, csr`, is
+  // encoded as `CSRRS rd, csr, x0`.
+  BuildMI(*BB, MI, DL, TII->get(RISCV::CSRRS), SavedVL)
+      .addImm(RISCVSysReg::lookupSysRegByName("VL")->Encoding)
+      .addReg(RISCV::X0);
+  BuildMI(*BB, MI, DL, TII->get(RISCV::CSRRS), SavedVType)
+      .addImm(RISCVSysReg::lookupSysRegByName("VTYPE")->Encoding)
+      .addReg(RISCV::X0);
+
+  // Generate `vsetvli x0, x0, e<SEW>, m<LMUL>`
+  auto VTypeI = RISCVVType::encodeXTHeadVTYPE(SEW, LMUL, 1); //
+  BuildMI(*BB, MI, DL, TII->get(RISCV::XVSETVLI))
+      .addReg(RISCV::X0, RegState::Define | RegState::Dead)
+      .addReg(RISCV::X0)
+      .addImm(VTypeI)
+      .addReg(RISCV::VL, RegState::Implicit);
+
+  // Generate `vle.v`
+  // From GCC: `vl<LMUL>re<SEW>.v vd, offset(rs1)` -> `vle.v vd, offset(rs1)`
+  BuildMI(*BB, MI, DL, TII->get(RISCV::XVLE_V))
+      .add(MI.getOperand(0))      // dst
+      .add(MI.getOperand(1))      // rs1(address)
+      .addReg(RISCV::NoRegister); // vmask, currently no mask
+
+  // Restore vl, vtype with `vsetvl x0, SavedVL, SavedVType`
+  BuildMI(*BB, MI, DL, TII->get(RISCV::XVSETVL))
+      .addReg(RISCV::X0, RegState::Define | RegState::Dead)
+      .addReg(SavedVL, RegState::Kill)
+      .addReg(SavedVType, RegState::Kill);
+
+  // Erase the pseudoinstruction.
+  MI.eraseFromParent();
+  return BB;
+}
+
+static MachineBasicBlock *emitXWholeStore(MachineInstr &MI,
+                                          MachineBasicBlock *BB) {
+  return BB;
+}
+
 MachineBasicBlock *
 RISCVTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
                                                  MachineBasicBlock *BB) const {
@@ -14716,6 +14767,29 @@ RISCVTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
   case RISCV::PseudoFROUND_D_INX:
   case RISCV::PseudoFROUND_D_IN32X:
     return emitFROUND(MI, BB, Subtarget);
+
+#define PseudoXVL_CASE_SEW_LMUL(SEW_val, LMUL_val)                             \
+  case RISCV::PseudoXVL##LMUL_val##RE##SEW_val##_V:                            \
+    return emitXWholeLoad(MI, BB, SEW_val, LMUL_val);
+
+#define PseudoXVL_CASE_SEW(SEW_val)                                            \
+  PseudoXVL_CASE_SEW_LMUL(SEW_val, 1);                                         \
+  PseudoXVL_CASE_SEW_LMUL(SEW_val, 2);                                         \
+  PseudoXVL_CASE_SEW_LMUL(SEW_val, 4);                                         \
+  PseudoXVL_CASE_SEW_LMUL(SEW_val, 8);
+
+  // Emulated whole load instructions for RVV 0.7
+  PseudoXVL_CASE_SEW(8);
+  PseudoXVL_CASE_SEW(16);
+  PseudoXVL_CASE_SEW(32);
+  PseudoXVL_CASE_SEW(64);
+
+  // Emulated whole store instructions for RVV 0.7
+  case RISCV::PseudoXVS1R_V:
+  case RISCV::PseudoXVS2R_V:
+  case RISCV::PseudoXVS4R_V:
+  case RISCV::PseudoXVS8R_V:
+    return emitXWholeStore(MI, BB);
   }
 }
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -445,6 +445,20 @@ multiclass XVPseudoWholeLoadN<bits<3> nf, LMULInfo m, RegisterClass VRC> {
   }
 }
 
+class VPseudoWholeStore<Instruction instr, LMULInfo m, RegisterClass VRC>
+  : VPseudo<instr, m, (outs),   (ins VRC:$vs3, GPRMemZeroOffset:$rs1)> {
+}
+
+multiclass XVPseudoWholeStoreN<bits<3> nf, LMULInfo m, RegisterClass VRC> {
+  foreach l = [8, 16, 32, 64] in {
+    defvar sw = !cast<SchedWrite>("WriteVST" # !add(nf, 1) # "R");
+    defvar sr = !cast<SchedRead>("ReadVST" # !add(nf, 1) # "R");
+
+    def E # l # _V : VPseudoWholeStore<XVSE_V, m, VRC>,
+                     Sched<[sw, sr, ReadVSTX]>;
+  }
+}
+
 let Predicates = [HasVendorXTHeadV] in {
   // Whole register load
   let hasSideEffects = 0, mayLoad = 1, mayStore = 0, isCodeGenOnly = 1, usesCustomInserter = 1 in {
@@ -455,14 +469,10 @@ let Predicates = [HasVendorXTHeadV] in {
   }
   // Whole register store
   let hasSideEffects = 0, mayLoad = 0, mayStore = 1, isCodeGenOnly = 1, usesCustomInserter = 1 in {
-    def PseudoXVS1R_V : VPseudo<XVSE_V, V_M1, (outs), (ins VR:$vs3,  GPRMemZeroOffset:$rs1)>,
-                        Sched<[WriteVST1R, ReadVST1R, ReadVSTX]>;
-    def PseudoXVS2R_V : VPseudo<XVSE_V, V_M2, (outs), (ins VRM2:$vs3, GPRMemZeroOffset:$rs1)>,
-                        Sched<[WriteVST2R, ReadVST2R, ReadVSTX]>;
-    def PseudoXVS4R_V : VPseudo<XVSE_V, V_M4, (outs), (ins VRM4:$vs3, GPRMemZeroOffset:$rs1)>,
-                        Sched<[WriteVST4R, ReadVST4R, ReadVSTX]>;
-    def PseudoXVS8R_V : VPseudo<XVSE_V, V_M8, (outs), (ins VRM8:$vs3, GPRMemZeroOffset:$rs1)>,
-                        Sched<[WriteVST8R, ReadVST8R, ReadVSTX]>;
+    defm PseudoXVS1R : XVPseudoWholeStoreN<0, V_M1, VR>;
+    defm PseudoXVS2R : XVPseudoWholeStoreN<1, V_M2, VRM2>;
+    defm PseudoXVS4R : XVPseudoWholeStoreN<3, V_M4, VRM4>;
+    defm PseudoXVS8R : XVPseudoWholeStoreN<7, V_M8, VRM8>;
   }
 } // Predicates = [HasVendorXTHeadV]
 
@@ -474,7 +484,7 @@ multiclass XVPatUSLoadStoreWholeVRSDNode<ValueType type,
   defvar load_instr =
     !cast<Instruction>("PseudoXVL"#!substr(vlmul.MX, 1)#"RE"#sew#"_V");
   defvar store_instr =
-    !cast<Instruction>("PseudoXVS"#!substr(vlmul.MX, 1)#"R_V");
+    !cast<Instruction>("PseudoXVS"#!substr(vlmul.MX, 1)#"RE"#sew#"_V");
 
   // Load
   def : Pat<(type (load GPR:$rs1)),

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -72,6 +72,15 @@ defset list<VTypeInfo> AllXVectors = {
   }
 }
 
+class GetXVTypePredicates<VTypeInfo vti> {
+  // TODO: distinguish different types (like F16, F32, F64, AnyF)? Is it needed?
+  list<Predicate> Predicates = !cond(!eq(vti.Scalar, f16) : [HasVendorXTHeadV],
+                                     !eq(vti.Scalar, f32) : [HasVendorXTHeadV],
+                                     !eq(vti.Scalar, f64) : [HasVendorXTHeadV],
+                                     !eq(vti.SEW, 64) : [HasVendorXTHeadV],
+                                     true : [HasVendorXTHeadV]);
+}
+
 class XTHeadVVL<bit M, bit ST, bit U, bit E, bits<3> ME, bits<3> S, bits<3> L> {
   bits<1> Masked = M;
   bits<1> Strided = ST;
@@ -418,6 +427,70 @@ let Predicates = [HasVendorXTHeadV] in {
   defm PseudoXVL : XVPseudoSLoad;
   defm PseudoXVS : XVPseudoSStore;
 } // Predicates = [HasVendorXTHeadV]
+
+//===----------------------------------------------------------------------===//
+// 7. Vector Loads and Stores
+// for emulating Vector Load/Store Whole Register Instructions in RVV 1.0
+//===----------------------------------------------------------------------===//
+class VPseudoWholeLoad<Instruction instr, LMULInfo m, RegisterClass VRC>
+  : VPseudo<instr, m, (outs VRC:$vd),   (ins GPRMemZeroOffset:$rs1)> {
+}
+
+multiclass XVPseudoWholeLoadN<bits<3> nf, LMULInfo m, RegisterClass VRC> {
+  foreach l = [8, 16, 32, 64] in {
+    defvar s = !cast<SchedWrite>("WriteVLD" # !add(nf, 1) # "R");
+
+    def E # l # _V : VPseudoWholeLoad<XVLE_V, m, VRC>,
+                     Sched<[s, ReadVLDX]>;
+  }
+}
+
+let Predicates = [HasVendorXTHeadV] in {
+  // Whole register load
+  let hasSideEffects = 0, mayLoad = 1, mayStore = 0, isCodeGenOnly = 1 in {
+    defm PseudoXVL1R : XVPseudoWholeLoadN<0, V_M1, VR>;
+    defm PseudoXVL2R : XVPseudoWholeLoadN<1, V_M2, VRM2>;
+    defm PseudoXVL4R : XVPseudoWholeLoadN<3, V_M4, VRM4>;
+    defm PseudoXVL8R : XVPseudoWholeLoadN<7, V_M8, VRM8>;
+  }
+  // Whole register store
+  let hasSideEffects = 0, mayLoad = 0, mayStore = 1, isCodeGenOnly = 1 in {
+    def PseudoXVS1R_V : VPseudo<XVSB_V, V_M1, (outs), (ins VR:$vs3,  GPRMemZeroOffset:$rs1)>,
+                        Sched<[WriteVST1R, ReadVST1R, ReadVSTX]>;
+    def PseudoXVS2R_V : VPseudo<XVSH_V, V_M2, (outs), (ins VRM2:$vs3, GPRMemZeroOffset:$rs1)>,
+                        Sched<[WriteVST2R, ReadVST2R, ReadVSTX]>;
+    def PseudoXVS4R_V : VPseudo<XVSW_V, V_M4, (outs), (ins VRM4:$vs3, GPRMemZeroOffset:$rs1)>,
+                        Sched<[WriteVST4R, ReadVST4R, ReadVSTX]>;
+    def PseudoXVS8R_V : VPseudo<XVSE_V, V_M8, (outs), (ins VRM8:$vs3, GPRMemZeroOffset:$rs1)>,
+                        Sched<[WriteVST8R, ReadVST8R, ReadVSTX]>;
+  }
+} // Predicates = [HasVendorXTHeadV]
+
+multiclass XVPatUSLoadStoreWholeVRSDNode<ValueType type,
+                                         int log2sew,
+                                         LMULInfo vlmul,
+                                         VReg reg_class,
+                                         int sew = !shl(1, log2sew)> {
+  defvar load_instr =
+    !cast<Instruction>("PseudoXVL"#!substr(vlmul.MX, 1)#"RE"#sew#"_V");
+  defvar store_instr =
+    !cast<Instruction>("PseudoXVS"#!substr(vlmul.MX, 1)#"R_V");
+
+  // Load
+  def : Pat<(type (load GPR:$rs1)),
+            (load_instr GPR:$rs1)>;
+  // Store
+  def : Pat<(store type:$rs2, GPR:$rs1),
+            (store_instr reg_class:$rs2, GPR:$rs1)>;
+}
+foreach vti = [XVI8M1, XVI16M1, XVI32M1, XVI64M1] in
+  let Predicates = GetXVTypePredicates<vti>.Predicates in
+  defm : XVPatUSLoadStoreWholeVRSDNode<vti.Vector, vti.Log2SEW, vti.LMul,
+                                       vti.RegClass>;
+foreach vti = GroupIntegerXVectors in
+  let Predicates = GetXVTypePredicates<vti>.Predicates in
+  defm : XVPatUSLoadStoreWholeVRSDNode<vti.Vector, vti.Log2SEW, vti.LMul,
+                                       vti.RegClass>;
 
 //===----------------------------------------------------------------------===//
 // 8. Vector AMO Operations

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -455,11 +455,11 @@ let Predicates = [HasVendorXTHeadV] in {
   }
   // Whole register store
   let hasSideEffects = 0, mayLoad = 0, mayStore = 1, isCodeGenOnly = 1 in {
-    def PseudoXVS1R_V : VPseudo<XVSB_V, V_M1, (outs), (ins VR:$vs3,  GPRMemZeroOffset:$rs1)>,
+    def PseudoXVS1R_V : VPseudo<XVSE_V, V_M1, (outs), (ins VR:$vs3,  GPRMemZeroOffset:$rs1)>,
                         Sched<[WriteVST1R, ReadVST1R, ReadVSTX]>;
-    def PseudoXVS2R_V : VPseudo<XVSH_V, V_M2, (outs), (ins VRM2:$vs3, GPRMemZeroOffset:$rs1)>,
+    def PseudoXVS2R_V : VPseudo<XVSE_V, V_M2, (outs), (ins VRM2:$vs3, GPRMemZeroOffset:$rs1)>,
                         Sched<[WriteVST2R, ReadVST2R, ReadVSTX]>;
-    def PseudoXVS4R_V : VPseudo<XVSW_V, V_M4, (outs), (ins VRM4:$vs3, GPRMemZeroOffset:$rs1)>,
+    def PseudoXVS4R_V : VPseudo<XVSE_V, V_M4, (outs), (ins VRM4:$vs3, GPRMemZeroOffset:$rs1)>,
                         Sched<[WriteVST4R, ReadVST4R, ReadVSTX]>;
     def PseudoXVS8R_V : VPseudo<XVSE_V, V_M8, (outs), (ins VRM8:$vs3, GPRMemZeroOffset:$rs1)>,
                         Sched<[WriteVST8R, ReadVST8R, ReadVSTX]>;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -447,14 +447,14 @@ multiclass XVPseudoWholeLoadN<bits<3> nf, LMULInfo m, RegisterClass VRC> {
 
 let Predicates = [HasVendorXTHeadV] in {
   // Whole register load
-  let hasSideEffects = 0, mayLoad = 1, mayStore = 0, isCodeGenOnly = 1 in {
+  let hasSideEffects = 0, mayLoad = 1, mayStore = 0, isCodeGenOnly = 1, usesCustomInserter = 1 in {
     defm PseudoXVL1R : XVPseudoWholeLoadN<0, V_M1, VR>;
     defm PseudoXVL2R : XVPseudoWholeLoadN<1, V_M2, VRM2>;
     defm PseudoXVL4R : XVPseudoWholeLoadN<3, V_M4, VRM4>;
     defm PseudoXVL8R : XVPseudoWholeLoadN<7, V_M8, VRM8>;
   }
   // Whole register store
-  let hasSideEffects = 0, mayLoad = 0, mayStore = 1, isCodeGenOnly = 1 in {
+  let hasSideEffects = 0, mayLoad = 0, mayStore = 1, isCodeGenOnly = 1, usesCustomInserter = 1 in {
     def PseudoXVS1R_V : VPseudo<XVSE_V, V_M1, (outs), (ins VR:$vs3,  GPRMemZeroOffset:$rs1)>,
                         Sched<[WriteVST1R, ReadVST1R, ReadVSTX]>;
     def PseudoXVS2R_V : VPseudo<XVSE_V, V_M2, (outs), (ins VRM2:$vs3, GPRMemZeroOffset:$rs1)>,

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -165,20 +165,40 @@ public:
   bool hasMacroFusion() const { return hasLUIADDIFusion(); }
 
   // Vector codegen related methods.
+  // If a SubTarget has either standard V or XTHeadV:
   bool hasVInstructions() const {
-    return HasStdExtZve32x || HasVendorXTHeadV;
+    return hasOnlyStdV() || hasVendorXTHeadV();
   }
   bool hasVInstructionsI64() const {
-    return HasStdExtZve64x || HasVendorXTHeadV;
+    return hasOnlyStdVI64() || hasVendorXTHeadV();
   }
-  bool hasVInstructionsF16() const { return HasStdExtZvfh; }
+  bool hasVInstructionsF16() const { return hasOnlyStdVF16(); }
+  bool hasVInstructionsF32() const { return hasOnlyStdVF32(); }
+  bool hasVInstructionsF64() const { return hasOnlyStdVF64(); }
+  bool hasVInstructionsAnyF() const { return hasOnlyStdVAnyF(); }
+  bool hasVInstructionsFullMultiply() const { return hasOnlyStdV() || hasVendorXTHeadV(); }
+  //  If a SubTarget only has the standard V extension:
+  bool hasOnlyStdV() const {
+    return HasStdExtZve32x;
+  }
+  bool hasOnlyStdVI64() const {
+    return HasStdExtZve64x;
+  }
+  bool hasOnlyStdVF16() const { return HasStdExtZvfh; }
   // FIXME: Consider Zfinx in the future
-  bool hasVInstructionsF32() const { return HasStdExtZve32f && HasStdExtF; }
+  bool hasOnlyStdVF32() const { return HasStdExtZve32f && HasStdExtF; }
   // FIXME: Consider Zdinx in the future
-  bool hasVInstructionsF64() const { return HasStdExtZve64d && HasStdExtD; }
+  bool hasOnlyStdVF64() const { return HasStdExtZve64d && HasStdExtD; }
   // F16 and F64 both require F32.
-  bool hasVInstructionsAnyF() const { return hasVInstructionsF32(); }
-  bool hasVInstructionsFullMultiply() const { return HasStdExtV; }
+  bool hasOnlyStdVAnyF() const { return hasOnlyStdVF32(); }
+  bool hasOnlyStdVFullMultiply() const { return HasStdExtV; }
+  // XTHeadV codegen related methods.
+  bool hasStdVOrXTHeadV() const {
+    return hasVInstructions() || hasVendorXTHeadV();
+  }
+  bool hasStdVOrXTHeadVI64() const {
+    return hasVInstructionsI64() || hasVendorXTHeadV();
+  }
   unsigned getMaxInterleaveFactor() const {
     return hasVInstructions() ? MaxInterleaveFactor : 1;
   }

--- a/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-16.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-16.ll
@@ -1,0 +1,48 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 4 x i16> @llvm.riscv.xvadd.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>,
+  iXLen);
+
+define void @vadd_vint16m1(<vscale x 4 x i16> *%pc, <vscale x 4 x i16> *%pa, <vscale x 4 x i16> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint16m1:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e16, m1, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e16, m1, d1
+; CHECK-NEXT:    vle.v	v9, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e16, m1, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v9
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e16, m1, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 4 x i16>, <vscale x 4 x i16>* %pa
+  %vb = load <vscale x 4 x i16>, <vscale x 4 x i16>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 4 x i16> %va, %vb
+  %vc = call <vscale x 4 x i16> @llvm.riscv.xvadd.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16> %va,
+    <vscale x 4 x i16> %vb,
+    iXLen %vl)
+  store <vscale x 4 x i16> %vc, <vscale x 4 x i16> *%pc
+  ret void
+}

--- a/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-32.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-32.ll
@@ -1,0 +1,48 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 2 x i32> @llvm.riscv.xvadd.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define void @vadd_vint32m1(<vscale x 2 x i32> *%pc, <vscale x 2 x i32> *%pa, <vscale x 2 x i32> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint32m1:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e32, m1, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e32, m1, d1
+; CHECK-NEXT:    vle.v	v9, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e32, m1, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v9
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e32, m1, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 2 x i32>, <vscale x 2 x i32>* %pa
+  %vb = load <vscale x 2 x i32>, <vscale x 2 x i32>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 2 x i32> %va, %vb
+  %vc = call <vscale x 2 x i32> @llvm.riscv.xvadd.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32> %va,
+    <vscale x 2 x i32> %vb,
+    iXLen %vl)
+  store <vscale x 2 x i32> %vc, <vscale x 2 x i32> *%pc
+  ret void
+}

--- a/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-64.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-64.ll
@@ -1,0 +1,48 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 1 x i64> @llvm.riscv.xvadd.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>,
+  iXLen);
+
+define void @vadd_vint64m1(<vscale x 1 x i64> *%pc, <vscale x 1 x i64> *%pa, <vscale x 1 x i64> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint64m1:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e64, m1, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e64, m1, d1
+; CHECK-NEXT:    vle.v	v9, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e64, m1, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v9
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e64, m1, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 1 x i64>, <vscale x 1 x i64>* %pa
+  %vb = load <vscale x 1 x i64>, <vscale x 1 x i64>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 1 x i64> %va, %vb
+  %vc = call <vscale x 1 x i64> @llvm.riscv.xvadd.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64> %va,
+    <vscale x 1 x i64> %vb,
+    iXLen %vl)
+  store <vscale x 1 x i64> %vc, <vscale x 1 x i64> *%pc
+  ret void
+}

--- a/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-8.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-8.ll
@@ -1,0 +1,55 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 8 x i8> @llvm.riscv.xvadd.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>,
+  iXLen);
+
+declare <vscale x 16 x i8> @llvm.riscv.xvadd.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>,
+  iXLen);
+
+define void @vadd_vint8m1(<vscale x 8 x i8> *%pc, <vscale x 8 x i8> *%pa, <vscale x 8 x i8> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint8m1:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e8, m1, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e8, m1, d1
+; CHECK-NEXT:    vle.v	v9, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e8, m1, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v9
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e8, m1, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 8 x i8>, <vscale x 8 x i8>* %pa
+  %vb = load <vscale x 8 x i8>, <vscale x 8 x i8>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 8 x i8> %va, %vb
+  %vc = call <vscale x 8 x i8> @llvm.riscv.xvadd.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8> %va,
+    <vscale x 8 x i8> %vb,
+    iXLen %vl)
+  store <vscale x 8 x i8> %vc, <vscale x 8 x i8> *%pc
+  ret void
+}
+


### PR DESCRIPTION
This PR emulated vector register whole load/store instructions for RVV 0.7.1. After merging this PR, related code generation should work as expected: [Demo here](https://github.com/ruyisdk/llvm-project/pull/23#issuecomment-1816095955). This may also fix the vamo tests.

## Known bugs
- `XVLE_V` and `XVSE_V` only return or accept `VR` register group, but for cases where LMUL is 2, 4, and 8, they should also return/accept `VRM2`, `VRM4` and `VRM8`. This will be addressed in future PRs.