### PR TITLE
[LLVM] [RVV 0.7.1] Implement RVV 0.7.1 strided load/store intrinsics.

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
@@ -108,6 +108,71 @@ let TargetPrefix = "riscv" in {
   def int_riscv_xvsh_mask : XVUSStoreMasked;
   def int_riscv_xvsw_mask : XVUSStoreMasked;
   def int_riscv_xvse_mask : XVUSStoreMasked;
+
+  // 7.5 Vector Strided Instructions
+  // For strided load with passthru operand
+  // Input: (maskedoff, pointer, strided, vl)
+  class XVSLoad
+    : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
+                [LLVMMatchType<0>, llvm_ptr_ty,
+                 llvm_anyint_ty, LLVMMatchType<1>],
+                [NoCapture<ArgIndex<1>>, IntrReadMem]>, RISCVVIntrinsic {
+    let VLOperand = 3;
+  }
+
+  // For strided load with mask
+  // Input: (maskedoff, pointer, stride, mask, vl)
+  class XVSLoadMasked
+    : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
+                [LLVMMatchType<0>, llvm_ptr_ty, llvm_anyint_ty,
+                 LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>, LLVMMatchType<1>],
+                [NoCapture<ArgIndex<1>>, IntrReadMem]>,
+                RISCVVIntrinsic {
+    let VLOperand = 4;
+  }
+
+  // For strided store
+  // Input: (vector_in, pointer, stride, vl)
+  class XVSStore
+        : DefaultAttrsIntrinsic<[],
+                    [llvm_anyvector_ty, llvm_ptr_ty,
+                     llvm_anyint_ty, LLVMMatchType<1>],
+                    [NoCapture<ArgIndex<1>>, IntrWriteMem]>, RISCVVIntrinsic {
+    let VLOperand = 3;
+  }
+  // For stride store with mask
+  // Input: (vector_in, pointer, stirde, mask, vl)
+  class XVSStoreMasked
+        : DefaultAttrsIntrinsic<[],
+                    [llvm_anyvector_ty, llvm_ptr_ty, llvm_anyint_ty,
+                     LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>, LLVMMatchType<1>],
+                    [NoCapture<ArgIndex<1>>, IntrWriteMem]>, RISCVVIntrinsic {
+    let VLOperand = 4;
+  }
+
+  def int_riscv_xvlsb : XVSLoad;
+  def int_riscv_xvlsh : XVSLoad;
+  def int_riscv_xvlsw : XVSLoad;
+  def int_riscv_xvlse : XVSLoad;
+  def int_riscv_xvlsbu : XVSLoad;
+  def int_riscv_xvlshu : XVSLoad;
+  def int_riscv_xvlswu : XVSLoad;
+  def int_riscv_xvlsb_mask : XVSLoadMasked;
+  def int_riscv_xvlsh_mask : XVSLoadMasked;
+  def int_riscv_xvlsw_mask : XVSLoadMasked;
+  def int_riscv_xvlse_mask : XVSLoadMasked;
+  def int_riscv_xvlsbu_mask : XVSLoadMasked;
+  def int_riscv_xvlshu_mask : XVSLoadMasked;
+  def int_riscv_xvlswu_mask : XVSLoadMasked;
+
+  def int_riscv_xvssb : XVSStore;
+  def int_riscv_xvssh : XVSStore;
+  def int_riscv_xvssw : XVSStore;
+  def int_riscv_xvsse : XVSStore;
+  def int_riscv_xvssb_mask : XVSStoreMasked;
+  def int_riscv_xvssh_mask : XVSStoreMasked;
+  def int_riscv_xvssw_mask : XVSStoreMasked;
+  def int_riscv_xvsse_mask : XVSStoreMasked;
 } // TargetPrefix = "riscv"
 
 // let TargetPrefix = "riscv" in {

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
@@ -149,12 +149,13 @@ public:
                                   bool IsLoad = false, MVT *IndexVT = nullptr);
   void addXTHeadVLoadStoreOperands(SDNode *Node, unsigned SEWImm,
                                   const SDLoc &DL, unsigned CurOp,
-                                  bool IsMasked, SmallVectorImpl<SDValue> &Operands);
+                                  bool IsMasked, bool IsStrided,
+                                  SmallVectorImpl<SDValue> &Operands);
 
   void selectXVL(SDNode *Node, const SDLoc& DL, unsigned IntNo,
-                 bool IsUnsigned, bool IsMasked, bool IsE);
+                 bool IsUnsigned, bool IsMasked, bool IsStrided, bool IsE);
   void selectXVS(SDNode *Node, const SDLoc& DL, unsigned IntNo,
-                 bool IsMasked, bool IsE);
+                 bool IsMasked, bool IsStrided, bool IsE);
   void selectVLSEG(SDNode *Node, bool IsMasked, bool IsStrided);
   void selectVLSEGFF(SDNode *Node, bool IsMasked);
   void selectVLXSEG(SDNode *Node, bool IsMasked, bool IsOrdered);
