### PR TITLE
[LLVM] [RVV 0.7.1] Implement RVV 0.7.1 indexed load/store intrinsics.

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
@@ -172,6 +172,42 @@ let TargetPrefix = "riscv" in {
   def int_riscv_xvssh_mask : XVSStoreMasked;
   def int_riscv_xvssw_mask : XVSStoreMasked;
   def int_riscv_xvsse_mask : XVSStoreMasked;
+
+  // 7.6. Vector Indexed Instructions
+  // For indexed load with passthru operand
+  // Input: (passthru, pointer, index, vl)
+  class XVILoad
+        : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
+                    [LLVMMatchType<0>, llvm_ptr_ty,
+                     llvm_anyvector_ty, llvm_anyint_ty],
+                    [NoCapture<ArgIndex<1>>, IntrReadMem]>, RISCVVIntrinsic {
+    let VLOperand = 3;
+  }
+  // For indexed load with mask
+  // Input: (maskedoff, pointer, index, mask, vl)
+  class XVILoadMasked
+        : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
+                    [LLVMMatchType<0>, llvm_ptr_ty, llvm_anyvector_ty,
+                     LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>, llvm_anyint_ty],
+                    [NoCapture<ArgIndex<1>>, IntrReadMem]>,
+                    RISCVVIntrinsic {
+    let VLOperand = 4;
+  }
+
+  def int_riscv_xvlxb : XVILoad;
+  def int_riscv_xvlxh : XVILoad;
+  def int_riscv_xvlxw : XVILoad;
+  def int_riscv_xvlxe : XVILoad;
+  def int_riscv_xvlxbu : XVILoad;
+  def int_riscv_xvlxhu : XVILoad;
+  def int_riscv_xvlxwu : XVILoad;
+  def int_riscv_xvlxb_mask : XVILoadMasked;
+  def int_riscv_xvlxh_mask : XVILoadMasked;
+  def int_riscv_xvlxw_mask : XVILoadMasked;
+  def int_riscv_xvlxe_mask : XVILoadMasked;
+  def int_riscv_xvlxbu_mask : XVILoadMasked;
+  def int_riscv_xvlxhu_mask : XVILoadMasked;
+  def int_riscv_xvlxwu_mask : XVILoadMasked;
 } // TargetPrefix = "riscv"
 
 let TargetPrefix = "riscv" in {

--- a/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCVXTHeadV.td
@@ -194,6 +194,25 @@ let TargetPrefix = "riscv" in {
     let VLOperand = 4;
   }
 
+  // For indexed store
+  // Input: (vector_in, pointer, index, vl)
+  class XVIStore
+        : DefaultAttrsIntrinsic<[],
+                    [llvm_anyvector_ty, llvm_ptr_ty,
+                     llvm_anyvector_ty, llvm_anyint_ty],
+                    [NoCapture<ArgIndex<1>>, IntrWriteMem]>, RISCVVIntrinsic {
+    let VLOperand = 3;
+  }
+  // For indexed store with mask
+  // Input: (vector_in, pointer, index, mask, vl)
+  class XVIStoreMasked
+        : DefaultAttrsIntrinsic<[],
+                    [llvm_anyvector_ty, llvm_ptr_ty, llvm_anyvector_ty,
+                     LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>, llvm_anyint_ty],
+                    [NoCapture<ArgIndex<1>>, IntrWriteMem]>, RISCVVIntrinsic {
+    let VLOperand = 4;
+  }
+
   def int_riscv_xvlxb : XVILoad;
   def int_riscv_xvlxh : XVILoad;
   def int_riscv_xvlxw : XVILoad;
@@ -208,6 +227,15 @@ let TargetPrefix = "riscv" in {
   def int_riscv_xvlxbu_mask : XVILoadMasked;
   def int_riscv_xvlxhu_mask : XVILoadMasked;
   def int_riscv_xvlxwu_mask : XVILoadMasked;
+
+  def int_riscv_xvsxb : XVIStore;
+  def int_riscv_xvsxh : XVIStore;
+  def int_riscv_xvsxw : XVIStore;
+  def int_riscv_xvsxe : XVIStore;
+  def int_riscv_xvsxb_mask : XVIStoreMasked;
+  def int_riscv_xvsxh_mask : XVIStoreMasked;
+  def int_riscv_xvsxw_mask : XVIStoreMasked;
+  def int_riscv_xvsxe_mask : XVIStoreMasked;
 } // TargetPrefix = "riscv"
 
 let TargetPrefix = "riscv" in {

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
@@ -147,13 +147,12 @@ public:
                                   bool IsMasked, bool IsStridedOrIndexed,
                                   SmallVectorImpl<SDValue> &Operands,
                                   bool IsLoad = false, MVT *IndexVT = nullptr);
-  void addXTHeadVLoadStoreOperands(SDNode *Node, unsigned SEWImm,
-                                  const SDLoc &DL, unsigned CurOp,
-                                  bool IsMasked, bool IsStrided,
-                                  SmallVectorImpl<SDValue> &Operands);
+  void addXTHeadVLoadStoreOperands(SDNode *Node, unsigned SEWImm, const SDLoc &DL,
+                                   unsigned CurOp, bool IsMasked, bool IsStridedOrIndexed,
+                                  SmallVectorImpl<SDValue> &Operands, MVT *IndexVT = nullptr);
 
-  void selectXVL(SDNode *Node, const SDLoc& DL, unsigned IntNo,
-                 bool IsUnsigned, bool IsMasked, bool IsStrided, bool IsE);
+  void selectXVL(SDNode *Node, const SDLoc& DL, unsigned IntNo, bool IsUnsigned,
+                 bool IsMasked, bool IsStrided, bool IsIndexed, bool IsE);
   void selectXVS(SDNode *Node, const SDLoc& DL, unsigned IntNo,
                  bool IsMasked, bool IsStrided, bool IsE);
   void selectVLSEG(SDNode *Node, bool IsMasked, bool IsStrided);
@@ -250,6 +249,7 @@ struct VLEPseudo {
 struct XVLPseudo {
   uint16_t Masked : 1;
   uint16_t Strided : 1;
+  uint16_t Indexed : 1;
   uint16_t Unsigned : 1;
   uint16_t IsE : 1;
   uint16_t Log2MEM : 3;

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
@@ -154,7 +154,7 @@ public:
   void selectXVL(SDNode *Node, const SDLoc& DL, unsigned IntNo, bool IsUnsigned,
                  bool IsMasked, bool IsStrided, bool IsIndexed, bool IsE);
   void selectXVS(SDNode *Node, const SDLoc& DL, unsigned IntNo,
-                 bool IsMasked, bool IsStrided, bool IsE);
+                 bool IsMasked, bool IsStrided, bool IsIndexed, bool IsE);
   void selectVLSEG(SDNode *Node, bool IsMasked, bool IsStrided);
   void selectVLSEGFF(SDNode *Node, bool IsMasked);
   void selectVLXSEG(SDNode *Node, bool IsMasked, bool IsOrdered);
@@ -269,6 +269,7 @@ struct VSEPseudo {
 struct XVSPseudo {
   uint16_t Masked : 1;
   uint16_t Strided : 1;
+  uint16_t Indexed : 1;
   uint16_t IsE : 1;
   uint16_t Log2MEM : 3;
   uint16_t Log2SEW : 3;

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -1418,6 +1418,14 @@ bool RISCVTargetLowering::getTgtMemIntrinsic(IntrinsicInfo &Info,
   case Intrinsic::riscv_xvssw_mask:
   case Intrinsic::riscv_xvsse:
   case Intrinsic::riscv_xvsse_mask:
+  case Intrinsic::riscv_xvsxb:
+  case Intrinsic::riscv_xvsxb_mask:
+  case Intrinsic::riscv_xvsxh:
+  case Intrinsic::riscv_xvsxh_mask:
+  case Intrinsic::riscv_xvsxw:
+  case Intrinsic::riscv_xvsxw_mask:
+  case Intrinsic::riscv_xvsxe:
+  case Intrinsic::riscv_xvsxe_mask:
     if (!Subtarget.hasVendorXTHeadV())
       return false;
     return SetRVVLoadStoreInfo(/*PtrOp*/ 1,

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -1382,6 +1382,20 @@ bool RISCVTargetLowering::getTgtMemIntrinsic(IntrinsicInfo &Info,
   case Intrinsic::riscv_xvlswu_mask:
   case Intrinsic::riscv_xvlse:
   case Intrinsic::riscv_xvlse_mask:
+  case Intrinsic::riscv_xvlxb:
+  case Intrinsic::riscv_xvlxbu:
+  case Intrinsic::riscv_xvlxb_mask:
+  case Intrinsic::riscv_xvlxbu_mask:
+  case Intrinsic::riscv_xvlxh:
+  case Intrinsic::riscv_xvlxhu:
+  case Intrinsic::riscv_xvlxh_mask:
+  case Intrinsic::riscv_xvlxhu_mask:
+  case Intrinsic::riscv_xvlxw:
+  case Intrinsic::riscv_xvlxwu:
+  case Intrinsic::riscv_xvlxw_mask:
+  case Intrinsic::riscv_xvlxwu_mask:
+  case Intrinsic::riscv_xvlxe:
+  case Intrinsic::riscv_xvlxe_mask:
     if (!Subtarget.hasVendorXTHeadV())
       return false;
     return SetRVVLoadStoreInfo(/*PtrOp*/ 1,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -88,9 +88,11 @@ class GetXVTypePredicates<VTypeInfo vti> {
                                      true : [HasVendorXTHeadV]);
 }
 
-class XTHeadVVL<bit M, bit ST, bit U, bit E, bits<3> ME, bits<3> S, bits<3> L> {
+class XTHeadVVL<bit M, bit ST, bit I, bit U, bit E,
+                bits<3> ME, bits<3> S, bits<3> L> {
   bits<1> Masked = M;
   bits<1> Strided = ST;
+  bits<1> Indexed = I;
   bits<1> Unsigned = U;
   bits<1> IsE = E;
   bits<3> Log2MEM = ME;
@@ -102,8 +104,10 @@ class XTHeadVVL<bit M, bit ST, bit U, bit E, bits<3> ME, bits<3> S, bits<3> L> {
 def XTHeadVVLTable : GenericTable {
   let FilterClass = "XTHeadVVL";
   let CppTypeName = "XVLPseudo";
-  let Fields = ["Masked", "Strided", "Unsigned", "IsE", "Log2MEM", "Log2SEW", "LMUL", "Pseudo"];
-  let PrimaryKey = ["Masked", "Strided", "Unsigned", "IsE", "Log2MEM", "Log2SEW", "LMUL"];
+  let Fields = ["Masked", "Strided", "Indexed", "Unsigned",
+                "IsE", "Log2MEM", "Log2SEW", "LMUL", "Pseudo"];
+  let PrimaryKey = ["Masked", "Strided", "Indexed", "Unsigned",
+                    "IsE", "Log2MEM", "Log2SEW", "LMUL"];
   let PrimaryKeyName = "getXVLPseudo";
 }
 
@@ -169,7 +173,7 @@ class XVPseudoUSLoadNoMask<VReg RetClass, int MEM, int REG, bit unsigned, bit e>
       Pseudo<(outs RetClass:$rd),
              (ins RetClass:$dest, GPRMem:$rs1, AVL:$vl, ixlenimm:$sew),[]>,
       RISCVVPseudo,
-      XTHeadVVL</*Masked*/0, /*Strided*/0, unsigned, e,
+      XTHeadVVL</*Masked*/0, /*Strided*/0, /*Indexed*/0, unsigned, e,
                 !logtwo(MEM), !logtwo(REG), VLMul> {
   let mayLoad = 1;
   let mayStore = 0;
@@ -185,7 +189,7 @@ class XVPseudoUSLoadMask<VReg RetClass, int MEM, int REG, bit unsigned, bit e> :
                    GPRMem:$rs1,
                    VMaskOp:$vm, AVL:$vl, ixlenimm:$sew),[]>,
       RISCVVPseudo,
-      XTHeadVVL</*Masked*/1, /*Strided*/0, unsigned, e,
+      XTHeadVVL</*Masked*/1, /*Strided*/0, /*Indexed*/0, unsigned, e,
                 !logtwo(MEM), !logtwo(REG), VLMul> {
   let mayLoad = 1;
   let mayStore = 0;
@@ -309,7 +313,7 @@ class XVPseudoSLoadNoMask<VReg RetClass, int MEM, int REG, bit unsigned, bit e>:
              (ins RetClass:$dest, GPRMem:$rs1, GPR:$rs2, AVL:$vl,
                   ixlenimm:$sew),[]>,
       RISCVVPseudo,
-      XTHeadVVL</*Masked*/0, /*Strided*/1, unsigned, e,
+      XTHeadVVL</*Masked*/0, /*Strided*/1, /*Indexed*/0, unsigned, e,
                 !logtwo(MEM), !logtwo(REG), VLMul> {
   let mayLoad = 1;
   let mayStore = 0;
@@ -325,7 +329,7 @@ class XVPseudoSLoadMask<VReg RetClass, int MEM, int REG, bit unsigned, bit e>:
                    GPRMem:$rs1, GPR:$rs2,
                    VMaskOp:$vm, AVL:$vl, ixlenimm:$sew),[]>,
       RISCVVPseudo,
-      XTHeadVVL</*Masked*/1, /*Strided*/1, unsigned, e,
+      XTHeadVVL</*Masked*/1, /*Strided*/1, /*Indexed*/0, unsigned, e,
                 !logtwo(MEM), !logtwo(REG), VLMul> {
   let mayLoad = 1;
   let mayStore = 0;
@@ -438,11 +442,89 @@ multiclass XVPseudoSStore {
   }
 }
 
+// 7.6 Vector Indexed Instructions
+class XVPseudoILoadNoMask<VReg RetClass, int MEM, int REG, bit unsigned, bit e>:
+      Pseudo<(outs RetClass:$rd),
+             (ins RetClass:$dest, GPRMem:$rs1, RetClass:$rs2,
+              AVL:$vl, ixlenimm:$sew),[]>,
+      RISCVVPseudo,
+      XTHeadVVL</*Masked*/0, /*Strided*/0, /*Indexed*/1, unsigned, e,
+                !logtwo(MEM), !logtwo(REG), VLMul> {
+  let mayLoad = 1;
+  let mayStore = 0;
+  let hasSideEffects = 0;
+  let HasVLOp = 1;
+  let HasSEWOp = 1;
+  let Constraints = "$rd = $dest";
+}
+
+class XVPseudoILoadMask<VReg RetClass, int MEM, int REG, bit unsigned, bit e>:
+      Pseudo<(outs GetVRegNoV0<RetClass>.R:$rd),
+              (ins GetVRegNoV0<RetClass>.R:$merge,
+                   GPRMem:$rs1, RetClass:$rs2,
+                   VMaskOp:$vm, AVL:$vl, ixlenimm:$sew),[]>,
+      RISCVVPseudo,
+      XTHeadVVL</*Masked*/1, /*Strided*/0, /*Indexed*/1, unsigned, e,
+                !logtwo(MEM), !logtwo(REG), VLMul> {
+  let mayLoad = 1;
+  let mayStore = 0;
+  let hasSideEffects = 0;
+  let HasVLOp = 1;
+  let HasSEWOp = 1;
+  let Constraints = "$rd = $merge";
+}
+
+multiclass XVPseudoILoad {
+  foreach mem = [8, 16, 32] in {
+    foreach lmul = MxListXTHeadV in {
+      defvar LInfo = lmul.MX;
+      defvar vreg = lmul.vrclass;
+      defvar tag = MemBitsToTag<mem>.ret;
+      foreach reg = EEWList in {
+        if !ge(reg, mem) then {
+          let VLMul = lmul.value, SEW = mem in {
+            def "X" # tag # "_V_E" # reg # "_" # LInfo :
+              XVPseudoILoadNoMask<vreg, mem, reg, 0, 0>,
+              VLXSched<mem, "O", LInfo, LInfo>;
+            def "X" # tag # "U_V_E" # reg # "_" # LInfo :
+              XVPseudoILoadNoMask<vreg, mem, reg, 1, 0>,
+              VLXSched<mem, "O", LInfo, LInfo>;
+            def "X" # tag # "_V_E" # reg # "_" # LInfo # "_MASK" :
+              XVPseudoILoadMask<vreg, mem, reg, 0, 0>,
+              RISCVMaskedPseudo<MaskIdx=3>,
+              VLXSched<mem, "O", LInfo, LInfo>;
+            def "X" # tag # "U_V_E" # reg # "_" # LInfo # "_MASK" :
+              XVPseudoILoadMask<vreg, mem, reg, 1, 0>,
+              RISCVMaskedPseudo<MaskIdx=3>,
+              VLXSched<mem, "O", LInfo, LInfo>;
+          }
+        }
+      }
+    }
+  }
+  foreach eew = EEWList in {
+    foreach lmul = MxListXTHeadV in {
+      defvar LInfo = lmul.MX;
+      defvar vreg = lmul.vrclass;
+      let VLMul = lmul.value, SEW = eew in {
+        def "XE_V_E" # eew # "_" # LInfo :
+          XVPseudoILoadNoMask<vreg, eew, eew, 0, 1>,
+          VLXSched<eew, "O", LInfo, LInfo>;
+        def "XE_V_E" # eew # "_" # LInfo # "_MASK" :
+          XVPseudoILoadMask<vreg, eew, eew, 0, 1>,
+          RISCVMaskedPseudo<MaskIdx=3>,
+          VLXSched<eew, "O", LInfo, LInfo>;
+      }
+    }
+  }
+}
+
 let Predicates = [HasVendorXTHeadV] in {
   defm PseudoXVL : XVPseudoUSLoad;
   defm PseudoXVS : XVPseudoUSStore;
   defm PseudoXVL : XVPseudoSLoad;
   defm PseudoXVS : XVPseudoSStore;
+  defm PseudoXVL : XVPseudoILoad;
 } // Predicates = [HasVendorXTHeadV]
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -111,9 +111,10 @@ def XTHeadVVLTable : GenericTable {
   let PrimaryKeyName = "getXVLPseudo";
 }
 
-class XTHeadVVS<bit M, bit ST, bit E, bits<3> ME, bits<3> S, bits<3> L> {
+class XTHeadVVS<bit M, bit ST, bit I, bit E, bits<3> ME, bits<3> S, bits<3> L> {
   bits<1> Masked = M;
   bits<1> Strided = ST;
+  bits<1> Indexed = I;
   bits<1> IsE = E;
   bits<3> Log2MEM = ME;
   bits<3> Log2SEW = S;
@@ -124,8 +125,10 @@ class XTHeadVVS<bit M, bit ST, bit E, bits<3> ME, bits<3> S, bits<3> L> {
 def XTHeadVVSTable : GenericTable {
   let FilterClass = "XTHeadVVS";
   let CppTypeName = "XVSPseudo";
-  let Fields = ["Masked", "Strided", "IsE", "Log2MEM", "Log2SEW", "LMUL", "Pseudo"];
-  let PrimaryKey = ["Masked", "Strided", "IsE", "Log2MEM", "Log2SEW", "LMUL"];
+  let Fields = ["Masked", "Strided", "Indexed", "IsE",
+                "Log2MEM", "Log2SEW", "LMUL", "Pseudo"];
+  let PrimaryKey = ["Masked", "Strided", "Indexed", "IsE",
+                    "Log2MEM", "Log2SEW", "LMUL"];
   let PrimaryKeyName = "getXVSPseudo";
 }
 
@@ -203,7 +206,8 @@ class XVPseudoUSStoreNoMask<VReg StClass, int MEM, int REG, bit e>:
       Pseudo<(outs),
               (ins StClass:$rd, GPRMem:$rs1, AVL:$vl, ixlenimm:$sew),[]>,
       RISCVVPseudo,
-      XTHeadVVS</*Masked*/0, /*Strided*/0, e, !logtwo(MEM), !logtwo(REG), VLMul> {
+      XTHeadVVS</*Masked*/0, /*Strided*/0, /*Indexed*/0, e,
+                !logtwo(MEM), !logtwo(REG), VLMul> {
   let mayLoad = 0;
   let mayStore = 1;
   let hasSideEffects = 0;
@@ -215,7 +219,8 @@ class XVPseudoUSStoreMask<VReg StClass, int MEM, int REG, int e>:
       Pseudo<(outs),
               (ins StClass:$rd, GPRMem:$rs1, VMaskOp:$vm, AVL:$vl, ixlenimm:$sew),[]>,
       RISCVVPseudo,
-      XTHeadVVS</*Masked*/1, /*Strided*/0, e, !logtwo(MEM), !logtwo(REG), VLMul> {
+      XTHeadVVS</*Masked*/1, /*Strided*/0, /*Indexed*/0, e,
+                !logtwo(MEM), !logtwo(REG), VLMul> {
   let mayLoad = 0;
   let mayStore = 1;
   let hasSideEffects = 0;
@@ -343,7 +348,8 @@ class XVPseudoSStoreNoMask<VReg StClass, int MEM, int REG, bit e>:
       Pseudo<(outs),
               (ins StClass:$rd, GPRMem:$rs1, GPR:$rs2, AVL:$vl, ixlenimm:$sew),[]>,
       RISCVVPseudo,
-      XTHeadVVS</*Masked*/0, /*Strided*/1, e, !logtwo(MEM), !logtwo(REG), VLMul> {
+      XTHeadVVS</*Masked*/0, /*Strided*/1, /*Indexed*/0, e,
+                !logtwo(MEM), !logtwo(REG), VLMul> {
   let mayLoad = 0;
   let mayStore = 1;
   let hasSideEffects = 0;
@@ -355,7 +361,8 @@ class XVPseudoSStoreMask<VReg StClass, int MEM, int REG, int e>:
       Pseudo<(outs),
               (ins StClass:$rd, GPRMem:$rs1, GPR:$rs2, VMaskOp:$vm, AVL:$vl, ixlenimm:$sew),[]>,
       RISCVVPseudo,
-      XTHeadVVS</*Masked*/1, /*Strided*/1, e, !logtwo(MEM), !logtwo(REG), VLMul> {
+      XTHeadVVS</*Masked*/1, /*Strided*/1, /*Indexed*/0, e,
+                !logtwo(MEM), !logtwo(REG), VLMul> {
   let mayLoad = 0;
   let mayStore = 1;
   let hasSideEffects = 0;
@@ -519,12 +526,75 @@ multiclass XVPseudoILoad {
   }
 }
 
+class XVPseudoIStoreNoMask<VReg StClass, int MEM, int REG, bit e>:
+      Pseudo<(outs),
+             (ins StClass:$rd, GPRMem:$rs1, StClass:$rs2,
+              AVL:$vl, ixlenimm:$sew),[]>,
+      RISCVVPseudo,
+      XTHeadVVS</*Masked*/0, /*Strided*/0, /*Indexed*/1, e,
+                !logtwo(MEM), !logtwo(REG), VLMul> {
+  let mayLoad = 0;
+  let mayStore = 1;
+  let hasSideEffects = 0;
+  let HasVLOp = 1;
+  let HasSEWOp = 1;
+}
+
+class XVPseudoIStoreMask<VReg StClass, int MEM, int REG, bit e>:
+      Pseudo<(outs),
+             (ins StClass:$rd, GPRMem:$rs1, StClass:$rs2, VMaskOp:$vm,
+              AVL:$vl, ixlenimm:$sew),[]>,
+      RISCVVPseudo,
+      XTHeadVVS</*Masked*/1, /*Strided*/0, /*Indexed*/1, e,
+                !logtwo(MEM), !logtwo(REG), VLMul> {
+  let mayLoad = 0;
+  let mayStore = 1;
+  let hasSideEffects = 0;
+  let HasVLOp = 1;
+  let HasSEWOp = 1;
+}
+
+multiclass XVPseudoIStore {
+  foreach mem = [8, 16, 32] in {
+    foreach lmul = MxListXTHeadV in {
+      defvar LInfo = lmul.MX;
+      defvar vreg = lmul.vrclass;
+      defvar tag = MemBitsToTag<mem>.ret;
+      foreach reg = EEWList in {
+        let VLMul = lmul.value, SEW = mem in {
+          def "X" # tag # "_V_E" # reg # "_" # LInfo :
+            XVPseudoIStoreNoMask<vreg, mem, reg, 0>,
+            VSXSched<mem, "O", LInfo, LInfo>;
+          def "X" # tag # "_V_E" # reg # "_" # LInfo # "_MASK" :
+            XVPseudoIStoreMask<vreg, mem, reg, 0>,
+            VSXSched<mem, "O", LInfo, LInfo>;
+        }
+      }
+    }
+  }
+  foreach eew = EEWList in {
+    foreach lmul = MxListXTHeadV in {
+      defvar LInfo = lmul.MX;
+      defvar vreg = lmul.vrclass;
+      let VLMul = lmul.value, SEW = eew in {
+        def "XE_V_E" # eew # "_" # LInfo :
+          XVPseudoIStoreNoMask<vreg, eew, eew, 1>,
+          VSXSched<eew, "O", LInfo, LInfo>;
+        def "XE_V_E" # eew # "_" # LInfo # "_MASK" :
+          XVPseudoIStoreMask<vreg, eew, eew, 1>,
+          VSXSched<eew, "O", LInfo, LInfo>;
+      }
+    }
+  }
+}
+
 let Predicates = [HasVendorXTHeadV] in {
   defm PseudoXVL : XVPseudoUSLoad;
   defm PseudoXVS : XVPseudoUSStore;
   defm PseudoXVL : XVPseudoSLoad;
   defm PseudoXVS : XVPseudoSStore;
   defm PseudoXVL : XVPseudoILoad;
+  defm PseudoXVS : XVPseudoIStore;
 } // Predicates = [HasVendorXTHeadV]
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vlx-64.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vlx-64.ll
@@ -1,0 +1,962 @@
+; RUN: llc -mtriple=riscv64 -mattr=+xtheadv -verify-machineinstrs < %s | \
+; RUN: FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlxb.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  i64);
+
+define <vscale x 1 x i64> @intrinsic_xvlxb_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlxb.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlxb.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  i64);
+
+define <vscale x 1 x i64> @intrinsic_xvlxb_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlxb.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlxb.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  i64);
+
+define <vscale x 2 x i64> @intrinsic_xvlxb_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlxb.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlxb.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  i64);
+
+define <vscale x 2 x i64> @intrinsic_xvlxb_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlxb.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlxb.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  i64);
+
+define <vscale x 4 x i64> @intrinsic_xvlxb_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlxb.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlxb.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  i64);
+
+define <vscale x 4 x i64> @intrinsic_xvlxb_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlxb.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlxb.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  i64);
+
+define <vscale x 8 x i64> @intrinsic_xvlxb_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlxb.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlxb.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  i64);
+
+define <vscale x 8 x i64> @intrinsic_xvlxb_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlxb.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlxh.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  i64);
+
+define <vscale x 1 x i64> @intrinsic_xvlxh_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlxh.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlxh.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  i64);
+
+define <vscale x 1 x i64> @intrinsic_xvlxh_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlxh.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlxh.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  i64);
+
+define <vscale x 2 x i64> @intrinsic_xvlxh_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlxh.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlxh.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  i64);
+
+define <vscale x 2 x i64> @intrinsic_xvlxh_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlxh.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlxh.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  i64);
+
+define <vscale x 4 x i64> @intrinsic_xvlxh_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlxh.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlxh.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  i64);
+
+define <vscale x 4 x i64> @intrinsic_xvlxh_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlxh.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlxh.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  i64);
+
+define <vscale x 8 x i64> @intrinsic_xvlxh_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlxh.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlxh.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  i64);
+
+define <vscale x 8 x i64> @intrinsic_xvlxh_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlxh.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlxw.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  i64);
+
+define <vscale x 1 x i64> @intrinsic_xvlxw_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlxw.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlxw.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  i64);
+
+define <vscale x 1 x i64> @intrinsic_xvlxw_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlxw.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlxw.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  i64);
+
+define <vscale x 2 x i64> @intrinsic_xvlxw_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlxw.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlxw.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  i64);
+
+define <vscale x 2 x i64> @intrinsic_xvlxw_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlxw.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlxw.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  i64);
+
+define <vscale x 4 x i64> @intrinsic_xvlxw_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlxw.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlxw.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  i64);
+
+define <vscale x 4 x i64> @intrinsic_xvlxw_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlxw.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlxw.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  i64);
+
+define <vscale x 8 x i64> @intrinsic_xvlxw_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlxw.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlxw.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  i64);
+
+define <vscale x 8 x i64> @intrinsic_xvlxw_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlxw.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlxe.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  i64);
+
+define <vscale x 1 x i64> @intrinsic_xvlxe_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlxe.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlxe.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  i64);
+
+define <vscale x 1 x i64> @intrinsic_xvlxe_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlxe.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlxe.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  i64);
+
+define <vscale x 2 x i64> @intrinsic_xvlxe_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlxe.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlxe.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  i64);
+
+define <vscale x 2 x i64> @intrinsic_xvlxe_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlxe.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlxe.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  i64);
+
+define <vscale x 4 x i64> @intrinsic_xvlxe_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlxe.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlxe.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  i64);
+
+define <vscale x 4 x i64> @intrinsic_xvlxe_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlxe.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlxe.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  i64);
+
+define <vscale x 8 x i64> @intrinsic_xvlxe_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlxe.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlxe.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  i64);
+
+define <vscale x 8 x i64> @intrinsic_xvlxe_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlxe.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 1 x double> @llvm.riscv.xvlxe.nxv1f64.nxv1f64(
+  <vscale x 1 x double>,
+  <vscale x 1 x double>*,
+  <vscale x 1 x double>,
+  i64);
+
+define <vscale x 1 x double> @intrinsic_xvlxe_v_nxv1f64_nxv1f64(<vscale x 1 x double>* %0, <vscale x 1 x double> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv1f64_nxv1f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x double> @llvm.riscv.xvlxe.nxv1f64.nxv1f64(
+    <vscale x 1 x double> undef,
+    <vscale x 1 x double>* %0,
+    <vscale x 1 x double> %1,
+    i64 %2)
+
+  ret <vscale x 1 x double> %a
+}
+
+declare <vscale x 1 x double> @llvm.riscv.xvlxe.mask.nxv1f64.nxv1f64(
+  <vscale x 1 x double>,
+  <vscale x 1 x double>*,
+  <vscale x 1 x double>,
+  <vscale x 1 x i1>,
+  i64);
+
+define <vscale x 1 x double> @intrinsic_xvlxe_mask_v_nxv1f64_nxv1f64(<vscale x 1 x double> %0, <vscale x 1 x double>* %1, <vscale x 1 x double> %2, <vscale x 1 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv1f64_nxv1f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x double> @llvm.riscv.xvlxe.mask.nxv1f64.nxv1f64(
+    <vscale x 1 x double> %0,
+    <vscale x 1 x double>* %1,
+    <vscale x 1 x double> %2,
+    <vscale x 1 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 1 x double> %a
+}
+
+declare <vscale x 2 x double> @llvm.riscv.xvlxe.nxv2f64.nxv2f64(
+  <vscale x 2 x double>,
+  <vscale x 2 x double>*,
+  <vscale x 2 x double>,
+  i64);
+
+define <vscale x 2 x double> @intrinsic_xvlxe_v_nxv2f64_nxv2f64(<vscale x 2 x double>* %0, <vscale x 2 x double> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv2f64_nxv2f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x double> @llvm.riscv.xvlxe.nxv2f64.nxv2f64(
+    <vscale x 2 x double> undef,
+    <vscale x 2 x double>* %0,
+    <vscale x 2 x double> %1,
+    i64 %2)
+
+  ret <vscale x 2 x double> %a
+}
+
+declare <vscale x 2 x double> @llvm.riscv.xvlxe.mask.nxv2f64.nxv2f64(
+  <vscale x 2 x double>,
+  <vscale x 2 x double>*,
+  <vscale x 2 x double>,
+  <vscale x 2 x i1>,
+  i64);
+
+define <vscale x 2 x double> @intrinsic_xvlxe_mask_v_nxv2f64_nxv2f64(<vscale x 2 x double> %0, <vscale x 2 x double>* %1, <vscale x 2 x double> %2, <vscale x 2 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv2f64_nxv2f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x double> @llvm.riscv.xvlxe.mask.nxv2f64.nxv2f64(
+    <vscale x 2 x double> %0,
+    <vscale x 2 x double>* %1,
+    <vscale x 2 x double> %2,
+    <vscale x 2 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 2 x double> %a
+}
+
+declare <vscale x 4 x double> @llvm.riscv.xvlxe.nxv4f64.nxv4f64(
+  <vscale x 4 x double>,
+  <vscale x 4 x double>*,
+  <vscale x 4 x double>,
+  i64);
+
+define <vscale x 4 x double> @intrinsic_xvlxe_v_nxv4f64_nxv4f64(<vscale x 4 x double>* %0, <vscale x 4 x double> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv4f64_nxv4f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x double> @llvm.riscv.xvlxe.nxv4f64.nxv4f64(
+    <vscale x 4 x double> undef,
+    <vscale x 4 x double>* %0,
+    <vscale x 4 x double> %1,
+    i64 %2)
+
+  ret <vscale x 4 x double> %a
+}
+
+declare <vscale x 4 x double> @llvm.riscv.xvlxe.mask.nxv4f64.nxv4f64(
+  <vscale x 4 x double>,
+  <vscale x 4 x double>*,
+  <vscale x 4 x double>,
+  <vscale x 4 x i1>,
+  i64);
+
+define <vscale x 4 x double> @intrinsic_xvlxe_mask_v_nxv4f64_nxv4f64(<vscale x 4 x double> %0, <vscale x 4 x double>* %1, <vscale x 4 x double> %2, <vscale x 4 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv4f64_nxv4f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x double> @llvm.riscv.xvlxe.mask.nxv4f64.nxv4f64(
+    <vscale x 4 x double> %0,
+    <vscale x 4 x double>* %1,
+    <vscale x 4 x double> %2,
+    <vscale x 4 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 4 x double> %a
+}
+
+declare <vscale x 8 x double> @llvm.riscv.xvlxe.nxv8f64.nxv8f64(
+  <vscale x 8 x double>,
+  <vscale x 8 x double>*,
+  <vscale x 8 x double>,
+  i64);
+
+define <vscale x 8 x double> @intrinsic_xvlxe_v_nxv8f64_nxv8f64(<vscale x 8 x double>* %0, <vscale x 8 x double> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv8f64_nxv8f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x double> @llvm.riscv.xvlxe.nxv8f64.nxv8f64(
+    <vscale x 8 x double> undef,
+    <vscale x 8 x double>* %0,
+    <vscale x 8 x double> %1,
+    i64 %2)
+
+  ret <vscale x 8 x double> %a
+}
+
+declare <vscale x 8 x double> @llvm.riscv.xvlxe.mask.nxv8f64.nxv8f64(
+  <vscale x 8 x double>,
+  <vscale x 8 x double>*,
+  <vscale x 8 x double>,
+  <vscale x 8 x i1>,
+  i64);
+
+define <vscale x 8 x double> @intrinsic_xvlxe_mask_v_nxv8f64_nxv8f64(<vscale x 8 x double> %0, <vscale x 8 x double>* %1, <vscale x 8 x double> %2, <vscale x 8 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv8f64_nxv8f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x double> @llvm.riscv.xvlxe.mask.nxv8f64.nxv8f64(
+    <vscale x 8 x double> %0,
+    <vscale x 8 x double>* %1,
+    <vscale x 8 x double> %2,
+    <vscale x 8 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 8 x double> %a
+}

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vlx.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vlx.ll
@@ -1,0 +1,2116 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlxb.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i8>,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlxb_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlxb.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    <vscale x 8 x i8> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlxb.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i8>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlxb_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i8> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlxb.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    <vscale x 8 x i8> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlxb.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i8>,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlxb_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, <vscale x 16 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlxb.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    <vscale x 16 x i8> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlxb.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i8>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlxb_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i8> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlxb.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    <vscale x 16 x i8> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlxb.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i8>,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlxb_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, <vscale x 32 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlxb.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    <vscale x 32 x i8> %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlxb.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i8>,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlxb_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, <vscale x 32 x i8> %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlxb.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    <vscale x 32 x i8> %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlxb.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i8>,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlxb_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, <vscale x 64 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlxb.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    <vscale x 64 x i8> %1,
+    iXLen %2)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlxb.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i8>,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlxb_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, <vscale x 64 x i8> %2, <vscale x 64 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlxb.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    <vscale x 64 x i8> %2,
+    <vscale x 64 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlxb.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i16>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlxb_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlxb.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    <vscale x 4 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlxb.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i16>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlxb_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i16> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlxb.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    <vscale x 4 x i16> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlxb.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i16>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlxb_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlxb.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    <vscale x 8 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlxb.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i16>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlxb_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i16> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlxb.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    <vscale x 8 x i16> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlxb.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i16>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlxb_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, <vscale x 16 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlxb.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    <vscale x 16 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlxb.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i16>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlxb_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i16> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlxb.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    <vscale x 16 x i16> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlxb.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i16>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlxb_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, <vscale x 32 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlxb.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    <vscale x 32 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlxb.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i16>,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlxb_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, <vscale x 32 x i16> %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlxb.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    <vscale x 32 x i16> %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlxb.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlxb_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlxb.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlxb.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlxb_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlxb.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlxb.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlxb_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlxb.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlxb.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlxb_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlxb.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlxb.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlxb_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlxb.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlxb.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlxb_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlxb.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlxb.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlxb_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlxb.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlxb.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlxb_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxb_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxb.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlxb.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlxh.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i16>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlxh_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlxh.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    <vscale x 4 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlxh.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i16>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlxh_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i16> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlxh.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    <vscale x 4 x i16> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlxh.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i16>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlxh_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlxh.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    <vscale x 8 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlxh.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i16>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlxh_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i16> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlxh.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    <vscale x 8 x i16> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlxh.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i16>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlxh_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, <vscale x 16 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlxh.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    <vscale x 16 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlxh.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i16>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlxh_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i16> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlxh.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    <vscale x 16 x i16> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlxh.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i16>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlxh_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, <vscale x 32 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlxh.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    <vscale x 32 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlxh.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i16>,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlxh_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, <vscale x 32 x i16> %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlxh.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    <vscale x 32 x i16> %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlxh.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlxh_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlxh.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlxh.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlxh_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlxh.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlxh.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlxh_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlxh.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlxh.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlxh_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlxh.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlxh.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlxh_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlxh.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlxh.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlxh_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlxh.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlxh.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlxh_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlxh.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlxh.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlxh_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxh_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxh.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlxh.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlxw.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlxw_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlxw.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlxw.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlxw_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlxw.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlxw.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlxw_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlxw.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlxw.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlxw_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlxw.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlxw.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlxw_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlxw.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlxw.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlxw_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlxw.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlxw.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlxw_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlxw.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlxw.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlxw_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxw_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxw.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlxw.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlxe.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i8>,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlxe_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlxe.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    <vscale x 8 x i8> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlxe.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i8>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlxe_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i8> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlxe.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    <vscale x 8 x i8> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlxe.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i8>,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlxe_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, <vscale x 16 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlxe.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    <vscale x 16 x i8> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlxe.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i8>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlxe_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i8> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlxe.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    <vscale x 16 x i8> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlxe.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i8>,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlxe_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, <vscale x 32 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlxe.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    <vscale x 32 x i8> %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlxe.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i8>,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlxe_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, <vscale x 32 x i8> %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlxe.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    <vscale x 32 x i8> %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlxe.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i8>,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlxe_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, <vscale x 64 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlxe.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    <vscale x 64 x i8> %1,
+    iXLen %2)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlxe.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i8>,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlxe_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, <vscale x 64 x i8> %2, <vscale x 64 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlxe.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    <vscale x 64 x i8> %2,
+    <vscale x 64 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlxe.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i16>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlxe_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlxe.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    <vscale x 4 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlxe.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i16>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlxe_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i16> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlxe.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    <vscale x 4 x i16> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlxe.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i16>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlxe_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlxe.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    <vscale x 8 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlxe.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i16>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlxe_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i16> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlxe.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    <vscale x 8 x i16> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlxe.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i16>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlxe_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, <vscale x 16 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlxe.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    <vscale x 16 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlxe.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i16>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlxe_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i16> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlxe.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    <vscale x 16 x i16> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlxe.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i16>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlxe_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, <vscale x 32 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlxe.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    <vscale x 32 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlxe.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i16>,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlxe_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, <vscale x 32 x i16> %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlxe.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    <vscale x 32 x i16> %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 4 x half> @llvm.riscv.xvlxe.nxv4f16.nxv4f16(
+  <vscale x 4 x half>,
+  <vscale x 4 x half>*,
+  <vscale x 4 x half>,
+  iXLen);
+
+define <vscale x 4 x half> @intrinsic_xvlxe_v_nxv4f16_nxv4f16(<vscale x 4 x half>* %0, <vscale x 4 x half> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv4f16_nxv4f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x half> @llvm.riscv.xvlxe.nxv4f16.nxv4f16(
+    <vscale x 4 x half> undef,
+    <vscale x 4 x half>* %0,
+    <vscale x 4 x half> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x half> %a
+}
+
+declare <vscale x 4 x half> @llvm.riscv.xvlxe.mask.nxv4f16.nxv4f16(
+  <vscale x 4 x half>,
+  <vscale x 4 x half>*,
+  <vscale x 4 x half>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x half> @intrinsic_xvlxe_mask_v_nxv4f16_nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x half>* %1, <vscale x 4 x half> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv4f16_nxv4f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x half> @llvm.riscv.xvlxe.mask.nxv4f16.nxv4f16(
+    <vscale x 4 x half> %0,
+    <vscale x 4 x half>* %1,
+    <vscale x 4 x half> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x half> %a
+}
+
+declare <vscale x 8 x half> @llvm.riscv.xvlxe.nxv8f16.nxv8f16(
+  <vscale x 8 x half>,
+  <vscale x 8 x half>*,
+  <vscale x 8 x half>,
+  iXLen);
+
+define <vscale x 8 x half> @intrinsic_xvlxe_v_nxv8f16_nxv8f16(<vscale x 8 x half>* %0, <vscale x 8 x half> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv8f16_nxv8f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x half> @llvm.riscv.xvlxe.nxv8f16.nxv8f16(
+    <vscale x 8 x half> undef,
+    <vscale x 8 x half>* %0,
+    <vscale x 8 x half> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x half> %a
+}
+
+declare <vscale x 8 x half> @llvm.riscv.xvlxe.mask.nxv8f16.nxv8f16(
+  <vscale x 8 x half>,
+  <vscale x 8 x half>*,
+  <vscale x 8 x half>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x half> @intrinsic_xvlxe_mask_v_nxv8f16_nxv8f16(<vscale x 8 x half> %0, <vscale x 8 x half>* %1, <vscale x 8 x half> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv8f16_nxv8f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x half> @llvm.riscv.xvlxe.mask.nxv8f16.nxv8f16(
+    <vscale x 8 x half> %0,
+    <vscale x 8 x half>* %1,
+    <vscale x 8 x half> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x half> %a
+}
+
+declare <vscale x 16 x half> @llvm.riscv.xvlxe.nxv16f16.nxv16f16(
+  <vscale x 16 x half>,
+  <vscale x 16 x half>*,
+  <vscale x 16 x half>,
+  iXLen);
+
+define <vscale x 16 x half> @intrinsic_xvlxe_v_nxv16f16_nxv16f16(<vscale x 16 x half>* %0, <vscale x 16 x half> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv16f16_nxv16f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x half> @llvm.riscv.xvlxe.nxv16f16.nxv16f16(
+    <vscale x 16 x half> undef,
+    <vscale x 16 x half>* %0,
+    <vscale x 16 x half> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x half> %a
+}
+
+declare <vscale x 16 x half> @llvm.riscv.xvlxe.mask.nxv16f16.nxv16f16(
+  <vscale x 16 x half>,
+  <vscale x 16 x half>*,
+  <vscale x 16 x half>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x half> @intrinsic_xvlxe_mask_v_nxv16f16_nxv16f16(<vscale x 16 x half> %0, <vscale x 16 x half>* %1, <vscale x 16 x half> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv16f16_nxv16f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x half> @llvm.riscv.xvlxe.mask.nxv16f16.nxv16f16(
+    <vscale x 16 x half> %0,
+    <vscale x 16 x half>* %1,
+    <vscale x 16 x half> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x half> %a
+}
+
+declare <vscale x 32 x half> @llvm.riscv.xvlxe.nxv32f16.nxv32f16(
+  <vscale x 32 x half>,
+  <vscale x 32 x half>*,
+  <vscale x 32 x half>,
+  iXLen);
+
+define <vscale x 32 x half> @intrinsic_xvlxe_v_nxv32f16_nxv32f16(<vscale x 32 x half>* %0, <vscale x 32 x half> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv32f16_nxv32f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x half> @llvm.riscv.xvlxe.nxv32f16.nxv32f16(
+    <vscale x 32 x half> undef,
+    <vscale x 32 x half>* %0,
+    <vscale x 32 x half> %1,
+    iXLen %2)
+
+  ret <vscale x 32 x half> %a
+}
+
+declare <vscale x 32 x half> @llvm.riscv.xvlxe.mask.nxv32f16.nxv32f16(
+  <vscale x 32 x half>,
+  <vscale x 32 x half>*,
+  <vscale x 32 x half>,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x half> @intrinsic_xvlxe_mask_v_nxv32f16_nxv32f16(<vscale x 32 x half> %0, <vscale x 32 x half>* %1, <vscale x 32 x half> %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv32f16_nxv32f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x half> @llvm.riscv.xvlxe.mask.nxv32f16.nxv32f16(
+    <vscale x 32 x half> %0,
+    <vscale x 32 x half>* %1,
+    <vscale x 32 x half> %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x half> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlxe.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlxe_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlxe.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlxe.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlxe_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlxe.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlxe.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlxe_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlxe.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlxe.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlxe_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlxe.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlxe.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlxe_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlxe.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlxe.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlxe_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlxe.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlxe.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlxe_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlxe.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlxe.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlxe_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlxe.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 2 x float> @llvm.riscv.xvlxe.nxv2f32.nxv2f32(
+  <vscale x 2 x float>,
+  <vscale x 2 x float>*,
+  <vscale x 2 x float>,
+  iXLen);
+
+define <vscale x 2 x float> @intrinsic_xvlxe_v_nxv2f32_nxv2f32(<vscale x 2 x float>* %0, <vscale x 2 x float> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv2f32_nxv2f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x float> @llvm.riscv.xvlxe.nxv2f32.nxv2f32(
+    <vscale x 2 x float> undef,
+    <vscale x 2 x float>* %0,
+    <vscale x 2 x float> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x float> %a
+}
+
+declare <vscale x 2 x float> @llvm.riscv.xvlxe.mask.nxv2f32.nxv2f32(
+  <vscale x 2 x float>,
+  <vscale x 2 x float>*,
+  <vscale x 2 x float>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x float> @intrinsic_xvlxe_mask_v_nxv2f32_nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x float>* %1, <vscale x 2 x float> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv2f32_nxv2f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x float> @llvm.riscv.xvlxe.mask.nxv2f32.nxv2f32(
+    <vscale x 2 x float> %0,
+    <vscale x 2 x float>* %1,
+    <vscale x 2 x float> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x float> %a
+}
+
+declare <vscale x 4 x float> @llvm.riscv.xvlxe.nxv4f32.nxv4f32(
+  <vscale x 4 x float>,
+  <vscale x 4 x float>*,
+  <vscale x 4 x float>,
+  iXLen);
+
+define <vscale x 4 x float> @intrinsic_xvlxe_v_nxv4f32_nxv4f32(<vscale x 4 x float>* %0, <vscale x 4 x float> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv4f32_nxv4f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x float> @llvm.riscv.xvlxe.nxv4f32.nxv4f32(
+    <vscale x 4 x float> undef,
+    <vscale x 4 x float>* %0,
+    <vscale x 4 x float> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x float> %a
+}
+
+declare <vscale x 4 x float> @llvm.riscv.xvlxe.mask.nxv4f32.nxv4f32(
+  <vscale x 4 x float>,
+  <vscale x 4 x float>*,
+  <vscale x 4 x float>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x float> @intrinsic_xvlxe_mask_v_nxv4f32_nxv4f32(<vscale x 4 x float> %0, <vscale x 4 x float>* %1, <vscale x 4 x float> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv4f32_nxv4f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x float> @llvm.riscv.xvlxe.mask.nxv4f32.nxv4f32(
+    <vscale x 4 x float> %0,
+    <vscale x 4 x float>* %1,
+    <vscale x 4 x float> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x float> %a
+}
+
+declare <vscale x 8 x float> @llvm.riscv.xvlxe.nxv8f32.nxv8f32(
+  <vscale x 8 x float>,
+  <vscale x 8 x float>*,
+  <vscale x 8 x float>,
+  iXLen);
+
+define <vscale x 8 x float> @intrinsic_xvlxe_v_nxv8f32_nxv8f32(<vscale x 8 x float>* %0, <vscale x 8 x float> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv8f32_nxv8f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x float> @llvm.riscv.xvlxe.nxv8f32.nxv8f32(
+    <vscale x 8 x float> undef,
+    <vscale x 8 x float>* %0,
+    <vscale x 8 x float> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x float> %a
+}
+
+declare <vscale x 8 x float> @llvm.riscv.xvlxe.mask.nxv8f32.nxv8f32(
+  <vscale x 8 x float>,
+  <vscale x 8 x float>*,
+  <vscale x 8 x float>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x float> @intrinsic_xvlxe_mask_v_nxv8f32_nxv8f32(<vscale x 8 x float> %0, <vscale x 8 x float>* %1, <vscale x 8 x float> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv8f32_nxv8f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x float> @llvm.riscv.xvlxe.mask.nxv8f32.nxv8f32(
+    <vscale x 8 x float> %0,
+    <vscale x 8 x float>* %1,
+    <vscale x 8 x float> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x float> %a
+}
+
+declare <vscale x 16 x float> @llvm.riscv.xvlxe.nxv16f32.nxv16f32(
+  <vscale x 16 x float>,
+  <vscale x 16 x float>*,
+  <vscale x 16 x float>,
+  iXLen);
+
+define <vscale x 16 x float> @intrinsic_xvlxe_v_nxv16f32_nxv16f32(<vscale x 16 x float>* %0, <vscale x 16 x float> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_v_nxv16f32_nxv16f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x float> @llvm.riscv.xvlxe.nxv16f32.nxv16f32(
+    <vscale x 16 x float> undef,
+    <vscale x 16 x float>* %0,
+    <vscale x 16 x float> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x float> %a
+}
+
+declare <vscale x 16 x float> @llvm.riscv.xvlxe.mask.nxv16f32.nxv16f32(
+  <vscale x 16 x float>,
+  <vscale x 16 x float>*,
+  <vscale x 16 x float>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x float> @intrinsic_xvlxe_mask_v_nxv16f32_nxv16f32(<vscale x 16 x float> %0, <vscale x 16 x float>* %1, <vscale x 16 x float> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxe_mask_v_nxv16f32_nxv16f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxe.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x float> @llvm.riscv.xvlxe.mask.nxv16f32.nxv16f32(
+    <vscale x 16 x float> %0,
+    <vscale x 16 x float>* %1,
+    <vscale x 16 x float> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x float> %a
+}

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vlxu-64.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vlxu-64.ll
@@ -1,0 +1,578 @@
+; RUN: llc -mtriple=riscv64 -mattr=+xtheadv -verify-machineinstrs < %s | \
+; RUN: FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlxbu.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  i64);
+
+define <vscale x 1 x i64> @intrinsic_xvlxbu_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlxbu.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlxbu.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  i64);
+
+define <vscale x 1 x i64> @intrinsic_xvlxbu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlxbu.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlxbu.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  i64);
+
+define <vscale x 2 x i64> @intrinsic_xvlxbu_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlxbu.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlxbu.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  i64);
+
+define <vscale x 2 x i64> @intrinsic_xvlxbu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlxbu.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlxbu.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  i64);
+
+define <vscale x 4 x i64> @intrinsic_xvlxbu_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlxbu.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlxbu.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  i64);
+
+define <vscale x 4 x i64> @intrinsic_xvlxbu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlxbu.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlxbu.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  i64);
+
+define <vscale x 8 x i64> @intrinsic_xvlxbu_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlxbu.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlxbu.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  i64);
+
+define <vscale x 8 x i64> @intrinsic_xvlxbu_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlxbu.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlxhu.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  i64);
+
+define <vscale x 1 x i64> @intrinsic_xvlxhu_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlxhu.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlxhu.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  i64);
+
+define <vscale x 1 x i64> @intrinsic_xvlxhu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlxhu.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlxhu.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  i64);
+
+define <vscale x 2 x i64> @intrinsic_xvlxhu_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlxhu.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlxhu.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  i64);
+
+define <vscale x 2 x i64> @intrinsic_xvlxhu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlxhu.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlxhu.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  i64);
+
+define <vscale x 4 x i64> @intrinsic_xvlxhu_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlxhu.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlxhu.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  i64);
+
+define <vscale x 4 x i64> @intrinsic_xvlxhu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlxhu.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlxhu.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  i64);
+
+define <vscale x 8 x i64> @intrinsic_xvlxhu_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlxhu.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlxhu.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  i64);
+
+define <vscale x 8 x i64> @intrinsic_xvlxhu_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlxhu.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlxwu.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  i64);
+
+define <vscale x 1 x i64> @intrinsic_xvlxwu_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlxwu.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 1 x i64> @llvm.riscv.xvlxwu.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  i64);
+
+define <vscale x 1 x i64> @intrinsic_xvlxwu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 1 x i64> @llvm.riscv.xvlxwu.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i64> %2,
+    <vscale x 1 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 1 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlxwu.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  i64);
+
+define <vscale x 2 x i64> @intrinsic_xvlxwu_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlxwu.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 2 x i64> @llvm.riscv.xvlxwu.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  i64);
+
+define <vscale x 2 x i64> @intrinsic_xvlxwu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i64> @llvm.riscv.xvlxwu.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i64> %2,
+    <vscale x 2 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 2 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlxwu.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  i64);
+
+define <vscale x 4 x i64> @intrinsic_xvlxwu_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlxwu.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvlxwu.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  i64);
+
+define <vscale x 4 x i64> @intrinsic_xvlxwu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i64> @llvm.riscv.xvlxwu.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i64> %2,
+    <vscale x 4 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 4 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlxwu.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  i64);
+
+define <vscale x 8 x i64> @intrinsic_xvlxwu_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlxwu.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    i64 %2)
+
+  ret <vscale x 8 x i64> %a
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvlxwu.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  i64);
+
+define <vscale x 8 x i64> @intrinsic_xvlxwu_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i64> @llvm.riscv.xvlxwu.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i64> %2,
+    <vscale x 8 x i1> %3,
+    i64 %4)
+
+  ret <vscale x 8 x i64> %a
+}

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vlxu.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vlxu.ll
@@ -1,0 +1,1156 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlxbu.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i8>,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlxbu_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlxbu.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    <vscale x 8 x i8> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 8 x i8> @llvm.riscv.xvlxbu.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i8>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i8> @intrinsic_xvlxbu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i8> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i8> @llvm.riscv.xvlxbu.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    <vscale x 8 x i8> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlxbu.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i8>,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlxbu_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, <vscale x 16 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlxbu.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    <vscale x 16 x i8> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 16 x i8> @llvm.riscv.xvlxbu.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i8>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i8> @intrinsic_xvlxbu_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i8> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i8> @llvm.riscv.xvlxbu.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    <vscale x 16 x i8> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlxbu.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i8>,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlxbu_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, <vscale x 32 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlxbu.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    <vscale x 32 x i8> %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvlxbu.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i8>,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i8> @intrinsic_xvlxbu_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, <vscale x 32 x i8> %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i8> @llvm.riscv.xvlxbu.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    <vscale x 32 x i8> %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlxbu.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i8>,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlxbu_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, <vscale x 64 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlxbu.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    <vscale x 64 x i8> %1,
+    iXLen %2)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvlxbu.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i8>,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define <vscale x 64 x i8> @intrinsic_xvlxbu_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, <vscale x 64 x i8> %2, <vscale x 64 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 64 x i8> @llvm.riscv.xvlxbu.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    <vscale x 64 x i8> %2,
+    <vscale x 64 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 64 x i8> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlxbu.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i16>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlxbu_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlxbu.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    <vscale x 4 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlxbu.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i16>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlxbu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i16> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlxbu.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    <vscale x 4 x i16> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlxbu.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i16>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlxbu_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlxbu.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    <vscale x 8 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlxbu.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i16>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlxbu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i16> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlxbu.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    <vscale x 8 x i16> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlxbu.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i16>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlxbu_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, <vscale x 16 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlxbu.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    <vscale x 16 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlxbu.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i16>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlxbu_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i16> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlxbu.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    <vscale x 16 x i16> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlxbu.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i16>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlxbu_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, <vscale x 32 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlxbu.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    <vscale x 32 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlxbu.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i16>,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlxbu_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, <vscale x 32 x i16> %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlxbu.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    <vscale x 32 x i16> %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlxbu.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlxbu_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlxbu.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlxbu.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlxbu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlxbu.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlxbu.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlxbu_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlxbu.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlxbu.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlxbu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlxbu.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlxbu.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlxbu_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlxbu.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlxbu.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlxbu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlxbu.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlxbu.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlxbu_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlxbu.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlxbu.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlxbu_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxbu_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxbu.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlxbu.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlxhu.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i16>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlxhu_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlxhu.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    <vscale x 4 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 4 x i16> @llvm.riscv.xvlxhu.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i16>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i16> @intrinsic_xvlxhu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i16> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i16> @llvm.riscv.xvlxhu.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    <vscale x 4 x i16> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlxhu.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i16>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlxhu_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlxhu.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    <vscale x 8 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 8 x i16> @llvm.riscv.xvlxhu.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i16>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i16> @intrinsic_xvlxhu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i16> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i16> @llvm.riscv.xvlxhu.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    <vscale x 8 x i16> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlxhu.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i16>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlxhu_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, <vscale x 16 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlxhu.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    <vscale x 16 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvlxhu.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i16>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i16> @intrinsic_xvlxhu_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i16> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i16> @llvm.riscv.xvlxhu.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    <vscale x 16 x i16> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlxhu.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i16>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlxhu_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, <vscale x 32 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlxhu.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    <vscale x 32 x i16> %1,
+    iXLen %2)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvlxhu.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i16>,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define <vscale x 32 x i16> @intrinsic_xvlxhu_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, <vscale x 32 x i16> %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 32 x i16> @llvm.riscv.xvlxhu.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    <vscale x 32 x i16> %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 32 x i16> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlxhu.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlxhu_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlxhu.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlxhu.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlxhu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlxhu.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlxhu.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlxhu_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlxhu.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlxhu.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlxhu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlxhu.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlxhu.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlxhu_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlxhu.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlxhu.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlxhu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlxhu.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlxhu.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlxhu_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlxhu.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlxhu.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlxhu_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxhu_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxhu.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlxhu.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlxwu.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlxwu_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlxwu.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 2 x i32> @llvm.riscv.xvlxwu.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i32> @intrinsic_xvlxwu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 2 x i32> @llvm.riscv.xvlxwu.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i32> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 2 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlxwu.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlxwu_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlxwu.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 4 x i32> @llvm.riscv.xvlxwu.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i32> @intrinsic_xvlxwu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 4 x i32> @llvm.riscv.xvlxwu.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i32> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 4 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlxwu.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlxwu_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlxwu.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvlxwu.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define <vscale x 8 x i32> @intrinsic_xvlxwu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 8 x i32> @llvm.riscv.xvlxwu.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i32> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 8 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlxwu.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlxwu_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlxwu.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    iXLen %2)
+
+  ret <vscale x 16 x i32> %a
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvlxwu.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define <vscale x 16 x i32> @intrinsic_xvlxwu_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvlxwu_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vlxwu.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  %a = call <vscale x 16 x i32> @llvm.riscv.xvlxwu.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i32> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret <vscale x 16 x i32> %a
+}

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vsx-64.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vsx-64.ll
@@ -1,0 +1,386 @@
+; RUN: llc -mtriple=riscv64 -mattr=+xtheadv -verify-machineinstrs < %s | \
+; RUN: FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare void @llvm.riscv.xvsxe.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  i64);
+
+define void @intrinsic_xvsxe_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> undef,
+    <vscale x 1 x i64>* %0,
+    <vscale x 1 x i64> %1,
+    i64 %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv1i64.nxv1i64(
+  <vscale x 1 x i64>,
+  <vscale x 1 x i64>*,
+  <vscale x 1 x i64>,
+  <vscale x 1 x i1>,
+  i64);
+
+define void @intrinsic_xvsxe_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i64> %2, <vscale x 1 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv1i64_nxv1i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv1i64.nxv1i64(
+    <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    <vscale x 1 x i64> %2, 
+    <vscale x 1 x i1> %3,
+    i64 %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv1f64.nxv1f64(
+  <vscale x 1 x double>,
+  <vscale x 1 x double>*,
+  <vscale x 1 x double>,
+  i64);
+
+define void @intrinsic_xvsxe_v_nxv1f64_nxv1f64(<vscale x 1 x double>* %0, <vscale x 1 x double> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv1f64_nxv1f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv1f64.nxv1f64(
+    <vscale x 1 x double> undef,
+    <vscale x 1 x double>* %0,
+    <vscale x 1 x double> %1,
+    i64 %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv1f64.nxv1f64(
+  <vscale x 1 x double>,
+  <vscale x 1 x double>*,
+  <vscale x 1 x double>,
+  <vscale x 1 x i1>,
+  i64);
+
+define void @intrinsic_xvsxe_mask_v_nxv1f64_nxv1f64(<vscale x 1 x double> %0, <vscale x 1 x double>* %1, <vscale x 1 x double> %2, <vscale x 1 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv1f64_nxv1f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m1, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv1f64.nxv1f64(
+    <vscale x 1 x double> %0,
+    <vscale x 1 x double>* %1,
+    <vscale x 1 x double> %2,
+    <vscale x 1 x i1> %3,
+    i64 %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  i64);
+
+define void @intrinsic_xvsxe_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64>* %0,
+    <vscale x 2 x i64> %1,
+    i64 %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>*,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i1>,
+  i64);
+
+define void @intrinsic_xvsxe_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i64> %2, <vscale x 2 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv2i64_nxv2i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    <vscale x 2 x i64> %2, 
+    <vscale x 2 x i1> %3,
+    i64 %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv2f64.nxv2f64(
+  <vscale x 2 x double>,
+  <vscale x 2 x double>*,
+  <vscale x 2 x double>,
+  i64);
+
+define void @intrinsic_xvsxe_v_nxv2f64_nxv2f64(<vscale x 2 x double>* %0, <vscale x 2 x double> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv2f64_nxv2f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv2f64.nxv2f64(
+    <vscale x 2 x double> undef,
+    <vscale x 2 x double>* %0,
+    <vscale x 2 x double> %1,
+    i64 %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv2f64.nxv2f64(
+  <vscale x 2 x double>,
+  <vscale x 2 x double>*,
+  <vscale x 2 x double>,
+  <vscale x 2 x i1>,
+  i64);
+
+define void @intrinsic_xvsxe_mask_v_nxv2f64_nxv2f64(<vscale x 2 x double> %0, <vscale x 2 x double>* %1, <vscale x 2 x double> %2, <vscale x 2 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv2f64_nxv2f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m2, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv2f64.nxv2f64(
+    <vscale x 2 x double> %0,
+    <vscale x 2 x double>* %1,
+    <vscale x 2 x double> %2,
+    <vscale x 2 x i1> %3,
+    i64 %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  i64);
+
+define void @intrinsic_xvsxe_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64>* %0,
+    <vscale x 4 x i64> %1,
+    i64 %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>*,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i1>,
+  i64);
+
+define void @intrinsic_xvsxe_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i64> %2, <vscale x 4 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv4i64_nxv4i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    <vscale x 4 x i64> %2, 
+    <vscale x 4 x i1> %3,
+    i64 %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv4f64.nxv4f64(
+  <vscale x 4 x double>,
+  <vscale x 4 x double>*,
+  <vscale x 4 x double>,
+  i64);
+
+define void @intrinsic_xvsxe_v_nxv4f64_nxv4f64(<vscale x 4 x double>* %0, <vscale x 4 x double> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv4f64_nxv4f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv4f64.nxv4f64(
+    <vscale x 4 x double> undef,
+    <vscale x 4 x double>* %0,
+    <vscale x 4 x double> %1,
+    i64 %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv4f64.nxv4f64(
+  <vscale x 4 x double>,
+  <vscale x 4 x double>*,
+  <vscale x 4 x double>,
+  <vscale x 4 x i1>,
+  i64);
+
+define void @intrinsic_xvsxe_mask_v_nxv4f64_nxv4f64(<vscale x 4 x double> %0, <vscale x 4 x double>* %1, <vscale x 4 x double> %2, <vscale x 4 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv4f64_nxv4f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m4, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv4f64.nxv4f64(
+    <vscale x 4 x double> %0,
+    <vscale x 4 x double>* %1,
+    <vscale x 4 x double> %2,
+    <vscale x 4 x i1> %3,
+    i64 %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  i64);
+
+define void @intrinsic_xvsxe_v_nxv8i64_nxv8i64(<vscale x 8 x i64>* %0, <vscale x 8 x i64> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64>* %0,
+    <vscale x 8 x i64> %1,
+    i64 %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>*,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i1>,
+  i64);
+
+define void @intrinsic_xvsxe_mask_v_nxv8i64_nxv8i64(<vscale x 8 x i64> %0, <vscale x 8 x i64>* %1, <vscale x 8 x i64> %2, <vscale x 8 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv8i64_nxv8i64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> %0,
+    <vscale x 8 x i64>* %1,
+    <vscale x 8 x i64> %2, 
+    <vscale x 8 x i1> %3,
+    i64 %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv8f64.nxv8f64(
+  <vscale x 8 x double>,
+  <vscale x 8 x double>*,
+  <vscale x 8 x double>,
+  i64);
+
+define void @intrinsic_xvsxe_v_nxv8f64_nxv8f64(<vscale x 8 x double>* %0, <vscale x 8 x double> %1, i64 %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv8f64_nxv8f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv8f64.nxv8f64(
+    <vscale x 8 x double> undef,
+    <vscale x 8 x double>* %0,
+    <vscale x 8 x double> %1,
+    i64 %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv8f64.nxv8f64(
+  <vscale x 8 x double>,
+  <vscale x 8 x double>*,
+  <vscale x 8 x double>,
+  <vscale x 8 x i1>,
+  i64);
+
+define void @intrinsic_xvsxe_mask_v_nxv8f64_nxv8f64(<vscale x 8 x double> %0, <vscale x 8 x double>* %1, <vscale x 8 x double> %2, <vscale x 8 x i1> %3, i64 %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv8f64_nxv8f64
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e64, m8, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv8f64.nxv8f64(
+    <vscale x 8 x double> %0,
+    <vscale x 8 x double>* %1,
+    <vscale x 8 x double> %2,
+    <vscale x 8 x i1> %3,
+    i64 %4)
+
+  ret void
+}

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vsx.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vsx.ll
@@ -1,0 +1,1540 @@
+; RUN: sed 's/iXLen/i32/g' %s | llc -mtriple=riscv32 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadv \
+; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK,CHECK-LABEL,CHECK-NEXT
+
+declare void @llvm.riscv.xvsxb.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i8>,
+  iXLen);
+
+define void @intrinsic_xvsxb_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxb_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vsxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxb.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    <vscale x 8 x i8> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxb.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i8>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxb_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i8> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxb_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vsxb.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxb.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    <vscale x 8 x i8> %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxb.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i8>,
+  iXLen);
+
+define void @intrinsic_xvsxb_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, <vscale x 16 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxb_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vsxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxb.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    <vscale x 16 x i8> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxb.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i8>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxb_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i8> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxb_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vsxb.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxb.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    <vscale x 16 x i8> %2, 
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxb.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i8>,
+  iXLen);
+
+define void @intrinsic_xvsxb_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, <vscale x 32 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxb_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vsxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxb.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    <vscale x 32 x i8> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxb.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i8>,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxb_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, <vscale x 32 x i8> %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxb_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vsxb.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxb.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    <vscale x 32 x i8> %2, 
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxb.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i8>,
+  iXLen);
+
+define void @intrinsic_xvsxb_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, <vscale x 64 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxb_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vsxb.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxb.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    <vscale x 64 x i8> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxb.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i8>,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxb_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, <vscale x 64 x i8> %2, <vscale x 64 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxb_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vsxb.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxb.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    <vscale x 64 x i8> %2, 
+    <vscale x 64 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxh.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i16>,
+  iXLen);
+
+define void @intrinsic_xvsxh_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxh_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vsxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxh.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    <vscale x 4 x i16> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxh.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i16>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxh_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i16> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxh_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vsxh.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxh.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    <vscale x 4 x i16> %2, 
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxh.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i16>,
+  iXLen);
+
+define void @intrinsic_xvsxh_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxh_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vsxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxh.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    <vscale x 8 x i16> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxh.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i16>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxh_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i16> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxh_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vsxh.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxh.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    <vscale x 8 x i16> %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxh.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i16>,
+  iXLen);
+
+define void @intrinsic_xvsxh_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, <vscale x 16 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxh_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vsxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxh.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    <vscale x 16 x i16> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxh.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i16>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxh_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i16> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxh_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vsxh.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxh.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    <vscale x 16 x i16> %2, 
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxh.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i16>,
+  iXLen);
+
+define void @intrinsic_xvsxh_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, <vscale x 32 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxh_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vsxh.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxh.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    <vscale x 32 x i16> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxh.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i16>,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxh_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, <vscale x 32 x i16> %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxh_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vsxh.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxh.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    <vscale x 32 x i16> %2, 
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxw.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define void @intrinsic_xvsxw_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxw_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vsxw.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxw.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxw.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxw_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxw_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vsxw.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxw.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i32> %2, 
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxw.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define void @intrinsic_xvsxw_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxw_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vsxw.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxw.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxw.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxw_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxw_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vsxw.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxw.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i32> %2, 
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxw.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define void @intrinsic_xvsxw_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxw_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vsxw.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxw.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxw.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxw_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxw_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vsxw.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxw.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i32> %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxw.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define void @intrinsic_xvsxw_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxw_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vsxw.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxw.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxw.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxw_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxw_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vsxw.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxw.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i32> %2, 
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i8>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> undef,
+    <vscale x 8 x i8>* %0,
+    <vscale x 8 x i8> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv8i8.nxv8i8(
+  <vscale x 8 x i8>,
+  <vscale x 8 x i8>*,
+  <vscale x 8 x i8>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i8> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv8i8_nxv8i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv8i8.nxv8i8(
+    <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    <vscale x 8 x i8> %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i8>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, <vscale x 16 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8>* %0,
+    <vscale x 16 x i8> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>*,
+  <vscale x 16 x i8>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i8> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv16i8_nxv16i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m2, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    <vscale x 16 x i8> %2, 
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i8>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, <vscale x 32 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8>* %0,
+    <vscale x 32 x i8> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>*,
+  <vscale x 32 x i8>,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, <vscale x 32 x i8> %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv32i8_nxv32i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m4, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    <vscale x 32 x i8> %2, 
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i8>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv64i8_nxv64i8(<vscale x 64 x i8>* %0, <vscale x 64 x i8> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8>* %0,
+    <vscale x 64 x i8> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>*,
+  <vscale x 64 x i8>,
+  <vscale x 64 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv64i8_nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i8>* %1, <vscale x 64 x i8> %2, <vscale x 64 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv64i8_nxv64i8
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e8, m8, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> %0,
+    <vscale x 64 x i8>* %1,
+    <vscale x 64 x i8> %2, 
+    <vscale x 64 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i16>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> undef,
+    <vscale x 4 x i16>* %0,
+    <vscale x 4 x i16> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv4i16.nxv4i16(
+  <vscale x 4 x i16>,
+  <vscale x 4 x i16>*,
+  <vscale x 4 x i16>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i16> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv4i16_nxv4i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv4i16.nxv4i16(
+    <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    <vscale x 4 x i16> %2, 
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv4f16.nxv4f16(
+  <vscale x 4 x half>,
+  <vscale x 4 x half>*,
+  <vscale x 4 x half>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv4f16_nxv4f16(<vscale x 4 x half>* %0, <vscale x 4 x half> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv4f16_nxv4f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv4f16.nxv4f16(
+    <vscale x 4 x half> undef,
+    <vscale x 4 x half>* %0,
+    <vscale x 4 x half> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv4f16.nxv4f16(
+  <vscale x 4 x half>,
+  <vscale x 4 x half>*,
+  <vscale x 4 x half>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv4f16_nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x half>* %1, <vscale x 4 x half> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv4f16_nxv4f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m1, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv4f16.nxv4f16(
+    <vscale x 4 x half> %0,
+    <vscale x 4 x half>* %1,
+    <vscale x 4 x half> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i16>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16>* %0,
+    <vscale x 8 x i16> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>*,
+  <vscale x 8 x i16>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i16> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv8i16_nxv8i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    <vscale x 8 x i16> %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv8f16.nxv8f16(
+  <vscale x 8 x half>,
+  <vscale x 8 x half>*,
+  <vscale x 8 x half>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv8f16_nxv8f16(<vscale x 8 x half>* %0, <vscale x 8 x half> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv8f16_nxv8f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv8f16.nxv8f16(
+    <vscale x 8 x half> undef,
+    <vscale x 8 x half>* %0,
+    <vscale x 8 x half> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv8f16.nxv8f16(
+  <vscale x 8 x half>,
+  <vscale x 8 x half>*,
+  <vscale x 8 x half>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv8f16_nxv8f16(<vscale x 8 x half> %0, <vscale x 8 x half>* %1, <vscale x 8 x half> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv8f16_nxv8f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m2, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv8f16.nxv8f16(
+    <vscale x 8 x half> %0,
+    <vscale x 8 x half>* %1,
+    <vscale x 8 x half> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i16>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, <vscale x 16 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16>* %0,
+    <vscale x 16 x i16> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>*,
+  <vscale x 16 x i16>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i16> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv16i16_nxv16i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    <vscale x 16 x i16> %2, 
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv16f16.nxv16f16(
+  <vscale x 16 x half>,
+  <vscale x 16 x half>*,
+  <vscale x 16 x half>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv16f16_nxv16f16(<vscale x 16 x half>* %0, <vscale x 16 x half> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv16f16_nxv16f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv16f16.nxv16f16(
+    <vscale x 16 x half> undef,
+    <vscale x 16 x half>* %0,
+    <vscale x 16 x half> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv16f16.nxv16f16(
+  <vscale x 16 x half>,
+  <vscale x 16 x half>*,
+  <vscale x 16 x half>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv16f16_nxv16f16(<vscale x 16 x half> %0, <vscale x 16 x half>* %1, <vscale x 16 x half> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv16f16_nxv16f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m4, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv16f16.nxv16f16(
+    <vscale x 16 x half> %0,
+    <vscale x 16 x half>* %1,
+    <vscale x 16 x half> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i16>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv32i16_nxv32i16(<vscale x 32 x i16>* %0, <vscale x 32 x i16> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16>* %0,
+    <vscale x 32 x i16> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>*,
+  <vscale x 32 x i16>,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv32i16_nxv32i16(<vscale x 32 x i16> %0, <vscale x 32 x i16>* %1, <vscale x 32 x i16> %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv32i16_nxv32i16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> %0,
+    <vscale x 32 x i16>* %1,
+    <vscale x 32 x i16> %2, 
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv32f16.nxv32f16(
+  <vscale x 32 x half>,
+  <vscale x 32 x half>*,
+  <vscale x 32 x half>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv32f16_nxv32f16(<vscale x 32 x half>* %0, <vscale x 32 x half> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv32f16_nxv32f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv32f16.nxv32f16(
+    <vscale x 32 x half> undef,
+    <vscale x 32 x half>* %0,
+    <vscale x 32 x half> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv32f16.nxv32f16(
+  <vscale x 32 x half>,
+  <vscale x 32 x half>*,
+  <vscale x 32 x half>,
+  <vscale x 32 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv32f16_nxv32f16(<vscale x 32 x half> %0, <vscale x 32 x half>* %1, <vscale x 32 x half> %2, <vscale x 32 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv32f16_nxv32f16
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e16, m8, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv32f16.nxv32f16(
+    <vscale x 32 x half> %0,
+    <vscale x 32 x half>* %1,
+    <vscale x 32 x half> %2,
+    <vscale x 32 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> undef,
+    <vscale x 2 x i32>* %0,
+    <vscale x 2 x i32> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv2i32.nxv2i32(
+  <vscale x 2 x i32>,
+  <vscale x 2 x i32>*,
+  <vscale x 2 x i32>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv2i32_nxv2i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv2i32.nxv2i32(
+    <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    <vscale x 2 x i32> %2, 
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv2f32.nxv2f32(
+  <vscale x 2 x float>,
+  <vscale x 2 x float>*,
+  <vscale x 2 x float>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv2f32_nxv2f32(<vscale x 2 x float>* %0, <vscale x 2 x float> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv2f32_nxv2f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv2f32.nxv2f32(
+    <vscale x 2 x float> undef,
+    <vscale x 2 x float>* %0,
+    <vscale x 2 x float> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv2f32.nxv2f32(
+  <vscale x 2 x float>,
+  <vscale x 2 x float>*,
+  <vscale x 2 x float>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv2f32_nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x float>* %1, <vscale x 2 x float> %2, <vscale x 2 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv2f32_nxv2f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v9, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv2f32.nxv2f32(
+    <vscale x 2 x float> %0,
+    <vscale x 2 x float>* %1,
+    <vscale x 2 x float> %2,
+    <vscale x 2 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32>* %0,
+    <vscale x 4 x i32> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>*,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv4i32_nxv4i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    <vscale x 4 x i32> %2, 
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv4f32.nxv4f32(
+  <vscale x 4 x float>,
+  <vscale x 4 x float>*,
+  <vscale x 4 x float>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv4f32_nxv4f32(<vscale x 4 x float>* %0, <vscale x 4 x float> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv4f32_nxv4f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv4f32.nxv4f32(
+    <vscale x 4 x float> undef,
+    <vscale x 4 x float>* %0,
+    <vscale x 4 x float> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv4f32.nxv4f32(
+  <vscale x 4 x float>,
+  <vscale x 4 x float>*,
+  <vscale x 4 x float>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv4f32_nxv4f32(<vscale x 4 x float> %0, <vscale x 4 x float>* %1, <vscale x 4 x float> %2, <vscale x 4 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv4f32_nxv4f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m2, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v10, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv4f32.nxv4f32(
+    <vscale x 4 x float> %0,
+    <vscale x 4 x float>* %1,
+    <vscale x 4 x float> %2,
+    <vscale x 4 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32>* %0,
+    <vscale x 8 x i32> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>*,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv8i32_nxv8i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    <vscale x 8 x i32> %2, 
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv8f32.nxv8f32(
+  <vscale x 8 x float>,
+  <vscale x 8 x float>*,
+  <vscale x 8 x float>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv8f32_nxv8f32(<vscale x 8 x float>* %0, <vscale x 8 x float> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv8f32_nxv8f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv8f32.nxv8f32(
+    <vscale x 8 x float> undef,
+    <vscale x 8 x float>* %0,
+    <vscale x 8 x float> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv8f32.nxv8f32(
+  <vscale x 8 x float>,
+  <vscale x 8 x float>*,
+  <vscale x 8 x float>,
+  <vscale x 8 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv8f32_nxv8f32(<vscale x 8 x float> %0, <vscale x 8 x float>* %1, <vscale x 8 x float> %2, <vscale x 8 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv8f32_nxv8f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v12, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv8f32.nxv8f32(
+    <vscale x 8 x float> %0,
+    <vscale x 8 x float>* %1,
+    <vscale x 8 x float> %2,
+    <vscale x 8 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv16i32_nxv16i32(<vscale x 16 x i32>* %0, <vscale x 16 x i32> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32>* %0,
+    <vscale x 16 x i32> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>*,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32>* %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv16i32_nxv16i32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> %0,
+    <vscale x 16 x i32>* %1,
+    <vscale x 16 x i32> %2, 
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.nxv16f32.nxv16f32(
+  <vscale x 16 x float>,
+  <vscale x 16 x float>*,
+  <vscale x 16 x float>,
+  iXLen);
+
+define void @intrinsic_xvsxe_v_nxv16f32_nxv16f32(<vscale x 16 x float>* %0, <vscale x 16 x float> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_v_nxv16f32_nxv16f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v8
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.nxv16f32.nxv16f32(
+    <vscale x 16 x float> undef,
+    <vscale x 16 x float>* %0,
+    <vscale x 16 x float> %1,
+    iXLen %2)
+
+  ret void
+}
+
+declare void @llvm.riscv.xvsxe.mask.nxv16f32.nxv16f32(
+  <vscale x 16 x float>,
+  <vscale x 16 x float>*,
+  <vscale x 16 x float>,
+  <vscale x 16 x i1>,
+  iXLen);
+
+define void @intrinsic_xvsxe_mask_v_nxv16f32_nxv16f32(<vscale x 16 x float> %0, <vscale x 16 x float>* %1, <vscale x 16 x float> %2, <vscale x 16 x i1> %3, iXLen %4) nounwind {
+; CHECK-LABEL: intrinsic_xvsxe_mask_v_nxv16f32_nxv16f32
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, d1
+; CHECK-NEXT:    vsxe.v v8, (a0), v16, v0.t
+; CHECK-NEXT:    ret
+
+entry:
+  call void @llvm.riscv.xvsxe.mask.nxv16f32.nxv16f32(
+    <vscale x 16 x float> %0,
+    <vscale x 16 x float>* %1,
+    <vscale x 16 x float> %2,
+    <vscale x 16 x i1> %3,
+    iXLen %4)
+
+  ret void
+}


### PR DESCRIPTION
This PR implements indexed load/store intrinsics described in the page 72 [here](https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource/1836682/1638774209491/Xuantie+900+Series+RVV-0.7.1+Intrinsic+Manual.pdf).

Unlike RVV 1.0, in the RVV 0.7.1 function list, the type of indexed vector is always the same as that of the return type, so I did not define a separate search table for indexed intrinsics.

Because 32-bit platforms cannot use 64-bit indexed values, I placed tests for intrinsics taking 64-bit vectors as arguments into separate files.