### PR TITLE
[LLVM][RVV 0.7.1] Support whole load/store with LMUL = 2, 4, 8

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -14850,7 +14850,7 @@ RISCVTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
 #define PseudoXVL_CASE_SEW_LMUL(SEW_val, LMUL_val)                             \
   case RISCV::PseudoXVL##LMUL_val##RE##SEW_val##_V:                            \
     return emitXWholeLoad(MI, BB, SEW_val, LMUL_val,                           \
-                          RISCV::PseudoXVLE_V_E##SEW_val##_M##LMUL_val);
+                          RISCV::XVLE_M##LMUL_val##_V);
 
 #define PseudoXVL_CASE_SEW(SEW_val)                                            \
   PseudoXVL_CASE_SEW_LMUL(SEW_val, 1);                                         \
@@ -14867,7 +14867,7 @@ RISCVTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
 #define PseudoXVS_CASE_SEW_LMUL(SEW_val, LMUL_val)                             \
   case RISCV::PseudoXVS##LMUL_val##RE##SEW_val##_V:                            \
   return emitXWholeStore(MI, BB, SEW_val, LMUL_val,                            \
-                         RISCV::PseudoXVSE_V_E##SEW_val##_M##LMUL_val);
+                         RISCV::XVSE_M##LMUL_val##_V);
 
 #define PseudoXVS_CASE_SEW(SEW_val)                                            \
   PseudoXVS_CASE_SEW_LMUL(SEW_val, 1);                                         \

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -14652,9 +14652,8 @@ static MachineBasicBlock *emitXWholeLoadStore(MachineInstr &MI,
   // From GCC: `vl<LMUL>re<SEW>.v vd, (rs)` -> `vle.v vd, (rs), vm`
   // From GCC: `vs<LMUL>r.v       vd, (rs)` -> `vse.v vs, (rs), vm`
   BuildMI(*BB, MI, DL, TII->get(Opcode))
-      .add(MI.getOperand(0))      // vd or vs
-      .add(MI.getOperand(1))      // rs, the load/store address
-      .addReg(RISCV::NoRegister); // vmask, currently no mask
+      .add(MI.getOperand(0))  // vd or vs
+      .add(MI.getOperand(1)); // rs, the load/store address
 
   // Restore vl, vtype with `vsetvl x0, SavedVL, SavedVType`
   BuildMI(*BB, MI, DL, TII->get(RISCV::XVSETVL))
@@ -14850,7 +14849,7 @@ RISCVTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
 #define PseudoXVL_CASE_SEW_LMUL(SEW_val, LMUL_val)                             \
   case RISCV::PseudoXVL##LMUL_val##RE##SEW_val##_V:                            \
     return emitXWholeLoad(MI, BB, SEW_val, LMUL_val,                           \
-                          RISCV::XVLE_M##LMUL_val##_V);
+                          RISCV::PseudoXVLE_V_M##LMUL_val);
 
 #define PseudoXVL_CASE_SEW(SEW_val)                                            \
   PseudoXVL_CASE_SEW_LMUL(SEW_val, 1);                                         \
@@ -14867,7 +14866,7 @@ RISCVTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
 #define PseudoXVS_CASE_SEW_LMUL(SEW_val, LMUL_val)                             \
   case RISCV::PseudoXVS##LMUL_val##RE##SEW_val##_V:                            \
   return emitXWholeStore(MI, BB, SEW_val, LMUL_val,                            \
-                         RISCV::XVSE_M##LMUL_val##_V);
+                         RISCV::PseudoXVSE_V_M##LMUL_val);
 
 #define PseudoXVS_CASE_SEW(SEW_val)                                            \
   PseudoXVS_CASE_SEW_LMUL(SEW_val, 1);                                         \

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -14669,14 +14669,14 @@ static MachineBasicBlock *emitXWholeLoadStore(MachineInstr &MI,
 
 static MachineBasicBlock *emitXWholeLoad(MachineInstr &MI,
                                          MachineBasicBlock *BB, unsigned SEW,
-                                         unsigned LMUL) {
-  return emitXWholeLoadStore(MI, BB, SEW, LMUL, RISCV::XVLE_V);
+                                         unsigned LMUL, unsigned Opcode) {
+  return emitXWholeLoadStore(MI, BB, SEW, LMUL, Opcode);
 }
 
 static MachineBasicBlock *emitXWholeStore(MachineInstr &MI,
                                           MachineBasicBlock *BB, unsigned SEW,
-                                          unsigned LMUL) {
-  return emitXWholeLoadStore(MI, BB, SEW, LMUL, RISCV::XVSE_V);
+                                          unsigned LMUL, unsigned Opcode) {
+  return emitXWholeLoadStore(MI, BB, SEW, LMUL, Opcode);
 }
 
 static MachineBasicBlock *emitXWholeMove(MachineInstr &MI,
@@ -14849,7 +14849,8 @@ RISCVTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
 
 #define PseudoXVL_CASE_SEW_LMUL(SEW_val, LMUL_val)                             \
   case RISCV::PseudoXVL##LMUL_val##RE##SEW_val##_V:                            \
-    return emitXWholeLoad(MI, BB, SEW_val, LMUL_val);
+    return emitXWholeLoad(MI, BB, SEW_val, LMUL_val,                           \
+                          RISCV::PseudoXVLE_V_E##SEW_val##_M##LMUL_val);
 
 #define PseudoXVL_CASE_SEW(SEW_val)                                            \
   PseudoXVL_CASE_SEW_LMUL(SEW_val, 1);                                         \
@@ -14865,7 +14866,8 @@ RISCVTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
 
 #define PseudoXVS_CASE_SEW_LMUL(SEW_val, LMUL_val)                             \
   case RISCV::PseudoXVS##LMUL_val##RE##SEW_val##_V:                            \
-    return emitXWholeStore(MI, BB, SEW_val, LMUL_val);
+  return emitXWholeStore(MI, BB, SEW_val, LMUL_val,                            \
+                         RISCV::PseudoXVSE_V_E##SEW_val##_M##LMUL_val);
 
 #define PseudoXVS_CASE_SEW(SEW_val)                                            \
   PseudoXVS_CASE_SEW_LMUL(SEW_val, 1);                                         \

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -650,7 +650,7 @@ class XVPseudoWholeLoad<Instruction instr, LMULInfo m, RegisterClass VRC>
 }
 
 multiclass XVPseudoWholeLoadN<bits<3> nf, LMULInfo m, RegisterClass VRC> {
-  foreach l = [8, 16, 32, 64] in {
+  foreach l = EEWList in {
     defvar s = !cast<SchedWrite>("WriteVLD" # !add(nf, 1) # "R");
 
     def E # l # _V : XVPseudoWholeLoad<XVLE_V, m, VRC>,
@@ -663,7 +663,7 @@ class XVPseudoWholeStore<Instruction instr, LMULInfo m, RegisterClass VRC>
 }
 
 multiclass XVPseudoWholeStoreN<bits<3> nf, LMULInfo m, RegisterClass VRC> {
-  foreach l = [8, 16, 32, 64] in {
+  foreach l = EEWList in {
     defvar sw = !cast<SchedWrite>("WriteVST" # !add(nf, 1) # "R");
     defvar sr = !cast<SchedRead>("ReadVST" # !add(nf, 1) # "R");
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -602,49 +602,57 @@ let Predicates = [HasVendorXTHeadV] in {
 // for emulating Vector Load/Store Whole Register Instructions in RVV 1.0
 //===----------------------------------------------------------------------===//
 
-// This part redefines `vle.v` and `vse.v`, with the type of operands
-// being VRM2, VRM4 and VRM8, but generates the same MC instructions.
-// That is, only to make the lowered whole load/store well-typed.
-// See: https://github.com/ruyisdk/llvm-project/pull/23#issuecomment-1816071060
-// TODO: consider using `PseudoXVLE_V_E*_M*` and `PseudoXVSE_V_E*_M*` defined above.
+// This part defines the pseudo `PseudoXVLE_V_M*` and `PseudoXVSE_V_M*`,
+// with the type of operands being VRM2, VRM4 and VRM8.
+// We cannot directly convert `PseudoXVL<nr>R` or `PseudoXVS<nr>R` to `XVLE_V` or `XVSE_V`,
+// which will be reported as ill-typed program by the type checker.
+// See https://github.com/ruyisdk/llvm-project/pull/23#issuecomment-1816071060 for details.
 
-let hasSideEffects = 0, mayLoad = 1, mayStore = 0, RVVConstraint = VMConstraint in {
-  class XVLxU_VRC<bits<3> nf, bits<3> width, string opcodestr, RegisterClass VRC>
-      : XVLoadStore<nf, OPC_LOAD_FP, 0b000, width, (outs VRC:$rd),
-                    (ins GPRMemZeroOffset:$rs1, VMaskOp:$vm),
-                    opcodestr, "$rd, ${rs1}$vm"> {
-    let rs2 = 0b00000;
+// In the following, we define such pseudos only to make the type checker happy.
+// As the types in these pseudos are always erased when lowering to MCInst.
+// TODO: consider using `PseudoXVLE_V_E*_M*` and `PseudoXVSE_V_E*_M*` defined above,
+//   but these pseudos seems to require more operands like `AVL:$vl, ixlenimm:$sew`,
+//   some of which are not available in the original `PseudoXVL<nr>R` and `PseudoXVS<nr>R`.
+
+multiclass XVPseudoWellTypedUSLoadStore_VLE {
+  foreach lmul = MxListXTHeadV in {
+    defvar LInfo = lmul.MX;
+    defvar vreg = lmul.vrclass;
+
+    let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in {
+      def "_" # LInfo : Pseudo<(outs vreg:$vd), (ins GPRMemZeroOffset:$rs1), []>,
+                        RISCVVPseudo;
+    }
   }
 }
-let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in {
-  class XVSx_VRC<bits<3> nf, bits<3> width, string opcodestr, RegisterClass VRC>
-      : XVLoadStore<nf, OPC_STORE_FP, 0b000, width, (outs),
-                    (ins VRC:$rd, GPRMemZeroOffset:$rs1, VMaskOp:$vm),
-                    opcodestr, "$rd, ${rs1}$vm"> {
-    let rs2 = 0b00000;
+
+multiclass XVPseudoWellTypedUSLoadStore_VSE {
+  foreach lmul = MxListXTHeadV in {
+    defvar LInfo = lmul.MX;
+    defvar vreg = lmul.vrclass;
+
+    let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in {
+      def "_" # LInfo : Pseudo<(outs), (ins vreg:$vs, GPRMemZeroOffset:$rs1), []>,
+                        RISCVVPseudo;
+    }
   }
 }
 
 // Set `isCodeGenOnly = 1` to hide them from the tablegened assembly parser,
 // to avoid decoding conflict with the original `vle.v` and `vse.v` in RISCVInstraInfoXTHeadV.td
 let Predicates = [HasVendorXTHeadV], isCodeGenOnly = 1 in {
-  def XVLE_M1_V : XVLxU_VRC<0b000, 0b111, "vle.v", VR>;
-  def XVLE_M2_V : XVLxU_VRC<0b000, 0b111, "vle.v", VRM2>;
-  def XVLE_M4_V : XVLxU_VRC<0b000, 0b111, "vle.v", VRM4>;
-  def XVLE_M8_V : XVLxU_VRC<0b000, 0b111, "vle.v", VRM8>;
-
-  def XVSE_M1_V : XVSx_VRC<0b000, 0b111, "vse.v", VR>;
-  def XVSE_M2_V : XVSx_VRC<0b000, 0b111, "vse.v", VRM2>;
-  def XVSE_M4_V : XVSx_VRC<0b000, 0b111, "vse.v", VRM4>;
-  def XVSE_M8_V : XVSx_VRC<0b000, 0b111, "vse.v", VRM8>;
+  defm PseudoXVLE_V : XVPseudoWellTypedUSLoadStore_VLE;
+  defm PseudoXVSE_V : XVPseudoWellTypedUSLoadStore_VSE;
 } // Predicates = [HasVendorXTHeadV], isCodeGenOnly = 1
 
-// This part defines the pseudo version of vl<n>r.v and vs<n>r.v,
+// This part defines the pseudo version of `vl<n>r.v` and `vs<n>r.v`,
+// that is, `PseudoXVL<nr>R` and `PseudoXVS<nr>R`,
 // and explcitly binds them to LLVM IR `load`/`store` intrinsic calls
 // in the instruction selection process, which enables directly
 // loading/storing a vector register in LLVM IR with builtin `load`/`store`,
 // without the need of remembering the RISCV-V intrinsic name and type.
 // See: llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-*.ll
+
 class XVPseudoWholeLoad<Instruction instr, LMULInfo m, RegisterClass VRC>
   : VPseudo<instr, m, (outs VRC:$vd), (ins GPRMemZeroOffset:$rs1)> {
 }
@@ -672,7 +680,8 @@ multiclass XVPseudoWholeStoreN<bits<3> nf, LMULInfo m, RegisterClass VRC> {
   }
 }
 
-// Set `usesCustomInserter = 1` to lower these manually to `XVLE_M*_V` defined above.
+// Set `usesCustomInserter = 1` to lower these manually
+// to `PseudoXVLE_V_M*` or `PseudoXVSE_V_M*` defined above.
 // See: RISCVISelLowering.cpp, function `RISCVTargetLowering::EmitInstrWithCustomInserter`
 // and `emitXWholeLoadStore`.
 let Predicates = [HasVendorXTHeadV] in {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -601,8 +601,52 @@ let Predicates = [HasVendorXTHeadV] in {
 // 7. Vector Loads and Stores
 // for emulating Vector Load/Store Whole Register Instructions in RVV 1.0
 //===----------------------------------------------------------------------===//
+
+// This part redefines `vle.v` and `vse.v`, with the type of operands
+// being VRM2, VRM4 and VRM8, but generates the same MC instructions.
+// That is, only to make the lowered whole load/store well-typed.
+// See: https://github.com/ruyisdk/llvm-project/pull/23#issuecomment-1816071060
+// TODO: consider using `PseudoXVLE_V_E*_M*` and `PseudoXVSE_V_E*_M*` defined above.
+
+let hasSideEffects = 0, mayLoad = 1, mayStore = 0, RVVConstraint = VMConstraint in {
+  class XVLxU_VRC<bits<3> nf, bits<3> width, string opcodestr, RegisterClass VRC>
+      : XVLoadStore<nf, OPC_LOAD_FP, 0b000, width, (outs VRC:$rd),
+                    (ins GPRMemZeroOffset:$rs1, VMaskOp:$vm),
+                    opcodestr, "$rd, ${rs1}$vm"> {
+    let rs2 = 0b00000;
+  }
+}
+let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in {
+  class XVSx_VRC<bits<3> nf, bits<3> width, string opcodestr, RegisterClass VRC>
+      : XVLoadStore<nf, OPC_STORE_FP, 0b000, width, (outs),
+                    (ins VRC:$rd, GPRMemZeroOffset:$rs1, VMaskOp:$vm),
+                    opcodestr, "$rd, ${rs1}$vm"> {
+    let rs2 = 0b00000;
+  }
+}
+
+// Set `isCodeGenOnly = 1` to hide them from the tablegened assembly parser,
+// to avoid decoding conflict with the original `vle.v` and `vse.v` in RISCVInstraInfoXTHeadV.td
+let Predicates = [HasVendorXTHeadV], isCodeGenOnly = 1 in {
+  def XVLE_M1_V : XVLxU_VRC<0b000, 0b111, "vle.v", VR>;
+  def XVLE_M2_V : XVLxU_VRC<0b000, 0b111, "vle.v", VRM2>;
+  def XVLE_M4_V : XVLxU_VRC<0b000, 0b111, "vle.v", VRM4>;
+  def XVLE_M8_V : XVLxU_VRC<0b000, 0b111, "vle.v", VRM8>;
+
+  def XVSE_M1_V : XVSx_VRC<0b000, 0b111, "vse.v", VR>;
+  def XVSE_M2_V : XVSx_VRC<0b000, 0b111, "vse.v", VRM2>;
+  def XVSE_M4_V : XVSx_VRC<0b000, 0b111, "vse.v", VRM4>;
+  def XVSE_M8_V : XVSx_VRC<0b000, 0b111, "vse.v", VRM8>;
+}
+
+// This part defines the pseudo version of vl<n>r.v and vs<n>r.v,
+// and explcitly binds them to LLVM IR `load`/`store` intrinsic calls
+// in the instruction selection process, which enables directly
+// loading/storing a vector register in LLVM IR with builtin `load`/`store`,
+// without the need of remembering the RISCV-V intrinsic name and type.
+// See: llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-*.ll
 class XVPseudoWholeLoad<Instruction instr, LMULInfo m, RegisterClass VRC>
-  : VPseudo<instr, m, (outs VRC:$vd),   (ins GPRMemZeroOffset:$rs1)> {
+  : VPseudo<instr, m, (outs VRC:$vd), (ins GPRMemZeroOffset:$rs1)> {
 }
 
 multiclass XVPseudoWholeLoadN<bits<3> nf, LMULInfo m, RegisterClass VRC> {
@@ -615,7 +659,7 @@ multiclass XVPseudoWholeLoadN<bits<3> nf, LMULInfo m, RegisterClass VRC> {
 }
 
 class XVPseudoWholeStore<Instruction instr, LMULInfo m, RegisterClass VRC>
-  : VPseudo<instr, m, (outs),   (ins VRC:$vs3, GPRMemZeroOffset:$rs1)> {
+  : VPseudo<instr, m, (outs), (ins VRC:$vs3, GPRMemZeroOffset:$rs1)> {
 }
 
 multiclass XVPseudoWholeStoreN<bits<3> nf, LMULInfo m, RegisterClass VRC> {
@@ -645,7 +689,7 @@ let Predicates = [HasVendorXTHeadV] in {
   }
 } // Predicates = [HasVendorXTHeadV]
 
-// patterns for emulated whole register load/store
+// Patterns to bind the pseudo instructions to LLVM IR `load`/`store` intrinsic calls.
 multiclass XVPatUSLoadStoreWholeVRSDNode<ValueType type,
                                          int log2sew,
                                          LMULInfo vlmul,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -637,7 +637,7 @@ let Predicates = [HasVendorXTHeadV], isCodeGenOnly = 1 in {
   def XVSE_M2_V : XVSx_VRC<0b000, 0b111, "vse.v", VRM2>;
   def XVSE_M4_V : XVSx_VRC<0b000, 0b111, "vse.v", VRM4>;
   def XVSE_M8_V : XVSx_VRC<0b000, 0b111, "vse.v", VRM8>;
-}
+} // Predicates = [HasVendorXTHeadV], isCodeGenOnly = 1
 
 // This part defines the pseudo version of vl<n>r.v and vs<n>r.v,
 // and explcitly binds them to LLVM IR `load`/`store` intrinsic calls
@@ -672,6 +672,9 @@ multiclass XVPseudoWholeStoreN<bits<3> nf, LMULInfo m, RegisterClass VRC> {
   }
 }
 
+// Set `usesCustomInserter = 1` to lower these manually to `XVLE_M*_V` defined above.
+// See: RISCVISelLowering.cpp, function `RISCVTargetLowering::EmitInstrWithCustomInserter`
+// and `emitXWholeLoadStore`.
 let Predicates = [HasVendorXTHeadV] in {
   // Whole register load
   let hasSideEffects = 0, mayLoad = 1, mayStore = 0, isCodeGenOnly = 1, usesCustomInserter = 1 in {

--- a/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-16.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-16.ll
@@ -46,3 +46,135 @@ define void @vadd_vint16m1(<vscale x 4 x i16> *%pc, <vscale x 4 x i16> *%pa, <vs
   store <vscale x 4 x i16> %vc, <vscale x 4 x i16> *%pc
   ret void
 }
+
+declare <vscale x 8 x i16> @llvm.riscv.xvadd.nxv8i16.nxv8i16(
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>,
+  <vscale x 8 x i16>,
+  iXLen);
+
+define void @vadd_vint16m2(<vscale x 8 x i16> *%pc, <vscale x 8 x i16> *%pa, <vscale x 8 x i16> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint16m2:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e16, m2, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e16, m2, d1
+; CHECK-NEXT:    vle.v	v10, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e16, m2, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v10
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e16, m2, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 8 x i16>, <vscale x 8 x i16>* %pa
+  %vb = load <vscale x 8 x i16>, <vscale x 8 x i16>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 8 x i16> %va, %vb
+  %vc = call <vscale x 8 x i16> @llvm.riscv.xvadd.nxv8i16.nxv8i16(
+    <vscale x 8 x i16> undef,
+    <vscale x 8 x i16> %va,
+    <vscale x 8 x i16> %vb,
+    iXLen %vl)
+  store <vscale x 8 x i16> %vc, <vscale x 8 x i16> *%pc
+  ret void
+}
+
+declare <vscale x 16 x i16> @llvm.riscv.xvadd.nxv16i16.nxv16i16(
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>,
+  <vscale x 16 x i16>,
+  iXLen);
+
+define void @vadd_vint16m4(<vscale x 16 x i16> *%pc, <vscale x 16 x i16> *%pa, <vscale x 16 x i16> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint16m4:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e16, m4, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e16, m4, d1
+; CHECK-NEXT:    vle.v	v12, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e16, m4, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v12
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e16, m4, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 16 x i16>, <vscale x 16 x i16>* %pa
+  %vb = load <vscale x 16 x i16>, <vscale x 16 x i16>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 16 x i16> %va, %vb
+  %vc = call <vscale x 16 x i16> @llvm.riscv.xvadd.nxv16i16.nxv16i16(
+    <vscale x 16 x i16> undef,
+    <vscale x 16 x i16> %va,
+    <vscale x 16 x i16> %vb,
+    iXLen %vl)
+  store <vscale x 16 x i16> %vc, <vscale x 16 x i16> *%pc
+  ret void
+}
+
+declare <vscale x 32 x i16> @llvm.riscv.xvadd.nxv32i16.nxv32i16(
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>,
+  <vscale x 32 x i16>,
+  iXLen);
+
+define void @vadd_vint16m8(<vscale x 32 x i16> *%pc, <vscale x 32 x i16> *%pa, <vscale x 32 x i16> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint16m8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e16, m8, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e16, m8, d1
+; CHECK-NEXT:    vle.v	v16, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e16, m8, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v16
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e16, m8, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 32 x i16>, <vscale x 32 x i16>* %pa
+  %vb = load <vscale x 32 x i16>, <vscale x 32 x i16>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 32 x i16> %va, %vb
+  %vc = call <vscale x 32 x i16> @llvm.riscv.xvadd.nxv32i16.nxv32i16(
+    <vscale x 32 x i16> undef,
+    <vscale x 32 x i16> %va,
+    <vscale x 32 x i16> %vb,
+    iXLen %vl)
+  store <vscale x 32 x i16> %vc, <vscale x 32 x i16> *%pc
+  ret void
+}

--- a/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-32.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-32.ll
@@ -46,3 +46,135 @@ define void @vadd_vint32m1(<vscale x 2 x i32> *%pc, <vscale x 2 x i32> *%pa, <vs
   store <vscale x 2 x i32> %vc, <vscale x 2 x i32> *%pc
   ret void
 }
+
+declare <vscale x 4 x i32> @llvm.riscv.xvadd.nxv4i32.nxv4i32(
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  <vscale x 4 x i32>,
+  iXLen);
+
+define void @vadd_vint32m2(<vscale x 4 x i32> *%pc, <vscale x 4 x i32> *%pa, <vscale x 4 x i32> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint32m2:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e32, m2, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e32, m2, d1
+; CHECK-NEXT:    vle.v	v10, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e32, m2, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v10
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e32, m2, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 4 x i32>, <vscale x 4 x i32>* %pa
+  %vb = load <vscale x 4 x i32>, <vscale x 4 x i32>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 4 x i32> %va, %vb
+  %vc = call <vscale x 4 x i32> @llvm.riscv.xvadd.nxv4i32.nxv4i32(
+    <vscale x 4 x i32> undef,
+    <vscale x 4 x i32> %va,
+    <vscale x 4 x i32> %vb,
+    iXLen %vl)
+  store <vscale x 4 x i32> %vc, <vscale x 4 x i32> *%pc
+  ret void
+}
+
+declare <vscale x 8 x i32> @llvm.riscv.xvadd.nxv8i32.nxv8i32(
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  <vscale x 8 x i32>,
+  iXLen);
+
+define void @vadd_vint32m4(<vscale x 8 x i32> *%pc, <vscale x 8 x i32> *%pa, <vscale x 8 x i32> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint32m4:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e32, m4, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e32, m4, d1
+; CHECK-NEXT:    vle.v	v12, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e32, m4, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v12
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e32, m4, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 8 x i32>, <vscale x 8 x i32>* %pa
+  %vb = load <vscale x 8 x i32>, <vscale x 8 x i32>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 8 x i32> %va, %vb
+  %vc = call <vscale x 8 x i32> @llvm.riscv.xvadd.nxv8i32.nxv8i32(
+    <vscale x 8 x i32> undef,
+    <vscale x 8 x i32> %va,
+    <vscale x 8 x i32> %vb,
+    iXLen %vl)
+  store <vscale x 8 x i32> %vc, <vscale x 8 x i32> *%pc
+  ret void
+}
+
+declare <vscale x 16 x i32> @llvm.riscv.xvadd.nxv16i32.nxv16i32(
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  <vscale x 16 x i32>,
+  iXLen);
+
+define void @vadd_vint32m8(<vscale x 16 x i32> *%pc, <vscale x 16 x i32> *%pa, <vscale x 16 x i32> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint32m8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e32, m8, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e32, m8, d1
+; CHECK-NEXT:    vle.v	v16, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e32, m8, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v16
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e32, m8, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 16 x i32>, <vscale x 16 x i32>* %pa
+  %vb = load <vscale x 16 x i32>, <vscale x 16 x i32>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 16 x i32> %va, %vb
+  %vc = call <vscale x 16 x i32> @llvm.riscv.xvadd.nxv16i32.nxv16i32(
+    <vscale x 16 x i32> undef,
+    <vscale x 16 x i32> %va,
+    <vscale x 16 x i32> %vb,
+    iXLen %vl)
+  store <vscale x 16 x i32> %vc, <vscale x 16 x i32> *%pc
+  ret void
+}

--- a/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-64.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-64.ll
@@ -46,3 +46,135 @@ define void @vadd_vint64m1(<vscale x 1 x i64> *%pc, <vscale x 1 x i64> *%pa, <vs
   store <vscale x 1 x i64> %vc, <vscale x 1 x i64> *%pc
   ret void
 }
+
+declare <vscale x 2 x i64> @llvm.riscv.xvadd.nxv2i64.nxv2i64(
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  <vscale x 2 x i64>,
+  iXLen);
+
+define void @vadd_vint32m2(<vscale x 2 x i64> *%pc, <vscale x 2 x i64> *%pa, <vscale x 2 x i64> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint32m2:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e64, m2, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e64, m2, d1
+; CHECK-NEXT:    vle.v	v10, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e64, m2, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v10
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e64, m2, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 2 x i64>, <vscale x 2 x i64>* %pa
+  %vb = load <vscale x 2 x i64>, <vscale x 2 x i64>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 2 x i64> %va, %vb
+  %vc = call <vscale x 2 x i64> @llvm.riscv.xvadd.nxv2i64.nxv2i64(
+    <vscale x 2 x i64> undef,
+    <vscale x 2 x i64> %va,
+    <vscale x 2 x i64> %vb,
+    iXLen %vl)
+  store <vscale x 2 x i64> %vc, <vscale x 2 x i64> *%pc
+  ret void
+}
+
+declare <vscale x 4 x i64> @llvm.riscv.xvadd.nxv4i64.nxv4i64(
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  <vscale x 4 x i64>,
+  iXLen);
+
+define void @vadd_vint32m4(<vscale x 4 x i64> *%pc, <vscale x 4 x i64> *%pa, <vscale x 4 x i64> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint32m4:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e64, m4, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e64, m4, d1
+; CHECK-NEXT:    vle.v	v12, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e64, m4, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v12
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e64, m4, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 4 x i64>, <vscale x 4 x i64>* %pa
+  %vb = load <vscale x 4 x i64>, <vscale x 4 x i64>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 4 x i64> %va, %vb
+  %vc = call <vscale x 4 x i64> @llvm.riscv.xvadd.nxv4i64.nxv4i64(
+    <vscale x 4 x i64> undef,
+    <vscale x 4 x i64> %va,
+    <vscale x 4 x i64> %vb,
+    iXLen %vl)
+  store <vscale x 4 x i64> %vc, <vscale x 4 x i64> *%pc
+  ret void
+}
+
+declare <vscale x 8 x i64> @llvm.riscv.xvadd.nxv8i64.nxv8i64(
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  <vscale x 8 x i64>,
+  iXLen);
+
+define void @vadd_vint32m8(<vscale x 8 x i64> *%pc, <vscale x 8 x i64> *%pa, <vscale x 8 x i64> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint32m8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e64, m8, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e64, m8, d1
+; CHECK-NEXT:    vle.v	v16, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e64, m8, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v16
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e64, m8, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 8 x i64>, <vscale x 8 x i64>* %pa
+  %vb = load <vscale x 8 x i64>, <vscale x 8 x i64>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 8 x i64> %va, %vb
+  %vc = call <vscale x 8 x i64> @llvm.riscv.xvadd.nxv8i64.nxv8i64(
+    <vscale x 8 x i64> undef,
+    <vscale x 8 x i64> %va,
+    <vscale x 8 x i64> %vb,
+    iXLen %vl)
+  store <vscale x 8 x i64> %vc, <vscale x 8 x i64> *%pc
+  ret void
+}

--- a/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-8.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/whole-load-store-8.ll
@@ -9,12 +9,6 @@ declare <vscale x 8 x i8> @llvm.riscv.xvadd.nxv8i8.nxv8i8(
   <vscale x 8 x i8>,
   iXLen);
 
-declare <vscale x 16 x i8> @llvm.riscv.xvadd.nxv16i8.nxv16i8(
-  <vscale x 16 x i8>,
-  <vscale x 16 x i8>,
-  <vscale x 16 x i8>,
-  iXLen);
-
 define void @vadd_vint8m1(<vscale x 8 x i8> *%pc, <vscale x 8 x i8> *%pa, <vscale x 8 x i8> *%pb, iXLen %vl) nounwind {
 ; CHECK-LABEL: vadd_vint8m1:
 ; CHECK:       # %bb.0:
@@ -53,3 +47,134 @@ define void @vadd_vint8m1(<vscale x 8 x i8> *%pc, <vscale x 8 x i8> *%pa, <vscal
   ret void
 }
 
+declare <vscale x 16 x i8> @llvm.riscv.xvadd.nxv16i8.nxv16i8(
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>,
+  <vscale x 16 x i8>,
+  iXLen);
+
+define void @vadd_vint8m2(<vscale x 16 x i8> *%pc, <vscale x 16 x i8> *%pa, <vscale x 16 x i8> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint8m2:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e8, m2, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e8, m2, d1
+; CHECK-NEXT:    vle.v	v10, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e8, m2, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v10
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e8, m2, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 16 x i8>, <vscale x 16 x i8>* %pa
+  %vb = load <vscale x 16 x i8>, <vscale x 16 x i8>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 16 x i8> %va, %vb
+  %vc = call <vscale x 16 x i8> @llvm.riscv.xvadd.nxv16i8.nxv16i8(
+    <vscale x 16 x i8> undef,
+    <vscale x 16 x i8> %va,
+    <vscale x 16 x i8> %vb,
+    iXLen %vl)
+  store <vscale x 16 x i8> %vc, <vscale x 16 x i8> *%pc
+  ret void
+}
+
+declare <vscale x 32 x i8> @llvm.riscv.xvadd.nxv32i8.nxv32i8(
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>,
+  <vscale x 32 x i8>,
+  iXLen);
+
+define void @vadd_vint8m4(<vscale x 32 x i8> *%pc, <vscale x 32 x i8> *%pa, <vscale x 32 x i8> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint8m4:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e8, m4, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e8, m4, d1
+; CHECK-NEXT:    vle.v	v12, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e8, m4, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v12
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e8, m4, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 32 x i8>, <vscale x 32 x i8>* %pa
+  %vb = load <vscale x 32 x i8>, <vscale x 32 x i8>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 32 x i8> %va, %vb
+  %vc = call <vscale x 32 x i8> @llvm.riscv.xvadd.nxv32i8.nxv32i8(
+    <vscale x 32 x i8> undef,
+    <vscale x 32 x i8> %va,
+    <vscale x 32 x i8> %vb,
+    iXLen %vl)
+  store <vscale x 32 x i8> %vc, <vscale x 32 x i8> *%pc
+  ret void
+}
+
+declare <vscale x 64 x i8> @llvm.riscv.xvadd.nxv64i8.nxv64i8(
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>,
+  <vscale x 64 x i8>,
+  iXLen);
+
+define void @vadd_vint8m8(<vscale x 64 x i8> *%pc, <vscale x 64 x i8> *%pa, <vscale x 64 x i8> *%pb, iXLen %vl) nounwind {
+; CHECK-LABEL: vadd_vint8m8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    csrr	a4, vl
+; CHECK-NEXT:    csrr	a5, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e8, m8, d1
+; CHECK-NEXT:    vle.v	v8, (a1)
+; CHECK-NEXT:    vsetvl	zero, a4, a5
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a4, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e8, m8, d1
+; CHECK-NEXT:    vle.v	v16, (a2)
+; CHECK-NEXT:    vsetvl	zero, a1, a4
+
+; CHECK-NEXT:    vsetvli zero, a3, e8, m8, d1
+; CHECK-NEXT:    vadd.vv v8, v8, v16
+
+; CHECK-NEXT:    csrr	a1, vl
+; CHECK-NEXT:    csrr	a2, vtype
+; CHECK-NEXT:    vsetvli	zero, zero, e8, m8, d1
+; CHECK-NEXT:    vse.v	v8, (a0)
+; CHECK-NEXT:    vsetvl	zero, a1, a2
+
+; CHECK-NEXT:    ret
+  %va = load <vscale x 64 x i8>, <vscale x 64 x i8>* %pa
+  %vb = load <vscale x 64 x i8>, <vscale x 64 x i8>* %pb
+  ; TODO: support select `add` to `llvm.riscv.xvadd`
+  ; %vc = add <vscale x 64 x i8> %va, %vb
+  %vc = call <vscale x 64 x i8> @llvm.riscv.xvadd.nxv64i8.nxv64i8(
+    <vscale x 64 x i8> undef,
+    <vscale x 64 x i8> %va,
+    <vscale x 64 x i8> %vb,
+    iXLen %vl)
+  store <vscale x 64 x i8> %vc, <vscale x 64 x i8> *%pc
+  ret void
+}


### PR DESCRIPTION
Fixes https://github.com/ruyisdk/llvm-project/pull/23#issuecomment-1816071060 :

> Found a new problem. Would be fixed in new PRs.
> 
> Our `XVLE_V` and `XVSE_V` only return or accept registers from the `VR` group, which works fine when LMUL is 1. But for LMUL cases 2, 4, and 8, these instructions should also accept `VRM2`, `VRM4`, and `VRM8`.
> 
> To illustrate, add the following test code:
> 
> ```llvm
> declare <vscale x 16 x i8> @llvm.riscv.xvadd.nxv16i8.nxv16i8(
>   <vscale x 16 x i8>,
>   <vscale x 16 x i8>,
>   <vscale x 16 x i8>,
>   iXLen);
> 
> define void @vadd_vint8m2(<vscale x 16 x i8> *%pc, <vscale x 16 x i8> *%pa, <vscale x 16 x i8> *%pb, iXLen %vl) nounwind {
> ; CHECK-LABEL: vadd_vint8m2:
> ; CHECK:       # %bb.0:
> ; CHECK-NEXT:    csrr	a4, vl
> ; CHECK-NEXT:    csrr	a5, vtype
> ; CHECK-NEXT:    vsetvli	zero, zero, e8, m2, d1
> ; CHECK-NEXT:    vle.v	v8, (a1)
> ; CHECK-NEXT:    vsetvl	zero, a4, a5
> 
> ; CHECK-NEXT:    csrr	a1, vl
> ; CHECK-NEXT:    csrr	a4, vtype
> ; CHECK-NEXT:    vsetvli	zero, zero, e8, m2, d1
> ; CHECK-NEXT:    vle.v	v10, (a2)
> ; CHECK-NEXT:    vsetvl	zero, a1, a4
> 
> ; CHECK-NEXT:    vsetvli zero, a3, e8, m2, d1
> ; CHECK-NEXT:    vadd.vv v8, v8, v10
> 
> ; CHECK-NEXT:    csrr	a1, vl
> ; CHECK-NEXT:    csrr	a2, vtype
> ; CHECK-NEXT:    vsetvli	zero, zero, e8, m2, d1
> ; CHECK-NEXT:    vse.v	v8, (a0)
> ; CHECK-NEXT:    vsetvl	zero, a1, a2
> 
> ; CHECK-NEXT:    ret
>   %va = load <vscale x 16 x i8>, <vscale x 16 x i8>* %pa
>   %vb = load <vscale x 16 x i8>, <vscale x 16 x i8>* %pb
>   ; TODO: support select `add` to `llvm.riscv.xvadd`
>   ; %vc = add <vscale x 16 x i8> %va, %vb
>   %vc = call <vscale x 16 x i8> @llvm.riscv.xvadd.nxv16i8.nxv16i8(
>     <vscale x 16 x i8> undef,
>     <vscale x 16 x i8> %va,
>     <vscale x 16 x i8> %vb,
>     iXLen %vl)
>   store <vscale x 16 x i8> %vc, <vscale x 16 x i8> *%pc
>   ret void
> }
> ```
> 
> Now it crashes with:
> 
> ```
> *** Bad machine code: Illegal virtual register for instruction ***
> - function:    vadd_vint8m2
> - basic block: %bb.0  (0x5604bd33b7a8)
> - instruction: %4:vrm2 = XVLE_V %1:gpr, $noreg, implicit $vtype, implicit $vl
> - operand 0:   %4:vrm2
> Expected a VR register, but got a VRM2 register
> 
> *** Bad machine code: Illegal virtual register for instruction ***
> - function:    vadd_vint8m2
> - basic block: %bb.0  (0x5604bd33b7a8)
> - instruction: %5:vrm2 = XVLE_V %2:gpr, $noreg, implicit $vtype, implicit $vl
> - operand 0:   %5:vrm2
> Expected a VR register, but got a VRM2 register
> 
> *** Bad machine code: Illegal virtual register for instruction ***
> - function:    vadd_vint8m2
> - basic block: %bb.0  (0x5604bd33b7a8)
> - instruction: XVSE_V killed %6:vrm2, %0:gpr, $noreg, implicit $vtype, implicit $vl
> - operand 0:   killed %6:vrm2
> Expected a VR register, but got a VRM2 registe
> ```