@@ -248,6 +249,7 @@ struct VLEPseudo {
 
 struct XVLPseudo {
   uint16_t Masked : 1;
+  uint16_t Strided : 1;
   uint16_t Unsigned : 1;
   uint16_t IsE : 1;
   uint16_t Log2MEM : 3;
@@ -266,6 +268,7 @@ struct VSEPseudo {
 
 struct XVSPseudo {
   uint16_t Masked : 1;
+  uint16_t Strided : 1;
   uint16_t IsE : 1;
   uint16_t Log2MEM : 3;
   uint16_t Log2SEW : 3;

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -1368,12 +1368,44 @@ bool RISCVTargetLowering::getTgtMemIntrinsic(IntrinsicInfo &Info,
     return SetRVVLoadStoreInfo(/*PtrOp*/ 1,
                                /*IsStore*/ false,
                                /*IsUnitStrided*/ false);
+  case Intrinsic::riscv_xvlsb:
+  case Intrinsic::riscv_xvlsbu:
+  case Intrinsic::riscv_xvlsb_mask:
+  case Intrinsic::riscv_xvlsbu_mask:
+  case Intrinsic::riscv_xvlsh:
+  case Intrinsic::riscv_xvlshu:
+  case Intrinsic::riscv_xvlsh_mask:
+  case Intrinsic::riscv_xvlshu_mask:
+  case Intrinsic::riscv_xvlsw:
+  case Intrinsic::riscv_xvlswu:
+  case Intrinsic::riscv_xvlsw_mask:
+  case Intrinsic::riscv_xvlswu_mask:
+  case Intrinsic::riscv_xvlse:
+  case Intrinsic::riscv_xvlse_mask:
+    if (!Subtarget.hasVendorXTHeadV())
+      return false;
+    return SetRVVLoadStoreInfo(/*PtrOp*/ 1,
+                               /*IsStore*/ false,
+                               /*IsUnitStrided*/ false);
   case Intrinsic::riscv_vsse:
   case Intrinsic::riscv_vsse_mask:
   case Intrinsic::riscv_vsoxei:
   case Intrinsic::riscv_vsoxei_mask:
   case Intrinsic::riscv_vsuxei:
   case Intrinsic::riscv_vsuxei_mask:
+    return SetRVVLoadStoreInfo(/*PtrOp*/ 1,
+                               /*IsStore*/ true,
+                               /*IsUnitStrided*/ false);
+  case Intrinsic::riscv_xvssb:
+  case Intrinsic::riscv_xvssb_mask:
+  case Intrinsic::riscv_xvssh:
+  case Intrinsic::riscv_xvssh_mask:
+  case Intrinsic::riscv_xvssw:
+  case Intrinsic::riscv_xvssw_mask:
+  case Intrinsic::riscv_xvsse:
+  case Intrinsic::riscv_xvsse_mask:
+    if (!Subtarget.hasVendorXTHeadV())
+      return false;
     return SetRVVLoadStoreInfo(/*PtrOp*/ 1,
                                /*IsStore*/ true,
                                /*IsUnitStrided*/ false);

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -72,8 +72,9 @@ defset list<VTypeInfo> AllXVectors = {
   }
 }
 
-class XTHeadVVL<bit M, bit U, bit E, bits<3> ME, bits<3> S, bits<3> L> {
+class XTHeadVVL<bit M, bit ST, bit U, bit E, bits<3> ME, bits<3> S, bits<3> L> {
   bits<1> Masked = M;
+  bits<1> Strided = ST;
   bits<1> Unsigned = U;
   bits<1> IsE = E;
   bits<3> Log2MEM = ME;
@@ -85,13 +86,14 @@ class XTHeadVVL<bit M, bit U, bit E, bits<3> ME, bits<3> S, bits<3> L> {
 def XTHeadVVLTable : GenericTable {
   let FilterClass = "XTHeadVVL";
   let CppTypeName = "XVLPseudo";
-  let Fields = ["Masked", "Unsigned", "IsE", "Log2MEM", "Log2SEW", "LMUL", "Pseudo"];
-  let PrimaryKey = ["Masked", "Unsigned", "IsE", "Log2MEM", "Log2SEW", "LMUL"];
+  let Fields = ["Masked", "Strided", "Unsigned", "IsE", "Log2MEM", "Log2SEW", "LMUL", "Pseudo"];
+  let PrimaryKey = ["Masked", "Strided", "Unsigned", "IsE", "Log2MEM", "Log2SEW", "LMUL"];
   let PrimaryKeyName = "getXVLPseudo";
 }
 
-class XTHeadVVS<bit M, bit E, bits<3> ME, bits<3> S, bits<3> L> {
+class XTHeadVVS<bit M, bit ST, bit E, bits<3> ME, bits<3> S, bits<3> L> {
   bits<1> Masked = M;
+  bits<1> Strided = ST;
   bits<1> IsE = E;
   bits<3> Log2MEM = ME;
   bits<3> Log2SEW = S;
@@ -102,8 +104,8 @@ class XTHeadVVS<bit M, bit E, bits<3> ME, bits<3> S, bits<3> L> {
 def XTHeadVVSTable : GenericTable {
   let FilterClass = "XTHeadVVS";
   let CppTypeName = "XVSPseudo";
-  let Fields = ["Masked", "IsE", "Log2MEM", "Log2SEW", "LMUL", "Pseudo"];
-  let PrimaryKey = ["Masked", "IsE", "Log2MEM", "Log2SEW", "LMUL"];
+  let Fields = ["Masked", "Strided", "IsE", "Log2MEM", "Log2SEW", "LMUL", "Pseudo"];
+  let PrimaryKey = ["Masked", "Strided", "IsE", "Log2MEM", "Log2SEW", "LMUL"];
   let PrimaryKeyName = "getXVSPseudo";
 }
 
@@ -141,7 +143,7 @@ class XVPseudoUSLoadNoMask<VReg RetClass, int MEM, int REG, bit unsigned, bit e>
       Pseudo<(outs RetClass:$rd),
              (ins RetClass:$dest, GPRMem:$rs1, AVL:$vl, ixlenimm:$sew),[]>,
       RISCVVPseudo,
-      XTHeadVVL</*Masked*/0, unsigned, e,
+      XTHeadVVL</*Masked*/0, /*Strided*/0, unsigned, e,
                 !logtwo(MEM), !logtwo(REG), VLMul> {
   let mayLoad = 1;
   let mayStore = 0;
@@ -157,7 +159,7 @@ class XVPseudoUSLoadMask<VReg RetClass, int MEM, int REG, bit unsigned, bit e> :
                    GPRMem:$rs1,
                    VMaskOp:$vm, AVL:$vl, ixlenimm:$sew),[]>,
       RISCVVPseudo,
-      XTHeadVVL</*Masked*/1, unsigned, e,
+      XTHeadVVL</*Masked*/1, /*Strided*/0, unsigned, e,
                 !logtwo(MEM), !logtwo(REG), VLMul> {
   let mayLoad = 1;
   let mayStore = 0;
@@ -171,7 +173,7 @@ class XVPseudoUSStoreNoMask<VReg StClass, int MEM, int REG, bit e>:
       Pseudo<(outs),
               (ins StClass:$rd, GPRMem:$rs1, AVL:$vl, ixlenimm:$sew),[]>,
       RISCVVPseudo,
-      XTHeadVVS</*Masked*/0, e, !logtwo(MEM), !logtwo(REG), VLMul> {
+      XTHeadVVS</*Masked*/0, /*Strided*/0, e, !logtwo(MEM), !logtwo(REG), VLMul> {
   let mayLoad = 0;
   let mayStore = 1;
   let hasSideEffects = 0;
@@ -183,7 +185,7 @@ class XVPseudoUSStoreMask<VReg StClass, int MEM, int REG, int e>:
       Pseudo<(outs),
               (ins StClass:$rd, GPRMem:$rs1, VMaskOp:$vm, AVL:$vl, ixlenimm:$sew),[]>,
       RISCVVPseudo,
-      XTHeadVVS</*Masked*/1, e, !logtwo(MEM), !logtwo(REG), VLMul> {
+      XTHeadVVS</*Masked*/1, /*Strided*/0, e, !logtwo(MEM), !logtwo(REG), VLMul> {
   let mayLoad = 0;
   let mayStore = 1;
   let hasSideEffects = 0;
@@ -275,9 +277,146 @@ multiclass XVPseudoUSStore {
   }
 }
 
+// 7.5 Vector Strided Instructions
+class XVPseudoSLoadNoMask<VReg RetClass, int MEM, int REG, bit unsigned, bit e>:
+      Pseudo<(outs RetClass:$rd),
+             (ins RetClass:$dest, GPRMem:$rs1, GPR:$rs2, AVL:$vl,
+                  ixlenimm:$sew),[]>,
+      RISCVVPseudo,
+      XTHeadVVL</*Masked*/0, /*Strided*/1, unsigned, e,
+                !logtwo(MEM), !logtwo(REG), VLMul> {
+  let mayLoad = 1;
+  let mayStore = 0;
+  let hasSideEffects = 0;
+  let HasVLOp = 1;
+  let HasSEWOp = 1;
+  let Constraints = "$rd = $dest";
+}
+
+class XVPseudoSLoadMask<VReg RetClass, int MEM, int REG, bit unsigned, bit e>:
+      Pseudo<(outs GetVRegNoV0<RetClass>.R:$rd),
+              (ins GetVRegNoV0<RetClass>.R:$merge,
+                   GPRMem:$rs1, GPR:$rs2,
+                   VMaskOp:$vm, AVL:$vl, ixlenimm:$sew),[]>,
+      RISCVVPseudo,
+      XTHeadVVL</*Masked*/1, /*Strided*/1, unsigned, e,
+                !logtwo(MEM), !logtwo(REG), VLMul> {
+  let mayLoad = 1;
+  let mayStore = 0;
+  let hasSideEffects = 0;
+  let Constraints = "$rd = $merge";
+  let HasVLOp = 1;
+  let HasSEWOp = 1;
+}
+
+class XVPseudoSStoreNoMask<VReg StClass, int MEM, int REG, bit e>:
+      Pseudo<(outs),
+              (ins StClass:$rd, GPRMem:$rs1, GPR:$rs2, AVL:$vl, ixlenimm:$sew),[]>,
+      RISCVVPseudo,
+      XTHeadVVS</*Masked*/0, /*Strided*/1, e, !logtwo(MEM), !logtwo(REG), VLMul> {
+  let mayLoad = 0;
+  let mayStore = 1;
+  let hasSideEffects = 0;
+  let HasVLOp = 1;
+  let HasSEWOp = 1;
+}
+
+class XVPseudoSStoreMask<VReg StClass, int MEM, int REG, int e>:
+      Pseudo<(outs),
+              (ins StClass:$rd, GPRMem:$rs1, GPR:$rs2, VMaskOp:$vm, AVL:$vl, ixlenimm:$sew),[]>,
+      RISCVVPseudo,
+      XTHeadVVS</*Masked*/1, /*Strided*/1, e, !logtwo(MEM), !logtwo(REG), VLMul> {
+  let mayLoad = 0;
+  let mayStore = 1;
+  let hasSideEffects = 0;
+  let HasVLOp = 1;
+  let HasSEWOp = 1;
+}
+
+multiclass XVPseudoSLoad {
+  foreach mem = [8, 16, 32] in {
+    foreach lmul = [V_M1, V_M2, V_M4, V_M8] in {
+      defvar LInfo = lmul.MX;
+      defvar vreg = lmul.vrclass;
+      defvar tag = MemBitsToTag<mem>.ret;
+      foreach reg = EEWList in {
+        if !ge(reg, mem) then {
+          let VLMul = lmul.value, SEW = mem in {
+            def "S" # tag # "_V_E" # reg # "_" # LInfo :
+              XVPseudoSLoadNoMask<vreg, mem, reg, 0, 0>,
+              VLESched<LInfo>;
+            def "S" # tag # "U_V_E" # reg # "_" # LInfo :
+              XVPseudoSLoadNoMask<vreg, mem, reg, 1, 0>,
+              VLESched<LInfo>;
+            def "S" # tag # "_V_E" # reg # "_" # LInfo # "_MASK" :
+              XVPseudoSLoadMask<vreg, mem, reg, 0, 0>,
+              RISCVMaskedPseudo<MaskIdx=3>,
+              VLESched<LInfo>;
+            def "S" # tag # "U_V_E" # reg # "_" # LInfo # "_MASK" :
+              XVPseudoSLoadMask<vreg, mem, reg, 1, 0>,
+              RISCVMaskedPseudo<MaskIdx=3>,
+              VLESched<LInfo>;
+          }
+        }
+      }
+    }
+  }
+  foreach eew = EEWList in {
+    foreach lmul = [V_M1, V_M2, V_M4, V_M8] in {
+      defvar LInfo = lmul.MX;
+      defvar vreg = lmul.vrclass;
+      let VLMul = lmul.value, SEW = eew in {
+        def "SE_V_E" # eew # "_" # LInfo :
+          XVPseudoSLoadNoMask<vreg, eew, eew, 0, 1>,
+          VLESched<LInfo>;
+        def "SE_V_E" # eew # "_" # LInfo # "_MASK" :
+          XVPseudoSLoadMask<vreg, eew, eew, 0, 1>,
+          RISCVMaskedPseudo<MaskIdx=3>,
+          VLESched<LInfo>;
+      }
+    }
+  }
+}
+
+multiclass XVPseudoSStore {
+  foreach mem = [8, 16, 32] in {
+    foreach lmul = [V_M1, V_M2, V_M4, V_M8] in {
+      defvar LInfo = lmul.MX;
+      defvar vreg = lmul.vrclass;
+      defvar tag = MemBitsToTag<mem>.ret;
+      foreach sew = EEWList in {
+        let VLMul = lmul.value, SEW = mem in {
+          def "S" # tag # "_V_E" # sew # "_" # LInfo :
+            XVPseudoSStoreNoMask<vreg, mem, sew, 0>,
+            VSESched<LInfo>;
+          def "S" # tag # "_V_E" # sew # "_" # LInfo # "_MASK" :
+            XVPseudoSStoreMask<vreg, mem, sew, 0>,
+            VSESched<LInfo>;
+        }
+      }
+    }
+  }
+  foreach eew = EEWList in {
+    foreach lmul = [V_M1, V_M2, V_M4, V_M8] in {
+      defvar LInfo = lmul.MX;
+      defvar vreg = lmul.vrclass;
+      let VLMul = lmul.value, SEW = eew in {
+        def "SE_V_E" # eew # "_" # LInfo :
+          XVPseudoSStoreNoMask<vreg, eew, eew, 1>,
+          VSESched<LInfo>;
+        def "SE_V_E" # eew # "_" # LInfo # "_MASK" :
+          XVPseudoSStoreMask<vreg, eew, eew, 1>,
+          VSESched<LInfo>;
+      }
+    }
+  }
+}
+
 let Predicates = [HasVendorXTHeadV] in {
   defm PseudoXVL : XVPseudoUSLoad;
   defm PseudoXVS : XVPseudoUSStore;
+  defm PseudoXVL : XVPseudoSLoad;
+  defm PseudoXVS : XVPseudoSStore;
 } // Predicates = [HasVendorXTHeadV]
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vls.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vls.ll
@@ -1,0 +1,2500 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlsb.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlsb_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m1, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlsb.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlsb.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlsb_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m1, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlsb.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlsb.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlsb_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m2, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlsb.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlsb.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlsb_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m2, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlsb.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlsb.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlsb_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m4, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlsb.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlsb.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlsb_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, iXLen %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m4, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlsb.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    iXLen %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlsb.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlsb_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m8, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlsb.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlsb.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlsb_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, iXLen %2, <vscale x 64 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m8, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlsb.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    iXLen %2,
+    <vscale x 64 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlsb.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlsb_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlsb.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlsb.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlsb_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlsb.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlsb.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlsb_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlsb.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlsb.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlsb_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlsb.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlsb.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlsb_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlsb.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlsb.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlsb_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlsb.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlsb.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlsb_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlsb.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlsb.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlsb_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, iXLen %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlsb.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    iXLen %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlsb.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlsb_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlsb.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlsb.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlsb_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlsb.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlsb.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlsb_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlsb.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlsb.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlsb_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlsb.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlsb.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlsb_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlsb.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlsb.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlsb_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlsb.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlsb.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlsb_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlsb.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlsb.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlsb_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlsb.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlsb.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlsb_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlsb.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlsb.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlsb_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, iXLen %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlsb.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlsb.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlsb_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlsb.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlsb.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlsb_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlsb.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlsb.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlsb_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlsb.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlsb.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlsb_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlsb.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlsb.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlsb_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlsb.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlsb.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlsb_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsb_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlsb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlsb.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlsh.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlsh_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlsh.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlsh.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlsh_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlsh.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlsh.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlsh_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlsh.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlsh.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlsh_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlsh.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlsh.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlsh_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlsh.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlsh.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlsh_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlsh.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlsh.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlsh_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlsh.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlsh.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlsh_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, iXLen %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlsh.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    iXLen %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlsh.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlsh_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlsh.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlsh.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlsh_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlsh.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlsh.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlsh_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlsh.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlsh.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlsh_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlsh.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlsh.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlsh_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlsh.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlsh.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlsh_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlsh.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlsh.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlsh_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlsh.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlsh.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlsh_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlsh.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlsh.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlsh_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlsh.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlsh.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlsh_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, iXLen %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlsh.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlsh.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlsh_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlsh.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlsh.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlsh_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlsh.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlsh.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlsh_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlsh.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlsh.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlsh_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlsh.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlsh.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlsh_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlsh.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlsh.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlsh_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsh_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlsh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlsh.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlsw.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlsw_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlsw.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlsw.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlsw_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlsw.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlsw.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlsw_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlsw.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlsw.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlsw_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlsw.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlsw.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlsw_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlsw.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlsw.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlsw_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlsw.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlsw.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlsw_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlsw.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlsw.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlsw_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlsw.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlsw.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlsw_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlsw.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlsw.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlsw_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, iXLen %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlsw.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlsw.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlsw_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlsw.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlsw.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlsw_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlsw.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlsw.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlsw_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlsw.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlsw.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlsw_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlsw.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlsw.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlsw_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlsw.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlsw.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlsw_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsw_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlsw.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlsw.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlse.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlse_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m1, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlse.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlse.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlse_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m1, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlse.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlse.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlse_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m2, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlse.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlse.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlse_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m2, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlse.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlse.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlse_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m4, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlse.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlse.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlse_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, iXLen %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m4, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlse.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    iXLen %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlse.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlse_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m8, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlse.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlse.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlse_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, iXLen %2, <vscale x 64 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m8, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlse.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    iXLen %2,
+    <vscale x 64 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlse.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlse_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlse.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlse.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlse_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlse.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlse.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlse_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlse.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlse.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlse_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlse.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlse.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlse_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlse.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlse.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlse_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlse.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlse.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlse_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlse.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlse.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlse_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, iXLen %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlse.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    iXLen %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlse.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlse_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlse.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlse.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlse_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlse.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlse.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlse_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlse.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlse.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlse_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlse.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlse.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlse_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlse.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlse.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlse_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlse.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlse.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlse_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlse.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlse.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlse_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlse.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlse.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlse_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlse.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlse.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlse_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, iXLen %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlse.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlse.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlse_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlse.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlse.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlse_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlse.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlse.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlse_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlse.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlse.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlse_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlse.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlse.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlse_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlse.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlse.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlse_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlse.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vlsu.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vlsu.ll
@@ -1,0 +1,1733 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlsbu.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlsbu_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m1, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlsbu.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlsbu.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlsbu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m1, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlsbu.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlsbu.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlsbu_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m2, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlsbu.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlsbu.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlsbu_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m2, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlsbu.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlsbu.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlsbu_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m4, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlsbu.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlsbu.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlsbu_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, iXLen %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m4, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlsbu.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    iXLen %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlsbu.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlsbu_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m8, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlsbu.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlsbu.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlsbu_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, iXLen %2, <vscale x 64 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m8, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlsbu.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    iXLen %2,
+    <vscale x 64 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlsbu.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlsbu_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlsbu.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlsbu.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlsbu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlsbu.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlsbu.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlsbu_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlsbu.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlsbu.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlsbu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlsbu.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlsbu.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlsbu_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlsbu.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlsbu.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlsbu_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlsbu.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlsbu.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlsbu_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlsbu.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlsbu.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlsbu_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, iXLen %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlsbu.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    iXLen %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlsbu.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlsbu_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlsbu.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlsbu.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlsbu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlsbu.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlsbu.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlsbu_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlsbu.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlsbu.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlsbu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlsbu.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlsbu.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlsbu_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlsbu.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlsbu.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlsbu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlsbu.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlsbu.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlsbu_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlsbu.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlsbu.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlsbu_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlsbu.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlsbu.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlsbu_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlsbu.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlsbu.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlsbu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, iXLen %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlsbu.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlsbu.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlsbu_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlsbu.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlsbu.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlsbu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlsbu.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlsbu.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlsbu_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlsbu.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlsbu.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlsbu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlsbu.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlsbu.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlsbu_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlsbu.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlsbu.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlsbu_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlsbu_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlsbu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlsbu.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlshu.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlshu_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlshu.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlshu.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlshu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlshu.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlshu.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlshu_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlshu.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlshu.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlshu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlshu.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlshu.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlshu_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlshu.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlshu.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlshu_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlshu.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlshu.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlshu_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlshu.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlshu.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlshu_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, iXLen %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlshu.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    iXLen %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlshu.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlshu_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlshu.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlshu.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlshu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlshu.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlshu.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlshu_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlshu.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlshu.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlshu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlshu.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlshu.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlshu_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlshu.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlshu.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlshu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlshu.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlshu.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlshu_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlshu.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlshu.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlshu_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlshu.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlshu.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlshu_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlshu.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlshu.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlshu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, iXLen %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlshu.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlshu.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlshu_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlshu.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlshu.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlshu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlshu.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlshu.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlshu_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlshu.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlshu.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlshu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlshu.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlshu.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlshu_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlshu.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlshu.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlshu_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlshu_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlshu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlshu.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlswu.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlswu_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlswu.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlswu.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlswu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlswu.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlswu.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlswu_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlswu.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlswu.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlswu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlswu.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlswu.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlswu_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlswu.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlswu.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlswu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlswu.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlswu.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlswu_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlswu.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlswu.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlswu_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlswu.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlswu.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlswu_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlswu.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlswu.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i64> @intrinsic_xvlswu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, iXLen %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlswu.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlswu.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlswu_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlswu.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlswu.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i64> @intrinsic_xvlswu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlswu.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlswu.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlswu_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlswu.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlswu.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i64> @intrinsic_xvlswu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlswu.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlswu.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlswu_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlswu.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlswu.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i64> @intrinsic_xvlswu_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlswu_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlswu.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlswu.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i64> %a
+}
+

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vss.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vss.ll
@@ -1,0 +1,1349 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare void @llvm.riscv.xvssb.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvssb_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvssb_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m1, d1
+; CHECK-NEXT:    vssb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssb.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssb.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvssb_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvssb_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m1, d1
+; CHECK-NEXT:    vssb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssb.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssb.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvssb_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvssb_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m2, d1
+; CHECK-NEXT:    vssb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssb.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssb.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvssb_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvssb_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m2, d1
+; CHECK-NEXT:    vssb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssb.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    iXLen %2, 
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssb.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvssb_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvssb_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m4, d1
+; CHECK-NEXT:    vssb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssb.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssb.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvssb_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, iXLen %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvssb_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m4, d1
+; CHECK-NEXT:    vssb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssb.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    iXLen %2, 
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssb.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvssb_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvssb_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m8, d1
+; CHECK-NEXT:    vssb.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssb.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssb.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define void @intrinsic_xvssb_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, iXLen %2, <vscale x 64 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvssb_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m8, d1
+; CHECK-NEXT:    vssb.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssb.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    iXLen %2, 
+    <vscale x 64 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssh.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvssh_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvssh_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vssh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssh.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssh.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvssh_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvssh_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vssh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssh.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %2, 
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssh.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvssh_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvssh_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vssh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssh.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssh.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvssh_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvssh_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vssh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssh.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssh.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvssh_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvssh_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vssh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssh.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssh.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvssh_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvssh_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vssh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssh.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    iXLen %2, 
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssh.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvssh_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvssh_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vssh.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssh.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssh.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvssh_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, iXLen %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvssh_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vssh.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssh.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    iXLen %2, 
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssw.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvssw_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvssw_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vssw.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssw.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssw.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define void @intrinsic_xvssw_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvssw_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vssw.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssw.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %2, 
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssw.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvssw_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvssw_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vssw.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssw.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssw.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvssw_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvssw_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vssw.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssw.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %2, 
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssw.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvssw_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvssw_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vssw.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssw.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssw.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvssw_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvssw_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vssw.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssw.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssw.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvssw_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvssw_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vssw.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssw.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvssw.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvssw_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvssw_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vssw.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvssw.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    iXLen %2, 
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m1, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m1, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m2, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m2, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    iXLen %2, 
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m4, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  iXLen,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, iXLen %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m4, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    iXLen %2, 
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m8, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  iXLen,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, iXLen %2, <vscale x 64 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e8, m8, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    iXLen %2, 
+    <vscale x 64 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %2, 
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    iXLen %2, 
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  iXLen,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, iXLen %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    iXLen %2, 
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %2, 
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %2, 
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    iXLen %2, 
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  iXLen,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, iXLen %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %2, 
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %2, 
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %2, 
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    iXLen %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+


### PR DESCRIPTION
Similar to #22, in the first two commits I defined pseudo and intrinsics in TableGen files and in the third and the fourth commits I added custom selecting routine and set load/store information, respectively.