### PR TITLE
[LLVM][RVV 0.7.1] Emulate whole vector register move instructions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -14659,6 +14659,8 @@ static MachineBasicBlock *emitXWholeStore(MachineInstr &MI,
 
 static MachineBasicBlock *emitXWholeMove(MachineInstr &MI,
                                          MachineBasicBlock *BB, unsigned NREGS) {
+  assert((NREGS == 1 || NREGS == 2 || NREGS == 4 || NREGS == 8) &&
+         "Unexpected NREGS");
   DebugLoc DL = MI.getDebugLoc();
 
   auto *TII = BB->getParent()->getSubtarget().getInstrInfo();
@@ -14682,7 +14684,6 @@ static MachineBasicBlock *emitXWholeMove(MachineInstr &MI,
   auto DstRegNo = MI.getOperand(0).getReg();
   auto SrcRegNo = MI.getOperand(1).getReg();
 
-  // NREGS = 1, 2, 4, 8
   for (unsigned I = 0; I < NREGS; ++I) {
     auto DstReg = TRI->getSubReg(DstRegNo, RISCV::sub_vrm1_0 + I);
     auto SrcReg = TRI->getSubReg(SrcRegNo, RISCV::sub_vrm1_0 + I);

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -14679,14 +14679,15 @@ static MachineBasicBlock *emitXWholeMove(MachineInstr &MI,
   // when `NF` (much like the `NREGS` here) is not 1.
   // TODO[RVV 0.7.1]: be like vector operations?
 
-  auto DstReg = MI.getOperand(0).getReg();
-  auto SrcReg = MI.getOperand(1).getReg();
+  auto DstRegNo = MI.getOperand(0).getReg();
+  auto SrcRegNo = MI.getOperand(1).getReg();
 
+  // NREGS = 1, 2, 4, 8
   for (unsigned I = 0; I < NREGS; ++I) {
-    auto VReg = MRI->createVirtualRegister(&RISCV::VRRegClass);
+    auto DstReg = TRI->getSubReg(DstRegNo, RISCV::sub_vrm1_0 + I);
+    auto SrcReg = TRI->getSubReg(SrcRegNo, RISCV::sub_vrm1_0 + I);
     BuildMI(*BB, MI, DL, TII->get(RISCV::XVMV_V_V), DstReg)
         .addReg(SrcReg);
-    // How to increment `DstReg` and `SrcReg` depends on the register class?
   }
 
   MI.eraseFromParent();

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -536,6 +536,7 @@ void RISCVInstrInfo::storeRegToStackSlot(MachineBasicBlock &MBB,
 
   MachineFunction *MF = MBB.getParent();
   MachineFrameInfo &MFI = MF->getFrameInfo();
+  bool XTHeadV = STI.hasVendorXTHeadV();
 
   unsigned Opcode;
   bool IsScalableVector = true;
@@ -556,13 +557,17 @@ void RISCVInstrInfo::storeRegToStackSlot(MachineBasicBlock &MBB,
     Opcode = RISCV::FSD;
     IsScalableVector = false;
   } else if (RISCV::VRRegClass.hasSubClassEq(RC)) {
-    Opcode = RISCV::VS1R_V;
+    // [RVV 0.7.1] Spec:
+    // The vector whole register store instructions are encoded
+    // similar to unmasked unit-stride store of elements with EEW=8.
+    // Same for the following similar cases.
+    Opcode = XTHeadV ? RISCV::PseudoXVS1RE8_V : RISCV::VS1R_V;
   } else if (RISCV::VRM2RegClass.hasSubClassEq(RC)) {
-    Opcode = RISCV::VS2R_V;
+    Opcode = XTHeadV ? RISCV::PseudoXVS2RE8_V : RISCV::VS2R_V;
   } else if (RISCV::VRM4RegClass.hasSubClassEq(RC)) {
-    Opcode = RISCV::VS4R_V;
+    Opcode = XTHeadV ? RISCV::PseudoXVS4RE8_V : RISCV::VS4R_V;
   } else if (RISCV::VRM8RegClass.hasSubClassEq(RC)) {
-    Opcode = RISCV::VS8R_V;
+    Opcode = XTHeadV ? RISCV::PseudoXVS8RE8_V : RISCV::VS8R_V;
   } else if (RISCV::VRN2M1RegClass.hasSubClassEq(RC))
     Opcode = RISCV::PseudoVSPILL2_M1;
   else if (RISCV::VRN2M2RegClass.hasSubClassEq(RC))
@@ -623,6 +628,7 @@ void RISCVInstrInfo::loadRegFromStackSlot(MachineBasicBlock &MBB,
 
   MachineFunction *MF = MBB.getParent();
   MachineFrameInfo &MFI = MF->getFrameInfo();
+  bool XTHeadV = STI.hasVendorXTHeadV();
 
   unsigned Opcode;
   bool IsScalableVector = true;
@@ -643,13 +649,13 @@ void RISCVInstrInfo::loadRegFromStackSlot(MachineBasicBlock &MBB,
     Opcode = RISCV::FLD;
     IsScalableVector = false;
   } else if (RISCV::VRRegClass.hasSubClassEq(RC)) {
-    Opcode = RISCV::VL1RE8_V;
+    Opcode = XTHeadV ? RISCV::PseudoXVL1RE8_V : RISCV::VL1RE8_V;
   } else if (RISCV::VRM2RegClass.hasSubClassEq(RC)) {
-    Opcode = RISCV::VL2RE8_V;
+    Opcode = XTHeadV ? RISCV::PseudoXVL2RE8_V : RISCV::VL2RE8_V;
   } else if (RISCV::VRM4RegClass.hasSubClassEq(RC)) {
-    Opcode = RISCV::VL4RE8_V;
+    Opcode = XTHeadV ? RISCV::PseudoXVL4RE8_V : RISCV::VL4RE8_V;
   } else if (RISCV::VRM8RegClass.hasSubClassEq(RC)) {
-    Opcode = RISCV::VL8RE8_V;
+    Opcode = XTHeadV ? RISCV::PseudoXVL8RE8_V : RISCV::VL8RE8_V;
   } else if (RISCV::VRN2M1RegClass.hasSubClassEq(RC))
     Opcode = RISCV::PseudoVRELOAD2_M1;
   else if (RISCV::VRN2M2RegClass.hasSubClassEq(RC))

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -309,6 +309,7 @@ void RISCVInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
                                  const DebugLoc &DL, MCRegister DstReg,
                                  MCRegister SrcReg, bool KillSrc) const {
   const TargetRegisterInfo *TRI = STI.getRegisterInfo();
+  bool XTHeadV = STI.hasVendorXTHeadV();
 
   if (RISCV::GPRPF64RegClass.contains(DstReg))
     DstReg = TRI->getSubReg(DstReg, RISCV::sub_32);
@@ -358,16 +359,16 @@ void RISCVInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
     Opc = RISCV::FSGNJ_D;
     IsScalableVector = false;
   } else if (RISCV::VRRegClass.contains(DstReg, SrcReg)) {
-    Opc = RISCV::VMV1R_V;
+    Opc = XTHeadV ? RISCV::PseudoXVMV1R_V : RISCV::VMV1R_V;
     LMul = RISCVII::LMUL_1;
   } else if (RISCV::VRM2RegClass.contains(DstReg, SrcReg)) {
-    Opc = RISCV::VMV2R_V;
+    Opc = XTHeadV ? RISCV::PseudoXVMV2R_V : RISCV::VMV2R_V;
     LMul = RISCVII::LMUL_2;
   } else if (RISCV::VRM4RegClass.contains(DstReg, SrcReg)) {
-    Opc = RISCV::VMV4R_V;
+    Opc = XTHeadV ? RISCV::PseudoXVMV4R_V : RISCV::VMV4R_V;
     LMul = RISCVII::LMUL_4;
   } else if (RISCV::VRM8RegClass.contains(DstReg, SrcReg)) {
-    Opc = RISCV::VMV8R_V;
+    Opc = XTHeadV ? RISCV::PseudoXVMV8R_V : RISCV::VMV8R_V;
     LMul = RISCVII::LMUL_8;
   } else if (RISCV::VRN2M1RegClass.contains(DstReg, SrcReg)) {
     Opc = RISCV::VMV1R_V;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -449,7 +449,7 @@ let Predicates = [HasVendorXTHeadV] in {
 // 7. Vector Loads and Stores
 // for emulating Vector Load/Store Whole Register Instructions in RVV 1.0
 //===----------------------------------------------------------------------===//
-class VPseudoWholeLoad<Instruction instr, LMULInfo m, RegisterClass VRC>
+class XVPseudoWholeLoad<Instruction instr, LMULInfo m, RegisterClass VRC>
   : VPseudo<instr, m, (outs VRC:$vd),   (ins GPRMemZeroOffset:$rs1)> {
 }
 
@@ -457,12 +457,12 @@ multiclass XVPseudoWholeLoadN<bits<3> nf, LMULInfo m, RegisterClass VRC> {
   foreach l = [8, 16, 32, 64] in {
     defvar s = !cast<SchedWrite>("WriteVLD" # !add(nf, 1) # "R");
 
-    def E # l # _V : VPseudoWholeLoad<XVLE_V, m, VRC>,
+    def E # l # _V : XVPseudoWholeLoad<XVLE_V, m, VRC>,
                      Sched<[s, ReadVLDX]>;
   }
 }
 
-class VPseudoWholeStore<Instruction instr, LMULInfo m, RegisterClass VRC>
+class XVPseudoWholeStore<Instruction instr, LMULInfo m, RegisterClass VRC>
   : VPseudo<instr, m, (outs),   (ins VRC:$vs3, GPRMemZeroOffset:$rs1)> {
 }
 
@@ -471,7 +471,7 @@ multiclass XVPseudoWholeStoreN<bits<3> nf, LMULInfo m, RegisterClass VRC> {
     defvar sw = !cast<SchedWrite>("WriteVST" # !add(nf, 1) # "R");
     defvar sr = !cast<SchedRead>("ReadVST" # !add(nf, 1) # "R");
 
-    def E # l # _V : VPseudoWholeStore<XVSE_V, m, VRC>,
+    def E # l # _V : XVPseudoWholeStore<XVSE_V, m, VRC>,
                      Sched<[sw, sr, ReadVSTX]>;
   }
 }
@@ -759,3 +759,21 @@ foreach vti = AllXVectors in {
     // TODO: vmv.v.x, vmv.v.i
   }
 }
+
+//===----------------------------------------------------------------------===//
+// 12.14. Vector Integer Merge and Move Instructions
+// for emulating Whole Vector Register Move Instructions in RVV 1.0
+//===----------------------------------------------------------------------===//
+
+class XVPseudoWholeMove<Instruction instr, LMULInfo m, RegisterClass VRC>
+  : VPseudo<instr, m, (outs VRC:$vd), (ins VRC:$vs1)> {
+}
+
+let Predicates = [HasVendorXTHeadV] in {
+  let hasSideEffects = 0, mayLoad = 0, mayStore = 0, isCodeGenOnly = 1, usesCustomInserter = 1 in {
+    def PseudoXVMV1R_V : XVPseudoWholeMove<XVMV_V_V, V_M1, VR>;
+    def PseudoXVMV2R_V : XVPseudoWholeMove<XVMV_V_V, V_M2, VRM2>;
+    def PseudoXVMV4R_V : XVPseudoWholeMove<XVMV_V_V, V_M4, VRM4>;
+    def PseudoXVMV8R_V : XVPseudoWholeMove<XVMV_V_V, V_M8, VRM8>;
+  }
+} // Predicates = [HasVendorXTHeadV]

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -714,7 +714,6 @@ let Predicates = [HasVendorXTHeadV] in {
 } // Predicates = [HasVendorXTHeadV]
 
 let Predicates = [HasVendorXTHeadV] in {
-  // TODO: try `int_riscv_vadd`
   defm : VPatBinaryV_VV_VX_VI<"int_riscv_xvadd", "PseudoXVADD", AllIntegerXVectors>;
 } // Predicates = [HasVendorXTHeadV]
 
@@ -751,7 +750,6 @@ let Predicates = [HasVendorXTHeadV] in {
 foreach vti = AllXVectors in {
   let Predicates = GetXVTypePredicates<vti>.Predicates in {
     // vmv.v.v
-    // TODO: try `int_riscv_vmv_v_v`
     def : Pat<(vti.Vector (int_riscv_xvmv_v_v (vti.Vector vti.RegClass:$passthru),
                                               (vti.Vector vti.RegClass:$rs1),
                                               VLOpFrag)),

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -766,14 +766,19 @@ foreach vti = AllXVectors in {
 //===----------------------------------------------------------------------===//
 
 class XVPseudoWholeMove<Instruction instr, LMULInfo m, RegisterClass VRC>
-  : VPseudo<instr, m, (outs VRC:$vd), (ins VRC:$vs1)> {
+  : VPseudo<instr, m, (outs VRC:$vd), (ins VRC:$vs2)> {
 }
 
 let Predicates = [HasVendorXTHeadV] in {
   let hasSideEffects = 0, mayLoad = 0, mayStore = 0, isCodeGenOnly = 1, usesCustomInserter = 1 in {
+    // Note: All `LMULInfo` and `RegisterClass` should be `V_M1` and `VR` respectively.
+    // From RVV Spec 1.0: "These instructions are intended to aid compilers to
+    // shuffle vector registers without needing to know or change vl or vtype."
+    // The 1, 2, 4, 8 in suffixes are "the number of individual vector registers, NREG, to copy",
+    // rather than LMUL.
     def PseudoXVMV1R_V : XVPseudoWholeMove<XVMV_V_V, V_M1, VR>;
-    def PseudoXVMV2R_V : XVPseudoWholeMove<XVMV_V_V, V_M2, VRM2>;
-    def PseudoXVMV4R_V : XVPseudoWholeMove<XVMV_V_V, V_M4, VRM4>;
-    def PseudoXVMV8R_V : XVPseudoWholeMove<XVMV_V_V, V_M8, VRM8>;
+    def PseudoXVMV2R_V : XVPseudoWholeMove<XVMV_V_V, V_M1, VR>;
+    def PseudoXVMV4R_V : XVPseudoWholeMove<XVMV_V_V, V_M1, VR>;
+    def PseudoXVMV8R_V : XVPseudoWholeMove<XVMV_V_V, V_M1, VR>;
   }
 } // Predicates = [HasVendorXTHeadV]


### PR DESCRIPTION
Follow up of #23, when `isConvertibleToVMV_V_V` returns `false`, we still have to emulate such `vmv<1/2/4/8>r.`.

From RVV Spec 1.0:
```
vmv<nr>r.v vd,  vs2  # General form
vmv1r.v    v1,  v2   # Copy v1=v2
vmv2r.v    v10, v12  # Copy v10=v12; v11=v13
vmv4r.v    v4,  v8   # Copy v4=v8; v5=v9; v6=v10; v7=v11
vmv8r.v    v0,  v8   # Copy v0=v8; v1=v9; ...; v7=v15
```

This PR expands these `vmv<n>r.v` to a sequence of `vmv.v.v` instructions accordingly.