### PR TITLE
[LLVM] [RVV 0.7.1] Enable vector with float-point element type in RVV 0.7.1.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -938,3 +938,24 @@ def HasStdVOrXTHeadVI64 : Predicate<"Subtarget->hasStdVOrXTHeadVI64()">,
           "'V' (Vector Extension for Application Processors), 'Zve64x' "
           "(Vector Extensions for Embedded Processors) or"
           "'XTHeadV' (Vector Extension for T-Head)">;
+
+def HasStdVOrXTHeadVF16 : Predicate<"Subtarget->hasStdVOrXTHeadVF16()">,
+      AssemblerPredicate<
+          (any_of FeatureStdExtZvfh, FeatureVendorXTHeadV),
+          "'V' (Vector Extension for Application Processors), 'Zvfh' "
+          "(Vector Extensions for Embedded Processors) or"
+          "'XTHeadV' (Vector Extension for T-Head)">;
+
+def HasStdVOrXTHeadVF32 : Predicate<"Subtarget->hasStdVOrXTHeadVF32()">,
+      AssemblerPredicate<
+          (any_of FeatureStdExtZve32f, FeatureVendorXTHeadV),
+          "'V' (Vector Extension for Application Processors), 'Zve32f' "
+          "(Vector Extensions for Embedded Processors) or"
+          "'XTHeadV' (Vector Extension for T-Head)">;
+
+def HasStdVOrXTHeadVF64 : Predicate<"Subtarget->hasStdVOrXTHeadVF64()">,
+      AssemblerPredicate<
+          (any_of FeatureStdExtZve64d, FeatureVendorXTHeadV),
+          "'V' (Vector Extension for Application Processors), 'Zve64d' "
+          "(Vector Extensions for Embedded Processors) or"
+          "'XTHeadV' (Vector Extension for T-Head)">;

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -199,6 +199,15 @@ public:
   bool hasStdVOrXTHeadVI64() const {
     return hasVInstructionsI64() || hasVendorXTHeadV();
   }
+  bool hasStdVOrXTHeadVF16() const {
+    return hasVInstructionsF16() || hasVendorXTHeadV();
+  }
+  bool hasStdVOrXTHeadVF32() const {
+    return hasVInstructionsF32() || hasVendorXTHeadV();
+  }
+  bool hasStdVOrXTHeadVF64() const {
+    return hasVInstructionsF64() || hasVendorXTHeadV();
+  }
   unsigned getMaxInterleaveFactor() const {
     return hasVInstructions() ? MaxInterleaveFactor : 1;
   }

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -172,10 +172,10 @@ public:
   bool hasVInstructionsI64() const {
     return hasOnlyStdVI64() || hasVendorXTHeadV();
   }
-  bool hasVInstructionsF16() const { return hasOnlyStdVF16(); }
-  bool hasVInstructionsF32() const { return hasOnlyStdVF32(); }
-  bool hasVInstructionsF64() const { return hasOnlyStdVF64(); }
-  bool hasVInstructionsAnyF() const { return hasOnlyStdVAnyF(); }
+  bool hasVInstructionsF16() const { return hasOnlyStdVF16() || hasVendorXTHeadV(); }
+  bool hasVInstructionsF32() const { return hasOnlyStdVF32() || hasVendorXTHeadV(); }
+  bool hasVInstructionsF64() const { return hasOnlyStdVF64() || hasVendorXTHeadV(); }
+  bool hasVInstructionsAnyF() const { return hasOnlyStdVAnyF() || hasVendorXTHeadV(); }
   bool hasVInstructionsFullMultiply() const { return hasOnlyStdV() || hasVendorXTHeadV(); }
   //  If a SubTarget only has the standard V extension:
   bool hasOnlyStdV() const {

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vl.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vl.ll
@@ -1939,6 +1939,182 @@ entry:
   ret <vscale x 32 x i16> %a
 }
 
