### PR TITLE
fix build by changing enum definition

### DIFF
--- a/clang/utils/TableGen/TableGenBackends.h
+++ b/clang/utils/TableGen/TableGenBackends.h
@@ -29,7 +29,7 @@ namespace clang {
 // or
 // `#pragma clang riscv intrinsic thead_vector` for RVV 0.7.1 (the
 // `XTHEADV_VECTOR`).
-enum RVVHeaderType : uint8_t { RVV, XTHEADV_VECTOR };
+enum RVVHeaderType { RVV, XTHEADV_VECTOR };
 
 void EmitClangDeclContext(llvm::RecordKeeper &RK, llvm::raw_ostream &OS);
 void EmitClangASTNodes(llvm::RecordKeeper &RK, llvm::raw_ostream &OS,


### PR DESCRIPTION
First of all, thank you for including the `xtheadvector` into llvm :-)

I tried to build it from scratch, and I got this error. The build works with the proposed fix.

```bash
/home/janniss/Documents/llvm-project/clang/utils/TableGen/TableGenBackends.h:32:20: error: found ‘:’ in nested-name-specifier, expected ‘::’                                     
   32 | enum RVVHeaderType : uint8_t { RVV, XTHEADV_VECTOR };                                                                                                                    
      |                    ^                                                                                                                                                     
      |                    ::                                                                                                                                                    
/home/janniss/Documents/llvm-project/clang/utils/TableGen/TableGenBackends.h:32:6: error: ‘RVVHeaderType’ has not been declared                                                  
   32 | enum RVVHeaderType : uint8_t { RVV, XTHEADV_VECTOR };                                                                                                                    
      |      ^~~~~~~~~~~~~                                                                                                                                                       
/home/janniss/Documents/llvm-project/clang/utils/TableGen/TableGenBackends.h:32:30: error: expected unqualified-id before ‘{’ token                                              
   32 | enum RVVHeaderType : uint8_t { RVV, XTHEADV_VECTOR };
      |                              ^ 
/home/janniss/Documents/llvm-project/clang/utils/TableGen/TableGenBackends.h:125:20: error: ‘RVVHeaderType’ has not been declared
  125 |                    RVVHeaderType Type);
      |                    ^~~~~~~~~~~~~ 
/home/janniss/Documents/llvm-project/clang/utils/TableGen/TableGenBackends.h:127:22: error: ‘RVVHeaderType’ has not been declared
  127 |                      RVVHeaderType Type);
      |                      ^~~~~~~~~~~~~ 
```