+declare <vscale x 4 x half> @llvm.riscv.xvle.nxv4f16.nxv4f16(
+  <vscale x 4 x half>,
+  <vscale x 4 x half>*,
+  iXLen);
+
+define <vscale x 4 x half> @intrinsic_xvle_v_nxv4f16_nxv4f16(<vscale x 4 x half>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv4f16_nxv4f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x half> @llvm.riscv.xvle.nxv4f16.nxv4f16(
+    <vscale x 4 x half> undef,
+    <vscale x 4 x half>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x half> %a
+}
+
+declare <vscale x 4 x half> @llvm.riscv.xvle.mask.nxv4f16.nxv4f16(
+  <vscale x 4 x half>,
+  <vscale x 4 x half>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x half> @intrinsic_xvle_mask_v_nxv4f16_nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x half>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv4f16_nxv4f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x half> @llvm.riscv.xvle.mask.nxv4f16.nxv4f16(
+    <vscale x 4 x half> %0,
+    <vscale x 4 x half>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x half> %a
+}
+
+declare <vscale x 8 x half> @llvm.riscv.xvle.nxv8f16.nxv8f16(
+  <vscale x 8 x half>,
+  <vscale x 8 x half>*,
+  iXLen);
+
+define <vscale x 8 x half> @intrinsic_xvle_v_nxv8f16_nxv8f16(<vscale x 8 x half>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv8f16_nxv8f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x half> @llvm.riscv.xvle.nxv8f16.nxv8f16(
+    <vscale x 8 x half> undef,
+    <vscale x 8 x half>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x half> %a
+}
+
+declare <vscale x 8 x half> @llvm.riscv.xvle.mask.nxv8f16.nxv8f16(
+  <vscale x 8 x half>,
+  <vscale x 8 x half>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x half> @intrinsic_xvle_mask_v_nxv8f16_nxv8f16(<vscale x 8 x half> %0, <vscale x 8 x half>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv8f16_nxv8f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x half> @llvm.riscv.xvle.mask.nxv8f16.nxv8f16(
+    <vscale x 8 x half> %0,
+    <vscale x 8 x half>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x half> %a
+}
+
+declare <vscale x 16 x half> @llvm.riscv.xvle.nxv16f16.nxv16f16(
+  <vscale x 16 x half>,
+  <vscale x 16 x half>*,
+  iXLen);
+
+define <vscale x 16 x half> @intrinsic_xvle_v_nxv16f16_nxv16f16(<vscale x 16 x half>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv16f16_nxv16f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x half> @llvm.riscv.xvle.nxv16f16.nxv16f16(
+    <vscale x 16 x half> undef,
+    <vscale x 16 x half>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x half> %a
+}
+
+declare <vscale x 16 x half> @llvm.riscv.xvle.mask.nxv16f16.nxv16f16(
+  <vscale x 16 x half>,
+  <vscale x 16 x half>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x half> @intrinsic_xvle_mask_v_nxv16f16_nxv16f16(<vscale x 16 x half> %0, <vscale x 16 x half>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv16f16_nxv16f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x half> @llvm.riscv.xvle.mask.nxv16f16.nxv16f16(
+    <vscale x 16 x half> %0,
+    <vscale x 16 x half>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x half> %a
+}
+
+declare <vscale x 32 x half> @llvm.riscv.xvle.nxv32f16.nxv32f16(
+  <vscale x 32 x half>,
+  <vscale x 32 x half>*,
+  iXLen);
+
+define <vscale x 32 x half> @intrinsic_xvle_v_nxv32f16_nxv32f16(<vscale x 32 x half>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv32f16_nxv32f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x half> @llvm.riscv.xvle.nxv32f16.nxv32f16(
+    <vscale x 32 x half> undef,
+    <vscale x 32 x half>* %0,
+    iXLen %1)
+
+  ret <vscale x 32 x half> %a
+}
+
+declare <vscale x 32 x half> @llvm.riscv.xvle.mask.nxv32f16.nxv32f16(
+  <vscale x 32 x half>,
+  <vscale x 32 x half>*,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x half> @intrinsic_xvle_mask_v_nxv32f16_nxv32f16(<vscale x 32 x half> %0, <vscale x 32 x half>* %1, <vscale x 32 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv32f16_nxv32f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x half> @llvm.riscv.xvle.mask.nxv32f16.nxv32f16(
+    <vscale x 32 x half> %0,
+    <vscale x 32 x half>* %1,
+    <vscale x 32 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 32 x half> %a
+}
+
 declare <vscale x 2 x i32> @llvm.riscv.xvle.nxv2i32.nxv2i32(
   <vscale x 2 x i32>,
   <vscale x 2 x i32>*,
@@ -2113,6 +2289,182 @@ entry:
     iXLen %3)
 
   ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 2 x float> @llvm.riscv.xvle.nxv2f32.nxv2f32(
+  <vscale x 2 x float>,
+  <vscale x 2 x float>*,
+  iXLen);
+
+define <vscale x 2 x float> @intrinsic_xvle_v_nxv2f32_nxv2f32(<vscale x 2 x float>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv2f32_nxv2f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x float> @llvm.riscv.xvle.nxv2f32.nxv2f32(
+    <vscale x 2 x float> undef,
+    <vscale x 2 x float>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x float> %a
+}
+
+declare <vscale x 2 x float> @llvm.riscv.xvle.mask.nxv2f32.nxv2f32(
+  <vscale x 2 x float>,
+  <vscale x 2 x float>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x float> @intrinsic_xvle_mask_v_nxv2f32_nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x float>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv2f32_nxv2f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x float> @llvm.riscv.xvle.mask.nxv2f32.nxv2f32(
+    <vscale x 2 x float> %0,
+    <vscale x 2 x float>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x float> %a
+}
+
+declare <vscale x 4 x float> @llvm.riscv.xvle.nxv4f32.nxv4f32(
+  <vscale x 4 x float>,
+  <vscale x 4 x float>*,
+  iXLen);
+
+define <vscale x 4 x float> @intrinsic_xvle_v_nxv4f32_nxv4f32(<vscale x 4 x float>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv4f32_nxv4f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x float> @llvm.riscv.xvle.nxv4f32.nxv4f32(
+    <vscale x 4 x float> undef,
+    <vscale x 4 x float>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x float> %a
+}
+
+declare <vscale x 4 x float> @llvm.riscv.xvle.mask.nxv4f32.nxv4f32(
+  <vscale x 4 x float>,
+  <vscale x 4 x float>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x float> @intrinsic_xvle_mask_v_nxv4f32_nxv4f32(<vscale x 4 x float> %0, <vscale x 4 x float>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv4f32_nxv4f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x float> @llvm.riscv.xvle.mask.nxv4f32.nxv4f32(
+    <vscale x 4 x float> %0,
+    <vscale x 4 x float>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x float> %a
+}
+
+declare <vscale x 8 x float> @llvm.riscv.xvle.nxv8f32.nxv8f32(
+  <vscale x 8 x float>,
+  <vscale x 8 x float>*,
+  iXLen);
+
+define <vscale x 8 x float> @intrinsic_xvle_v_nxv8f32_nxv8f32(<vscale x 8 x float>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv8f32_nxv8f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x float> @llvm.riscv.xvle.nxv8f32.nxv8f32(
+    <vscale x 8 x float> undef,
+    <vscale x 8 x float>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x float> %a
+}
+
+declare <vscale x 8 x float> @llvm.riscv.xvle.mask.nxv8f32.nxv8f32(
+  <vscale x 8 x float>,
+  <vscale x 8 x float>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x float> @intrinsic_xvle_mask_v_nxv8f32_nxv8f32(<vscale x 8 x float> %0, <vscale x 8 x float>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv8f32_nxv8f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x float> @llvm.riscv.xvle.mask.nxv8f32.nxv8f32(
+    <vscale x 8 x float> %0,
+    <vscale x 8 x float>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x float> %a
+}
+
+declare <vscale x 16 x float> @llvm.riscv.xvle.nxv16f32.nxv16f32(
+  <vscale x 16 x float>,
+  <vscale x 16 x float>*,
+  iXLen);
+
+define <vscale x 16 x float> @intrinsic_xvle_v_nxv16f32_nxv16f32(<vscale x 16 x float>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv16f32_nxv16f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x float> @llvm.riscv.xvle.nxv16f32.nxv16f32(
+    <vscale x 16 x float> undef,
+    <vscale x 16 x float>* %0,
+    iXLen %1)
+
+  ret <vscale x 16 x float> %a
+}
+
+declare <vscale x 16 x float> @llvm.riscv.xvle.mask.nxv16f32.nxv16f32(
+  <vscale x 16 x float>,
+  <vscale x 16 x float>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x float> @intrinsic_xvle_mask_v_nxv16f32_nxv16f32(<vscale x 16 x float> %0, <vscale x 16 x float>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv16f32_nxv16f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x float> @llvm.riscv.xvle.mask.nxv16f32.nxv16f32(
+    <vscale x 16 x float> %0,
+    <vscale x 16 x float>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 16 x float> %a
 }
 
 declare <vscale x 1 x i64> @llvm.riscv.xvle.nxv1i64.nxv1i64(
@@ -2290,3 +2642,180 @@ entry:
 
   ret <vscale x 8 x i64> %a
 }
+
+declare <vscale x 1 x double> @llvm.riscv.xvle.nxv1f64.nxv1f64(
+  <vscale x 1 x double>,
+  <vscale x 1 x double>*,
+  iXLen);
+
+define <vscale x 1 x double> @intrinsic_xvle_v_nxv1f64_nxv1f64(<vscale x 1 x double>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv1f64_nxv1f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x double> @llvm.riscv.xvle.nxv1f64.nxv1f64(
+    <vscale x 1 x double> undef,
+    <vscale x 1 x double>* %0,
+    iXLen %1)
+
+  ret <vscale x 1 x double> %a
+}
+
+declare <vscale x 1 x double> @llvm.riscv.xvle.mask.nxv1f64.nxv1f64(
+  <vscale x 1 x double>,
+  <vscale x 1 x double>*,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x double> @intrinsic_xvle_mask_v_nxv1f64_nxv1f64(<vscale x 1 x double> %0, <vscale x 1 x double>* %1, <vscale x 1 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv1f64_nxv1f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x double> @llvm.riscv.xvle.mask.nxv1f64.nxv1f64(
+    <vscale x 1 x double> %0,
+    <vscale x 1 x double>* %1,
+    <vscale x 1 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 1 x double> %a
+}
+
+declare <vscale x 2 x double> @llvm.riscv.xvle.nxv2f64.nxv2f64(
+  <vscale x 2 x double>,
+  <vscale x 2 x double>*,
+  iXLen);
+
+define <vscale x 2 x double> @intrinsic_xvle_v_nxv2f64_nxv2f64(<vscale x 2 x double>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv2f64_nxv2f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x double> @llvm.riscv.xvle.nxv2f64.nxv2f64(
+    <vscale x 2 x double> undef,
+    <vscale x 2 x double>* %0,
+    iXLen %1)
+
+  ret <vscale x 2 x double> %a
+}
+
+declare <vscale x 2 x double> @llvm.riscv.xvle.mask.nxv2f64.nxv2f64(
+  <vscale x 2 x double>,
+  <vscale x 2 x double>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x double> @intrinsic_xvle_mask_v_nxv2f64_nxv2f64(<vscale x 2 x double> %0, <vscale x 2 x double>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv2f64_nxv2f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x double> @llvm.riscv.xvle.mask.nxv2f64.nxv2f64(
+    <vscale x 2 x double> %0,
+    <vscale x 2 x double>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 2 x double> %a
+}
+
+declare <vscale x 4 x double> @llvm.riscv.xvle.nxv4f64.nxv4f64(
+  <vscale x 4 x double>,
+  <vscale x 4 x double>*,
+  iXLen);
+
+define <vscale x 4 x double> @intrinsic_xvle_v_nxv4f64_nxv4f64(<vscale x 4 x double>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv4f64_nxv4f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x double> @llvm.riscv.xvle.nxv4f64.nxv4f64(
+    <vscale x 4 x double> undef,
+    <vscale x 4 x double>* %0,
+    iXLen %1)
+
+  ret <vscale x 4 x double> %a
+}
+
+declare <vscale x 4 x double> @llvm.riscv.xvle.mask.nxv4f64.nxv4f64(
+  <vscale x 4 x double>,
+  <vscale x 4 x double>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x double> @intrinsic_xvle_mask_v_nxv4f64_nxv4f64(<vscale x 4 x double> %0, <vscale x 4 x double>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv4f64_nxv4f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x double> @llvm.riscv.xvle.mask.nxv4f64.nxv4f64(
+    <vscale x 4 x double> %0,
+    <vscale x 4 x double>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 4 x double> %a
+}
+
+declare <vscale x 8 x double> @llvm.riscv.xvle.nxv8f64.nxv8f64(
+  <vscale x 8 x double>,
+  <vscale x 8 x double>*,
+  iXLen);
+
+define <vscale x 8 x double> @intrinsic_xvle_v_nxv8f64_nxv8f64(<vscale x 8 x double>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvle_v_nxv8f64_nxv8f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vle.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x double> @llvm.riscv.xvle.nxv8f64.nxv8f64(
+    <vscale x 8 x double> undef,
+    <vscale x 8 x double>* %0,
+    iXLen %1)
+
+  ret <vscale x 8 x double> %a
+}
+
+declare <vscale x 8 x double> @llvm.riscv.xvle.mask.nxv8f64.nxv8f64(
+  <vscale x 8 x double>,
+  <vscale x 8 x double>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x double> @intrinsic_xvle_mask_v_nxv8f64_nxv8f64(<vscale x 8 x double> %0, <vscale x 8 x double>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvle_mask_v_nxv8f64_nxv8f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vle.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x double> @llvm.riscv.xvle.mask.nxv8f64.nxv8f64(
+    <vscale x 8 x double> %0,
+    <vscale x 8 x double>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret <vscale x 8 x double> %a
+}
+

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vls.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vls.ll
@@ -2115,6 +2115,198 @@ entry:
   ret <vscale x 32 x i16> %a
 }
 
+declare <vscale x 4 x half> @llvm.riscv.xvlse.nxv4f16.nxv4f16(
+  <vscale x 4 x half>,
+  <vscale x 4 x half>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x half> @intrinsic_xvlse_v_nxv4f16_nxv4f16(<vscale x 4 x half>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv4f16_nxv4f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x half> @llvm.riscv.xvlse.nxv4f16.nxv4f16(
+    <vscale x 4 x half> undef,
+    <vscale x 4 x half>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x half> %a
+}
+
+declare <vscale x 4 x half> @llvm.riscv.xvlse.mask.nxv4f16.nxv4f16(
+  <vscale x 4 x half>,
+  <vscale x 4 x half>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x half> @intrinsic_xvlse_mask_v_nxv4f16_nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x half>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv4f16_nxv4f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x half> @llvm.riscv.xvlse.mask.nxv4f16.nxv4f16(
+    <vscale x 4 x half> %0,
+    <vscale x 4 x half>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x half> %a
+}
+
+declare <vscale x 8 x half> @llvm.riscv.xvlse.nxv8f16.nxv8f16(
+  <vscale x 8 x half>,
+  <vscale x 8 x half>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x half> @intrinsic_xvlse_v_nxv8f16_nxv8f16(<vscale x 8 x half>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv8f16_nxv8f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x half> @llvm.riscv.xvlse.nxv8f16.nxv8f16(
+    <vscale x 8 x half> undef,
+    <vscale x 8 x half>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x half> %a
+}
+
+declare <vscale x 8 x half> @llvm.riscv.xvlse.mask.nxv8f16.nxv8f16(
+  <vscale x 8 x half>,
+  <vscale x 8 x half>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x half> @intrinsic_xvlse_mask_v_nxv8f16_nxv8f16(<vscale x 8 x half> %0, <vscale x 8 x half>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv8f16_nxv8f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x half> @llvm.riscv.xvlse.mask.nxv8f16.nxv8f16(
+    <vscale x 8 x half> %0,
+    <vscale x 8 x half>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x half> %a
+}
+
+declare <vscale x 16 x half> @llvm.riscv.xvlse.nxv16f16.nxv16f16(
+  <vscale x 16 x half>,
+  <vscale x 16 x half>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x half> @intrinsic_xvlse_v_nxv16f16_nxv16f16(<vscale x 16 x half>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv16f16_nxv16f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x half> @llvm.riscv.xvlse.nxv16f16.nxv16f16(
+    <vscale x 16 x half> undef,
+    <vscale x 16 x half>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x half> %a
+}
+
+declare <vscale x 16 x half> @llvm.riscv.xvlse.mask.nxv16f16.nxv16f16(
+  <vscale x 16 x half>,
+  <vscale x 16 x half>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x half> @intrinsic_xvlse_mask_v_nxv16f16_nxv16f16(<vscale x 16 x half> %0, <vscale x 16 x half>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv16f16_nxv16f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x half> @llvm.riscv.xvlse.mask.nxv16f16.nxv16f16(
+    <vscale x 16 x half> %0,
+    <vscale x 16 x half>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x half> %a
+}
+
+declare <vscale x 32 x half> @llvm.riscv.xvlse.nxv32f16.nxv32f16(
+  <vscale x 32 x half>,
+  <vscale x 32 x half>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 32 x half> @intrinsic_xvlse_v_nxv32f16_nxv32f16(<vscale x 32 x half>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv32f16_nxv32f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x half> @llvm.riscv.xvlse.nxv32f16.nxv32f16(
+    <vscale x 32 x half> undef,
+    <vscale x 32 x half>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 32 x half> %a
+}
+
+declare <vscale x 32 x half> @llvm.riscv.xvlse.mask.nxv32f16.nxv32f16(
+  <vscale x 32 x half>,
+  <vscale x 32 x half>*,
+  iXLen,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x half> @intrinsic_xvlse_mask_v_nxv32f16_nxv32f16(<vscale x 32 x half> %0, <vscale x 32 x half>* %1, iXLen %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv32f16_nxv32f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x half> @llvm.riscv.xvlse.mask.nxv32f16.nxv32f16(
+    <vscale x 32 x half> %0,
+    <vscale x 32 x half>* %1,
+    iXLen %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x half> %a
+}
+
 declare <vscale x 2 x i32> @llvm.riscv.xvlse.nxv2i32.nxv2i32(
   <vscale x 2 x i32>,
   <vscale x 2 x i32>*,
@@ -2305,6 +2497,198 @@ entry:
     iXLen %4)
 
   ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 2 x float> @llvm.riscv.xvlse.nxv2f32.nxv2f32(
+  <vscale x 2 x float>,
+  <vscale x 2 x float>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x float> @intrinsic_xvlse_v_nxv2f32_nxv2f32(<vscale x 2 x float>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv2f32_nxv2f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x float> @llvm.riscv.xvlse.nxv2f32.nxv2f32(
+    <vscale x 2 x float> undef,
+    <vscale x 2 x float>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x float> %a
+}
+
+declare <vscale x 2 x float> @llvm.riscv.xvlse.mask.nxv2f32.nxv2f32(
+  <vscale x 2 x float>,
+  <vscale x 2 x float>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x float> @intrinsic_xvlse_mask_v_nxv2f32_nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x float>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv2f32_nxv2f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x float> @llvm.riscv.xvlse.mask.nxv2f32.nxv2f32(
+    <vscale x 2 x float> %0,
+    <vscale x 2 x float>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x float> %a
+}
+
+declare <vscale x 4 x float> @llvm.riscv.xvlse.nxv4f32.nxv4f32(
+  <vscale x 4 x float>,
+  <vscale x 4 x float>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x float> @intrinsic_xvlse_v_nxv4f32_nxv4f32(<vscale x 4 x float>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv4f32_nxv4f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x float> @llvm.riscv.xvlse.nxv4f32.nxv4f32(
+    <vscale x 4 x float> undef,
+    <vscale x 4 x float>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x float> %a
+}
+
+declare <vscale x 4 x float> @llvm.riscv.xvlse.mask.nxv4f32.nxv4f32(
+  <vscale x 4 x float>,
+  <vscale x 4 x float>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x float> @intrinsic_xvlse_mask_v_nxv4f32_nxv4f32(<vscale x 4 x float> %0, <vscale x 4 x float>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv4f32_nxv4f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x float> @llvm.riscv.xvlse.mask.nxv4f32.nxv4f32(
+    <vscale x 4 x float> %0,
+    <vscale x 4 x float>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x float> %a
+}
+
+declare <vscale x 8 x float> @llvm.riscv.xvlse.nxv8f32.nxv8f32(
+  <vscale x 8 x float>,
+  <vscale x 8 x float>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x float> @intrinsic_xvlse_v_nxv8f32_nxv8f32(<vscale x 8 x float>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv8f32_nxv8f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x float> @llvm.riscv.xvlse.nxv8f32.nxv8f32(
+    <vscale x 8 x float> undef,
+    <vscale x 8 x float>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x float> %a
+}
+
+declare <vscale x 8 x float> @llvm.riscv.xvlse.mask.nxv8f32.nxv8f32(
+  <vscale x 8 x float>,
+  <vscale x 8 x float>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x float> @intrinsic_xvlse_mask_v_nxv8f32_nxv8f32(<vscale x 8 x float> %0, <vscale x 8 x float>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv8f32_nxv8f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x float> @llvm.riscv.xvlse.mask.nxv8f32.nxv8f32(
+    <vscale x 8 x float> %0,
+    <vscale x 8 x float>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x float> %a
+}
+
+declare <vscale x 16 x float> @llvm.riscv.xvlse.nxv16f32.nxv16f32(
+  <vscale x 16 x float>,
+  <vscale x 16 x float>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 16 x float> @intrinsic_xvlse_v_nxv16f32_nxv16f32(<vscale x 16 x float>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv16f32_nxv16f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x float> @llvm.riscv.xvlse.nxv16f32.nxv16f32(
+    <vscale x 16 x float> undef,
+    <vscale x 16 x float>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 16 x float> %a
+}
+
+declare <vscale x 16 x float> @llvm.riscv.xvlse.mask.nxv16f32.nxv16f32(
+  <vscale x 16 x float>,
+  <vscale x 16 x float>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x float> @intrinsic_xvlse_mask_v_nxv16f32_nxv16f32(<vscale x 16 x float> %0, <vscale x 16 x float>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv16f32_nxv16f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x float> @llvm.riscv.xvlse.mask.nxv16f32.nxv16f32(
+    <vscale x 16 x float> %0,
+    <vscale x 16 x float>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x float> %a
 }
 
 declare <vscale x 1 x i64> @llvm.riscv.xvlse.nxv1i64.nxv1i64(
@@ -2498,3 +2882,196 @@ entry:
 
   ret <vscale x 8 x i64> %a
 }
+
+declare <vscale x 1 x double> @llvm.riscv.xvlse.nxv1f64.nxv1f64(
+  <vscale x 1 x double>,
+  <vscale x 1 x double>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 1 x double> @intrinsic_xvlse_v_nxv1f64_nxv1f64(<vscale x 1 x double>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv1f64_nxv1f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x double> @llvm.riscv.xvlse.nxv1f64.nxv1f64(
+    <vscale x 1 x double> undef,
+    <vscale x 1 x double>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 1 x double> %a
+}
+
+declare <vscale x 1 x double> @llvm.riscv.xvlse.mask.nxv1f64.nxv1f64(
+  <vscale x 1 x double>,
+  <vscale x 1 x double>*,
+  iXLen,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x double> @intrinsic_xvlse_mask_v_nxv1f64_nxv1f64(<vscale x 1 x double> %0, <vscale x 1 x double>* %1, iXLen %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv1f64_nxv1f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x double> @llvm.riscv.xvlse.mask.nxv1f64.nxv1f64(
+    <vscale x 1 x double> %0,
+    <vscale x 1 x double>* %1,
+    iXLen %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 1 x double> %a
+}
+
+declare <vscale x 2 x double> @llvm.riscv.xvlse.nxv2f64.nxv2f64(
+  <vscale x 2 x double>,
+  <vscale x 2 x double>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 2 x double> @intrinsic_xvlse_v_nxv2f64_nxv2f64(<vscale x 2 x double>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv2f64_nxv2f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x double> @llvm.riscv.xvlse.nxv2f64.nxv2f64(
+    <vscale x 2 x double> undef,
+    <vscale x 2 x double>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 2 x double> %a
+}
+
+declare <vscale x 2 x double> @llvm.riscv.xvlse.mask.nxv2f64.nxv2f64(
+  <vscale x 2 x double>,
+  <vscale x 2 x double>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x double> @intrinsic_xvlse_mask_v_nxv2f64_nxv2f64(<vscale x 2 x double> %0, <vscale x 2 x double>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv2f64_nxv2f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x double> @llvm.riscv.xvlse.mask.nxv2f64.nxv2f64(
+    <vscale x 2 x double> %0,
+    <vscale x 2 x double>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x double> %a
+}
+
+declare <vscale x 4 x double> @llvm.riscv.xvlse.nxv4f64.nxv4f64(
+  <vscale x 4 x double>,
+  <vscale x 4 x double>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 4 x double> @intrinsic_xvlse_v_nxv4f64_nxv4f64(<vscale x 4 x double>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv4f64_nxv4f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x double> @llvm.riscv.xvlse.nxv4f64.nxv4f64(
+    <vscale x 4 x double> undef,
+    <vscale x 4 x double>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 4 x double> %a
+}
+
+declare <vscale x 4 x double> @llvm.riscv.xvlse.mask.nxv4f64.nxv4f64(
+  <vscale x 4 x double>,
+  <vscale x 4 x double>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x double> @intrinsic_xvlse_mask_v_nxv4f64_nxv4f64(<vscale x 4 x double> %0, <vscale x 4 x double>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv4f64_nxv4f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x double> @llvm.riscv.xvlse.mask.nxv4f64.nxv4f64(
+    <vscale x 4 x double> %0,
+    <vscale x 4 x double>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x double> %a
+}
+
+declare <vscale x 8 x double> @llvm.riscv.xvlse.nxv8f64.nxv8f64(
+  <vscale x 8 x double>,
+  <vscale x 8 x double>*,
+  iXLen,
+  iXLen);
+
+define <vscale x 8 x double> @intrinsic_xvlse_v_nxv8f64_nxv8f64(<vscale x 8 x double>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_v_nxv8f64_nxv8f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x double> @llvm.riscv.xvlse.nxv8f64.nxv8f64(
+    <vscale x 8 x double> undef,
+    <vscale x 8 x double>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret <vscale x 8 x double> %a
+}
+
+declare <vscale x 8 x double> @llvm.riscv.xvlse.mask.nxv8f64.nxv8f64(
+  <vscale x 8 x double>,
+  <vscale x 8 x double>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x double> @intrinsic_xvlse_mask_v_nxv8f64_nxv8f64(<vscale x 8 x double> %0, <vscale x 8 x double>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlse_mask_v_nxv8f64_nxv8f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vlse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x double> @llvm.riscv.xvlse.mask.nxv8f64.nxv8f64(
+    <vscale x 8 x double> %0,
+    <vscale x 8 x double>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x double> %a
+}
+

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vs.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vs.ll
@@ -751,6 +751,50 @@ entry:
   ret void
 }
 
+declare void @llvm.riscv.xvse.nxv4f16.nxv4f16(
+  <vscale x 4 x half>,
+  <vscale x 4 x half>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv4f16_nxv4f16(<vscale x 4 x half>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv4f16_nxv4f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv4f16.nxv4f16(
+    <vscale x 4 x half> undef,
+    <vscale x 4 x half>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv4f16.nxv4f16(
+  <vscale x 4 x half>,
+  <vscale x 4 x half>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv4f16_nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x half>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv4f16_nxv4f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv4f16.nxv4f16(
+    <vscale x 4 x half> %0,
+    <vscale x 4 x half>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
 declare void @llvm.riscv.xvse.nxv8i16.nxv8i16(
   <vscale x 8 x i16>,
   <vscale x 8 x i16>*,
@@ -789,6 +833,50 @@ entry:
   call void @llvm.riscv.xvse.mask.nxv8i16.nxv8i16(
     <vscale x 8 x i16> %0,
     <vscale x 8 x i16>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv8f16.nxv8f16(
+  <vscale x 8 x half>,
+  <vscale x 8 x half>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv8f16_nxv8f16(<vscale x 8 x half>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv8f16_nxv8f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv8f16.nxv8f16(
+    <vscale x 8 x half> undef,
+    <vscale x 8 x half>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv8f16.nxv8f16(
+  <vscale x 8 x half>,
+  <vscale x 8 x half>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv8f16_nxv8f16(<vscale x 8 x half> %0, <vscale x 8 x half>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv8f16_nxv8f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv8f16.nxv8f16(
+    <vscale x 8 x half> %0,
+    <vscale x 8 x half>* %1,
     <vscale x 8 x i1> %2,
     iXLen %3)
 
@@ -839,6 +927,50 @@ entry:
   ret void
 }
 
+declare void @llvm.riscv.xvse.nxv16f16.nxv16f16(
+  <vscale x 16 x half>,
+  <vscale x 16 x half>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv16f16_nxv16f16(<vscale x 16 x half>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv16f16_nxv16f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv16f16.nxv16f16(
+    <vscale x 16 x half> undef,
+    <vscale x 16 x half>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv16f16.nxv16f16(
+  <vscale x 16 x half>,
+  <vscale x 16 x half>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv16f16_nxv16f16(<vscale x 16 x half> %0, <vscale x 16 x half>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv16f16_nxv16f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv16f16.nxv16f16(
+    <vscale x 16 x half> %0,
+    <vscale x 16 x half>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
 declare void @llvm.riscv.xvse.nxv32i16.nxv32i16(
   <vscale x 32 x i16>,
   <vscale x 32 x i16>*,
@@ -877,6 +1009,50 @@ entry:
   call void @llvm.riscv.xvse.mask.nxv32i16.nxv32i16(
     <vscale x 32 x i16> %0,
     <vscale x 32 x i16>* %1,
+    <vscale x 32 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv32f16.nxv32f16(
+  <vscale x 32 x half>,
+  <vscale x 32 x half>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv32f16_nxv32f16(<vscale x 32 x half>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv32f16_nxv32f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv32f16.nxv32f16(
+    <vscale x 32 x half> undef,
+    <vscale x 32 x half>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv32f16.nxv32f16(
+  <vscale x 32 x half>,
+  <vscale x 32 x half>*,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv32f16_nxv32f16(<vscale x 32 x half> %0, <vscale x 32 x half>* %1, <vscale x 32 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv32f16_nxv32f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv32f16.nxv32f16(
+    <vscale x 32 x half> %0,
+    <vscale x 32 x half>* %1,
     <vscale x 32 x i1> %2,
     iXLen %3)
 
@@ -927,6 +1103,50 @@ entry:
   ret void
 }
 
+declare void @llvm.riscv.xvse.nxv2f32.nxv2f32(
+  <vscale x 2 x float>,
+  <vscale x 2 x float>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv2f32_nxv2f32(<vscale x 2 x float>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv2f32_nxv2f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv2f32.nxv2f32(
+    <vscale x 2 x float> undef,
+    <vscale x 2 x float>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv2f32.nxv2f32(
+  <vscale x 2 x float>,
+  <vscale x 2 x float>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv2f32_nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x float>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv2f32_nxv2f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv2f32.nxv2f32(
+    <vscale x 2 x float> %0,
+    <vscale x 2 x float>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
 declare void @llvm.riscv.xvse.nxv4i32.nxv4i32(
   <vscale x 4 x i32>,
   <vscale x 4 x i32>*,
@@ -965,6 +1185,50 @@ entry:
   call void @llvm.riscv.xvse.mask.nxv4i32.nxv4i32(
     <vscale x 4 x i32> %0,
     <vscale x 4 x i32>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv4f32.nxv4f32(
+  <vscale x 4 x float>,
+  <vscale x 4 x float>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv4f32_nxv4f32(<vscale x 4 x float>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv4f32_nxv4f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv4f32.nxv4f32(
+    <vscale x 4 x float> undef,
+    <vscale x 4 x float>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv4f32.nxv4f32(
+  <vscale x 4 x float>,
+  <vscale x 4 x float>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv4f32_nxv4f32(<vscale x 4 x float> %0, <vscale x 4 x float>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv4f32_nxv4f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv4f32.nxv4f32(
+    <vscale x 4 x float> %0,
+    <vscale x 4 x float>* %1,
     <vscale x 4 x i1> %2,
     iXLen %3)
 
@@ -1015,6 +1279,50 @@ entry:
   ret void
 }
 
+declare void @llvm.riscv.xvse.nxv8f32.nxv8f32(
+  <vscale x 8 x float>,
+  <vscale x 8 x float>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv8f32_nxv8f32(<vscale x 8 x float>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv8f32_nxv8f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv8f32.nxv8f32(
+    <vscale x 8 x float> undef,
+    <vscale x 8 x float>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv8f32.nxv8f32(
+  <vscale x 8 x float>,
+  <vscale x 8 x float>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv8f32_nxv8f32(<vscale x 8 x float> %0, <vscale x 8 x float>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv8f32_nxv8f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv8f32.nxv8f32(
+    <vscale x 8 x float> %0,
+    <vscale x 8 x float>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
 declare void @llvm.riscv.xvse.nxv16i32.nxv16i32(
   <vscale x 16 x i32>,
   <vscale x 16 x i32>*,
@@ -1053,6 +1361,50 @@ entry:
   call void @llvm.riscv.xvse.mask.nxv16i32.nxv16i32(
     <vscale x 16 x i32> %0,
     <vscale x 16 x i32>* %1,
+    <vscale x 16 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv16f32.nxv16f32(
+  <vscale x 16 x float>,
+  <vscale x 16 x float>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv16f32_nxv16f32(<vscale x 16 x float>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv16f32_nxv16f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv16f32.nxv16f32(
+    <vscale x 16 x float> undef,
+    <vscale x 16 x float>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv16f32.nxv16f32(
+  <vscale x 16 x float>,
+  <vscale x 16 x float>*,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv16f32_nxv16f32(<vscale x 16 x float> %0, <vscale x 16 x float>* %1, <vscale x 16 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv16f32_nxv16f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv16f32.nxv16f32(
+    <vscale x 16 x float> %0,
+    <vscale x 16 x float>* %1,
     <vscale x 16 x i1> %2,
     iXLen %3)
 
@@ -1103,6 +1455,50 @@ entry:
   ret void
 }
 
+declare void @llvm.riscv.xvse.nxv1f64.nxv1f64(
+  <vscale x 1 x double>,
+  <vscale x 1 x double>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv1f64_nxv1f64(<vscale x 1 x double>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv1f64_nxv1f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv1f64.nxv1f64(
+    <vscale x 1 x double> undef,
+    <vscale x 1 x double>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv1f64.nxv1f64(
+  <vscale x 1 x double>,
+  <vscale x 1 x double>*,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv1f64_nxv1f64(<vscale x 1 x double> %0, <vscale x 1 x double>* %1, <vscale x 1 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv1f64_nxv1f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv1f64.nxv1f64(
+    <vscale x 1 x double> %0,
+    <vscale x 1 x double>* %1,
+    <vscale x 1 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
 declare void @llvm.riscv.xvse.nxv2i64.nxv2i64(
   <vscale x 2 x i64>,
   <vscale x 2 x i64>*,
@@ -1141,6 +1537,50 @@ entry:
   call void @llvm.riscv.xvse.mask.nxv2i64.nxv2i64(
     <vscale x 2 x i64> %0,
     <vscale x 2 x i64>* %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.nxv2f64.nxv2f64(
+  <vscale x 2 x double>,
+  <vscale x 2 x double>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv2f64_nxv2f64(<vscale x 2 x double>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv2f64_nxv2f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv2f64.nxv2f64(
+    <vscale x 2 x double> undef,
+    <vscale x 2 x double>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv2f64.nxv2f64(
+  <vscale x 2 x double>,
+  <vscale x 2 x double>*,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv2f64_nxv2f64(<vscale x 2 x double> %0, <vscale x 2 x double>* %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv2f64_nxv2f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv2f64.nxv2f64(
+    <vscale x 2 x double> %0,
+    <vscale x 2 x double>* %1,
     <vscale x 2 x i1> %2,
     iXLen %3)
 
@@ -1191,6 +1631,50 @@ entry:
   ret void
 }
 
+declare void @llvm.riscv.xvse.nxv4f64.nxv4f64(
+  <vscale x 4 x double>,
+  <vscale x 4 x double>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv4f64_nxv4f64(<vscale x 4 x double>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv4f64_nxv4f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv4f64.nxv4f64(
+    <vscale x 4 x double> undef,
+    <vscale x 4 x double>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv4f64.nxv4f64(
+  <vscale x 4 x double>,
+  <vscale x 4 x double>*,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv4f64_nxv4f64(<vscale x 4 x double> %0, <vscale x 4 x double>* %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv4f64_nxv4f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv4f64.nxv4f64(
+    <vscale x 4 x double> %0,
+    <vscale x 4 x double>* %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+
 declare void @llvm.riscv.xvse.nxv8i64.nxv8i64(
   <vscale x 8 x i64>,
   <vscale x 8 x i64>*,
@@ -1234,3 +1718,48 @@ entry:
 
   ret void
 }
+
+declare void @llvm.riscv.xvse.nxv8f64.nxv8f64(
+  <vscale x 8 x double>,
+  <vscale x 8 x double>*,
+  iXLen);
+
+define void @intrinsic_xvse_v_nxv8f64_nxv8f64(<vscale x 8 x double>* %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_xvse_v_nxv8f64_nxv8f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vse.v v8, (a0)
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.nxv8f64.nxv8f64(
+    <vscale x 8 x double> undef,
+    <vscale x 8 x double>* %0,
+    iXLen %1)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvse.mask.nxv8f64.nxv8f64(
+  <vscale x 8 x double>,
+  <vscale x 8 x double>*,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvse_mask_v_nxv8f64_nxv8f64(<vscale x 8 x double> %0, <vscale x 8 x double>* %1, <vscale x 8 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_xvse_mask_v_nxv8f64_nxv8f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vse.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvse.mask.nxv8f64.nxv8f64(
+    <vscale x 8 x double> %0,
+    <vscale x 8 x double>* %1,
+    <vscale x 8 x i1> %2,
+    iXLen %3)
+
+  ret void
+}
+

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vss.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vss.ll
@@ -819,6 +819,54 @@ entry:
   ret void
 }
 
+declare void @llvm.riscv.xvsse.nxv4f16.nxv4f16(
+  <vscale x 4 x half>,
+  <vscale x 4 x half>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv4f16_nxv4f16(<vscale x 4 x half>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv4f16_nxv4f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv4f16.nxv4f16(
+    <vscale x 4 x half> undef,
+    <vscale x 4 x half>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv4f16.nxv4f16(
+  <vscale x 4 x half>,
+  <vscale x 4 x half>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv4f16_nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x half>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv4f16_nxv4f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m1, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv4f16.nxv4f16(
+    <vscale x 4 x half> %0,
+    <vscale x 4 x half>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
 declare void @llvm.riscv.xvsse.nxv8i16.nxv8i16(
   <vscale x 8 x i16>,
   <vscale x 8 x i16>*,
@@ -861,6 +909,54 @@ entry:
     <vscale x 8 x i16> %0,
     <vscale x 8 x i16>* %1,
     iXLen %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv8f16.nxv8f16(
+  <vscale x 8 x half>,
+  <vscale x 8 x half>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv8f16_nxv8f16(<vscale x 8 x half>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv8f16_nxv8f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv8f16.nxv8f16(
+    <vscale x 8 x half> undef,
+    <vscale x 8 x half>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv8f16.nxv8f16(
+  <vscale x 8 x half>,
+  <vscale x 8 x half>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv8f16_nxv8f16(<vscale x 8 x half> %0, <vscale x 8 x half>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv8f16_nxv8f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m2, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv8f16.nxv8f16(
+    <vscale x 8 x half> %0,
+    <vscale x 8 x half>* %1,
+    iXLen %2,
     <vscale x 8 x i1> %3,
     iXLen %4)
 
@@ -915,6 +1011,54 @@ entry:
   ret void
 }
 
+declare void @llvm.riscv.xvsse.nxv16f16.nxv16f16(
+  <vscale x 16 x half>,
+  <vscale x 16 x half>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv16f16_nxv16f16(<vscale x 16 x half>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv16f16_nxv16f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv16f16.nxv16f16(
+    <vscale x 16 x half> undef,
+    <vscale x 16 x half>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv16f16.nxv16f16(
+  <vscale x 16 x half>,
+  <vscale x 16 x half>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv16f16_nxv16f16(<vscale x 16 x half> %0, <vscale x 16 x half>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv16f16_nxv16f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m4, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv16f16.nxv16f16(
+    <vscale x 16 x half> %0,
+    <vscale x 16 x half>* %1,
+    iXLen %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
 declare void @llvm.riscv.xvsse.nxv32i16.nxv32i16(
   <vscale x 32 x i16>,
   <vscale x 32 x i16>*,
@@ -957,6 +1101,54 @@ entry:
     <vscale x 32 x i16> %0,
     <vscale x 32 x i16>* %1,
     iXLen %2, 
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv32f16.nxv32f16(
+  <vscale x 32 x half>,
+  <vscale x 32 x half>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv32f16_nxv32f16(<vscale x 32 x half>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv32f16_nxv32f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv32f16.nxv32f16(
+    <vscale x 32 x half> undef,
+    <vscale x 32 x half>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv32f16.nxv32f16(
+  <vscale x 32 x half>,
+  <vscale x 32 x half>*,
+  iXLen,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv32f16_nxv32f16(<vscale x 32 x half> %0, <vscale x 32 x half>* %1, iXLen %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv32f16_nxv32f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e16, m8, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv32f16.nxv32f16(
+    <vscale x 32 x half> %0,
+    <vscale x 32 x half>* %1,
+    iXLen %2,
     <vscale x 32 x i1> %3,
     iXLen %4)
 
@@ -1011,6 +1203,54 @@ entry:
   ret void
 }
 
+declare void @llvm.riscv.xvsse.nxv2f32.nxv2f32(
+  <vscale x 2 x float>,
+  <vscale x 2 x float>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv2f32_nxv2f32(<vscale x 2 x float>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv2f32_nxv2f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv2f32.nxv2f32(
+    <vscale x 2 x float> undef,
+    <vscale x 2 x float>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv2f32.nxv2f32(
+  <vscale x 2 x float>,
+  <vscale x 2 x float>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv2f32_nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x float>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv2f32_nxv2f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m1, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv2f32.nxv2f32(
+    <vscale x 2 x float> %0,
+    <vscale x 2 x float>* %1,
+    iXLen %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
 declare void @llvm.riscv.xvsse.nxv4i32.nxv4i32(
   <vscale x 4 x i32>,
   <vscale x 4 x i32>*,
@@ -1053,6 +1293,54 @@ entry:
     <vscale x 4 x i32> %0,
     <vscale x 4 x i32>* %1,
     iXLen %2, 
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv4f32.nxv4f32(
+  <vscale x 4 x float>,
+  <vscale x 4 x float>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv4f32_nxv4f32(<vscale x 4 x float>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv4f32_nxv4f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv4f32.nxv4f32(
+    <vscale x 4 x float> undef,
+    <vscale x 4 x float>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv4f32.nxv4f32(
+  <vscale x 4 x float>,
+  <vscale x 4 x float>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv4f32_nxv4f32(<vscale x 4 x float> %0, <vscale x 4 x float>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv4f32_nxv4f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m2, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv4f32.nxv4f32(
+    <vscale x 4 x float> %0,
+    <vscale x 4 x float>* %1,
+    iXLen %2,
     <vscale x 4 x i1> %3,
     iXLen %4)
 
@@ -1107,6 +1395,54 @@ entry:
   ret void
 }
 
+declare void @llvm.riscv.xvsse.nxv8f32.nxv8f32(
+  <vscale x 8 x float>,
+  <vscale x 8 x float>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv8f32_nxv8f32(<vscale x 8 x float>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv8f32_nxv8f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv8f32.nxv8f32(
+    <vscale x 8 x float> undef,
+    <vscale x 8 x float>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv8f32.nxv8f32(
+  <vscale x 8 x float>,
+  <vscale x 8 x float>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv8f32_nxv8f32(<vscale x 8 x float> %0, <vscale x 8 x float>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv8f32_nxv8f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m4, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv8f32.nxv8f32(
+    <vscale x 8 x float> %0,
+    <vscale x 8 x float>* %1,
+    iXLen %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
 declare void @llvm.riscv.xvsse.nxv16i32.nxv16i32(
   <vscale x 16 x i32>,
   <vscale x 16 x i32>*,
@@ -1149,6 +1485,54 @@ entry:
     <vscale x 16 x i32> %0,
     <vscale x 16 x i32>* %1,
     iXLen %2, 
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv16f32.nxv16f32(
+  <vscale x 16 x float>,
+  <vscale x 16 x float>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv16f32_nxv16f32(<vscale x 16 x float>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv16f32_nxv16f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv16f32.nxv16f32(
+    <vscale x 16 x float> undef,
+    <vscale x 16 x float>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv16f32.nxv16f32(
+  <vscale x 16 x float>,
+  <vscale x 16 x float>*,
+  iXLen,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv16f32_nxv16f32(<vscale x 16 x float> %0, <vscale x 16 x float>* %1, iXLen %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv16f32_nxv16f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv16f32.nxv16f32(
+    <vscale x 16 x float> %0,
+    <vscale x 16 x float>* %1,
+    iXLen %2,
     <vscale x 16 x i1> %3,
     iXLen %4)
 
@@ -1203,6 +1587,54 @@ entry:
   ret void
 }
 
+declare void @llvm.riscv.xvsse.nxv1f64.nxv1f64(
+  <vscale x 1 x double>,
+  <vscale x 1 x double>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv1f64_nxv1f64(<vscale x 1 x double>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv1f64_nxv1f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv1f64.nxv1f64(
+    <vscale x 1 x double> undef,
+    <vscale x 1 x double>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv1f64.nxv1f64(
+  <vscale x 1 x double>,
+  <vscale x 1 x double>*,
+  iXLen,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv1f64_nxv1f64(<vscale x 1 x double> %0, <vscale x 1 x double>* %1, iXLen %2, <vscale x 1 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv1f64_nxv1f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m1, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv1f64.nxv1f64(
+    <vscale x 1 x double> %0,
+    <vscale x 1 x double>* %1,
+    iXLen %2,
+    <vscale x 1 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
 declare void @llvm.riscv.xvsse.nxv2i64.nxv2i64(
   <vscale x 2 x i64>,
   <vscale x 2 x i64>*,
@@ -1245,6 +1677,54 @@ entry:
     <vscale x 2 x i64> %0,
     <vscale x 2 x i64>* %1,
     iXLen %2, 
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv2f64.nxv2f64(
+  <vscale x 2 x double>,
+  <vscale x 2 x double>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv2f64_nxv2f64(<vscale x 2 x double>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv2f64_nxv2f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv2f64.nxv2f64(
+    <vscale x 2 x double> undef,
+    <vscale x 2 x double>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv2f64.nxv2f64(
+  <vscale x 2 x double>,
+  <vscale x 2 x double>*,
+  iXLen,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv2f64_nxv2f64(<vscale x 2 x double> %0, <vscale x 2 x double>* %1, iXLen %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv2f64_nxv2f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m2, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv2f64.nxv2f64(
+    <vscale x 2 x double> %0,
+    <vscale x 2 x double>* %1,
+    iXLen %2,
     <vscale x 2 x i1> %3,
     iXLen %4)
 
@@ -1299,6 +1779,54 @@ entry:
   ret void
 }
 
+declare void @llvm.riscv.xvsse.nxv4f64.nxv4f64(
+  <vscale x 4 x double>,
+  <vscale x 4 x double>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv4f64_nxv4f64(<vscale x 4 x double>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv4f64_nxv4f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv4f64.nxv4f64(
+    <vscale x 4 x double> undef,
+    <vscale x 4 x double>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv4f64.nxv4f64(
+  <vscale x 4 x double>,
+  <vscale x 4 x double>*,
+  iXLen,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv4f64_nxv4f64(<vscale x 4 x double> %0, <vscale x 4 x double>* %1, iXLen %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv4f64_nxv4f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m4, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv4f64.nxv4f64(
+    <vscale x 4 x double> %0,
+    <vscale x 4 x double>* %1,
+    iXLen %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
 declare void @llvm.riscv.xvsse.nxv8i64.nxv8i64(
   <vscale x 8 x i64>,
   <vscale x 8 x i64>*,
@@ -1341,6 +1869,54 @@ entry:
     <vscale x 8 x i64> %0,
     <vscale x 8 x i64>* %1,
     iXLen %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.nxv8f64.nxv8f64(
+  <vscale x 8 x double>,
+  <vscale x 8 x double>*,
+  iXLen,
+  iXLen);
+
+define void @intrinsic_xvsse_v_nxv8f64_nxv8f64(<vscale x 8 x double>* %0, iXLen %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_v_nxv8f64_nxv8f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.nxv8f64.nxv8f64(
+    <vscale x 8 x double> undef,
+    <vscale x 8 x double>* %0,
+    iXLen %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsse.mask.nxv8f64.nxv8f64(
+  <vscale x 8 x double>,
+  <vscale x 8 x double>*,
+  iXLen,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsse_mask_v_nxv8f64_nxv8f64(<vscale x 8 x double> %0, <vscale x 8 x double>* %1, iXLen %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsse_mask_v_nxv8f64_nxv8f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, d1
+; CHECK-NEXT:    vsse.v v8, (a0), a1, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsse.mask.nxv8f64.nxv8f64(
+    <vscale x 8 x double> %0,
+    <vscale x 8 x double>* %1,
+    iXLen %2,
     <vscale x 8 x i1> %3,
     iXLen %4)
 


### PR DESCRIPTION
In RVV 0.7.1 intrinsic we have things like this:

![截图 2023-11-18 22-10-26](https://github.com/ruyisdk/llvm-project/assets/77868093/a4c5c7f9-3087-42a8-bc20-a3adaeab8f4b)

The corresponding LLVM intrinsic is like:

```LLVM IR
declare <vscale x 4 x half> @llvm.riscv.xvle.nxv4f16.nxv4f16(
  <vscale x 4 x half>,
  <vscale x 4 x half>*,
  i64);

declare <vscale x 2 x float> @llvm.riscv.xvle.nxv2f32.nxv2f32(
  <vscale x 2 x float>,
  <vscale x 2 x float>*,
  i64);

declare <vscale x 1 x double> @llvm.riscv.xvle.nxv1f64.nxv1f64(
  <vscale x 1 x double>,
  <vscale x 1 x double>*,
  i64);
```

Currently if we directly define these intrinsic LLVM would crash because it thinks the xtheadv extension does not support this. So I modified the `hasVInstructionsF` methods to fix the crash.

This PR does fix the crash, but it is conflicted with #23 (namely, [here](https://github.com/ruyisdk/llvm-project/pull/23/commits/9cdd6061f6373e7a8b0192e90b381b88d4fe6b21#diff-1e4fe63a7b9022aa848db0a3b7b2ccfe5759ff05b06acfb6c4be7db3ee6f9a3eR175-R177)) and I'm not completely sure if it is okay to add `HasVendorXTHeadV` to the methods.

Please let me know if you have any suggestions...