### PR TITLE
[Clang][XTHeadVector] Add missing unit-stride load/store for `b/h/w` in clang

### DIFF
--- a/clang/include/clang/Basic/riscv_vector_xtheadv.td
+++ b/clang/include/clang/Basic/riscv_vector_xtheadv.td
@@ -175,10 +175,10 @@ let HasBuiltinAlias = false,
 
 let SupportOverloading = false,
     UnMaskedPolicyScheme = HasPassthruOperand in {
-  multiclass RVVVLEBuiltin<string ir, string masked_ir, list<string> types> {
+  multiclass RVVVLEBuiltin<string ir, list<string> types> {
     let Name = NAME # "_v",
         IRName = ir,
-        MaskedIRName = masked_ir in {
+        MaskedIRName = ir # "_mask" in {
       foreach type = types in {
         // `vPCe` is type `const T * -> VectorType`
         def : RVVOutBuiltin<"v", "vPCe", type>;
@@ -187,6 +187,21 @@ let SupportOverloading = false,
           def : RVVOutBuiltin<"Uv", "UvPCUe", type>;
         }
       }
+    }
+  }
+
+  multiclass RVVVLXBuiltin<string ir, list<string> types> {
+    foreach type = types in {
+      // `vPCe` is type `const T * -> VectorType`
+      let Name = NAME # "_v",
+          IRName = ir,
+          MaskedIRName = ir # "_mask" in
+      def : RVVOutBuiltin<"v", "vPCe", type>;
+      // `UvPCUe` is type `const unsigned T * -> unsigned VectorType`
+      let Name = NAME # "u_v",
+          IRName = ir # "u",
+          MaskedIRName = ir # "u_mask" in
+      def : RVVOutBuiltin<"Uv", "UvPCUe", type>;
     }
   }
 }
@@ -207,10 +222,10 @@ let HasMaskedOffOperand = false,
       else
         IntrinsicTypes = {Ops[0]->getType(), Ops[2]->getType()};
     }] in {
-  multiclass RVVVSEBuiltin<string ir, string masked_ir, list<string> types> {
+  multiclass RVVVSEBuiltin<string ir, list<string> types> {
     let Name = NAME # "_v",
         IRName = ir,
-        MaskedIRName = masked_ir in {
+        MaskedIRName = ir # "_mask" in {
       foreach type = types in {
         // `0Pev` is type `T * -> VectorType -> void`
         def : RVVBuiltin<"v", "0Pev", type>;
@@ -221,19 +236,37 @@ let HasMaskedOffOperand = false,
       }
     }
   }
+
+  multiclass RVVVSXBuiltin<string ir, list<string> types> {
+    let Name = NAME # "_v",
+        IRName = ir,
+        MaskedIRName = ir # "_mask" in {
+      foreach type = types in {
+        // `0Pev` is type `T * -> VectorType -> void`
+        def : RVVBuiltin<"v", "0Pev", type>;
+        // `0PUeUv` is type `unsigned T * -> unsigned VectorType -> void`
+        def : RVVBuiltin<"Uv", "0PUeUv", type>;
+      }
+    }
+  }
 }
 
 // 7.1. Vector Unit-Stride Operations
-// TODO: vlb, vlh, vlw
-defm th_vle8 : RVVVLEBuiltin<"th_vle", "th_vle_mask", ["c"]>;
-defm th_vle16: RVVVLEBuiltin<"th_vle", "th_vle_mask", ["s","x"]>;
-defm th_vle32: RVVVLEBuiltin<"th_vle", "th_vle_mask", ["i","f"]>;
-defm th_vle64: RVVVLEBuiltin<"th_vle", "th_vle_mask", ["l","d"]>;
-// TODO: vsb, vsh, vsw
-defm th_vse8 : RVVVSEBuiltin<"th_vse", "th_vse_mask", ["c"]>;
-defm th_vse16: RVVVSEBuiltin<"th_vse", "th_vse_mask", ["s","x"]>;
-defm th_vse32: RVVVSEBuiltin<"th_vse", "th_vse_mask", ["i","f"]>;
-defm th_vse64: RVVVSEBuiltin<"th_vse", "th_vse_mask", ["l","d"]>;
+defm th_vlb  : RVVVLXBuiltin<"th_vlb", ["c", "s", "i", "l"]>; // i8, i16, i32, i64
+defm th_vlh  : RVVVLXBuiltin<"th_vlh", ["c", "s", "i", "l"]>; // i8, i16, i32, i64
+defm th_vlw  : RVVVLXBuiltin<"th_vlw", ["c", "s", "i", "l"]>; // i8, i16, i32, i64
+defm th_vle8 : RVVVLEBuiltin<"th_vle", ["c"]>;     // i8
+defm th_vle16: RVVVLEBuiltin<"th_vle", ["s","x"]>; // i16, f16
+defm th_vle32: RVVVLEBuiltin<"th_vle", ["i","f"]>; // i32, f32
+defm th_vle64: RVVVLEBuiltin<"th_vle", ["l","d"]>; // i64, f64
+
+defm th_vsb  : RVVVSXBuiltin<"th_vsb", ["c", "s", "i", "l"]>; // i8, i16, i32, i64
+defm th_vsh  : RVVVSXBuiltin<"th_vsh", ["c", "s", "i", "l"]>; // i8, i16, i32, i64
+defm th_vsw  : RVVVSXBuiltin<"th_vsw", ["c", "s", "i", "l"]>; // i8, i16, i32, i64
+defm th_vse8 : RVVVSEBuiltin<"th_vse", ["c"]>;     // i8
+defm th_vse16: RVVVSEBuiltin<"th_vse", ["s","x"]>; // i16, f16
+defm th_vse32: RVVVSEBuiltin<"th_vse", ["i","f"]>; // i32, f32
+defm th_vse64: RVVVSEBuiltin<"th_vse", ["l","d"]>; // i64, f64
 
 //===----------------------------------------------------------------------===//
 // 12. Vector Integer Arithmetic Operations

--- a/clang/include/clang/Basic/riscv_vector_xtheadv.td
+++ b/clang/include/clang/Basic/riscv_vector_xtheadv.td
@@ -175,10 +175,10 @@ let HasBuiltinAlias = false,
 
 let SupportOverloading = false,
     UnMaskedPolicyScheme = HasPassthruOperand in {
-  multiclass RVVVLEBuiltin<list<string> types> {
+  multiclass RVVVLEBuiltin<string ir, string masked_ir, list<string> types> {
     let Name = NAME # "_v",
-        IRName = "th_vle",
-        MaskedIRName ="th_vle_mask" in {
+        IRName = ir,
+        MaskedIRName = masked_ir in {
       foreach type = types in {
         // `vPCe` is type `const T * -> VectorType`
         def : RVVOutBuiltin<"v", "vPCe", type>;
@@ -207,10 +207,10 @@ let HasMaskedOffOperand = false,
       else
         IntrinsicTypes = {Ops[0]->getType(), Ops[2]->getType()};
     }] in {
-  multiclass RVVVSEBuiltin<list<string> types> {
+  multiclass RVVVSEBuiltin<string ir, string masked_ir, list<string> types> {
     let Name = NAME # "_v",
-        IRName = "th_vse",
-        MaskedIRName = "th_vse_mask" in {
+        IRName = ir,
+        MaskedIRName = masked_ir in {
       foreach type = types in {
         // `0Pev` is type `T * -> VectorType -> void`
         def : RVVBuiltin<"v", "0Pev", type>;
@@ -225,15 +225,15 @@ let HasMaskedOffOperand = false,
 
 // 7.1. Vector Unit-Stride Operations
 // TODO: vlb, vlh, vlw
-defm th_vle8: RVVVLEBuiltin<["c"]>;
-defm th_vle16: RVVVLEBuiltin<["s","x"]>;
-defm th_vle32: RVVVLEBuiltin<["i","f"]>;
-defm th_vle64: RVVVLEBuiltin<["l","d"]>;
+defm th_vle8 : RVVVLEBuiltin<"th_vle", "th_vle_mask", ["c"]>;
+defm th_vle16: RVVVLEBuiltin<"th_vle", "th_vle_mask", ["s","x"]>;
+defm th_vle32: RVVVLEBuiltin<"th_vle", "th_vle_mask", ["i","f"]>;
+defm th_vle64: RVVVLEBuiltin<"th_vle", "th_vle_mask", ["l","d"]>;
 // TODO: vsb, vsh, vsw
-defm th_vse8 : RVVVSEBuiltin<["c"]>;
-defm th_vse16: RVVVSEBuiltin<["s","x"]>;
-defm th_vse32: RVVVSEBuiltin<["i","f"]>;
-defm th_vse64: RVVVSEBuiltin<["l","d"]>;
+defm th_vse8 : RVVVSEBuiltin<"th_vse", "th_vse_mask", ["c"]>;
+defm th_vse16: RVVVSEBuiltin<"th_vse", "th_vse_mask", ["s","x"]>;
+defm th_vse32: RVVVSEBuiltin<"th_vse", "th_vse_mask", ["i","f"]>;
+defm th_vse64: RVVVSEBuiltin<"th_vse", "th_vse_mask", ["l","d"]>;
 
 //===----------------------------------------------------------------------===//
 // 12. Vector Integer Arithmetic Operations

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vlb.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vlb.c
@@ -1,0 +1,166 @@
+// RUN: %clang_cc1 -triple riscv64 -target-feature +xtheadvector \
+// RUN:   -disable-O0-optnone -emit-llvm %s -o - | \
+// RUN:   opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i8> @test_th_vlb_v_i8m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i8> @llvm.riscv.th.vlb.nxv8i8.i64(<vscale x 8 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i8> [[TMP0]]
+//
+vint8m1_t test_th_vlb_v_i8m1(const int8_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i8m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i8> @test_th_vlb_v_i8m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i8> @llvm.riscv.th.vlb.nxv16i8.i64(<vscale x 16 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i8> [[TMP0]]
+//
+vint8m2_t test_th_vlb_v_i8m2(const int8_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i8m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 32 x i8> @test_th_vlb_v_i8m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 32 x i8> @llvm.riscv.th.vlb.nxv32i8.i64(<vscale x 32 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 32 x i8> [[TMP0]]
+//
+vint8m4_t test_th_vlb_v_i8m4(const int8_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i8m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 64 x i8> @test_th_vlb_v_i8m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 64 x i8> @llvm.riscv.th.vlb.nxv64i8.i64(<vscale x 64 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 64 x i8> [[TMP0]]
+//
+vint8m8_t test_th_vlb_v_i8m8(const int8_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i8m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i16> @test_th_vlb_v_i16m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i16> @llvm.riscv.th.vlb.nxv4i16.i64(<vscale x 4 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i16> [[TMP0]]
+//
+vint16m1_t test_th_vlb_v_i16m1(const int16_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i16m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i16> @test_th_vlb_v_i16m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i16> @llvm.riscv.th.vlb.nxv8i16.i64(<vscale x 8 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i16> [[TMP0]]
+//
+vint16m2_t test_th_vlb_v_i16m2(const int16_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i16m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i16> @test_th_vlb_v_i16m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i16> @llvm.riscv.th.vlb.nxv16i16.i64(<vscale x 16 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i16> [[TMP0]]
+//
+vint16m4_t test_th_vlb_v_i16m4(const int16_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i16m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 32 x i16> @test_th_vlb_v_i16m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 32 x i16> @llvm.riscv.th.vlb.nxv32i16.i64(<vscale x 32 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 32 x i16> [[TMP0]]
+//
+vint16m8_t test_th_vlb_v_i16m8(const int16_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i16m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_th_vlb_v_i32m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.th.vlb.nxv2i32.i64(<vscale x 2 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
+//
+vint32m1_t test_th_vlb_v_i32m1(const int32_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i32m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_th_vlb_v_i32m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.th.vlb.nxv4i32.i64(<vscale x 4 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
+//
+vint32m2_t test_th_vlb_v_i32m2(const int32_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i32m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_th_vlb_v_i32m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.th.vlb.nxv8i32.i64(<vscale x 8 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
+//
+vint32m4_t test_th_vlb_v_i32m4(const int32_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i32m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_th_vlb_v_i32m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.th.vlb.nxv16i32.i64(<vscale x 16 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
+//
+vint32m8_t test_th_vlb_v_i32m8(const int32_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i32m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 1 x i64> @test_th_vlb_v_i64m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i64> @llvm.riscv.th.vlb.nxv1i64.i64(<vscale x 1 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 1 x i64> [[TMP0]]
+//
+vint64m1_t test_th_vlb_v_i64m1(const int64_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i64m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 2 x i64> @test_th_vlb_v_i64m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i64> @llvm.riscv.th.vlb.nxv2i64.i64(<vscale x 2 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 2 x i64> [[TMP0]]
+//
+vint64m2_t test_th_vlb_v_i64m2(const int64_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i64m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i64> @test_th_vlb_v_i64m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i64> @llvm.riscv.th.vlb.nxv4i64.i64(<vscale x 4 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i64> [[TMP0]]
+//
+vint64m4_t test_th_vlb_v_i64m4(const int64_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i64m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i64> @test_th_vlb_v_i64m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i64> @llvm.riscv.th.vlb.nxv8i64.i64(<vscale x 8 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i64> [[TMP0]]
+//
+vint64m8_t test_th_vlb_v_i64m8(const int64_t *base, size_t vl) {
+  return __riscv_th_vlb_v_i64m8(base, vl);
+}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vlbu.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vlbu.c
@@ -1,0 +1,166 @@
+// RUN: %clang_cc1 -triple riscv64 -target-feature +xtheadvector \
+// RUN:   -disable-O0-optnone -emit-llvm %s -o - | \
+// RUN:   opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i8> @test_th_vlbu_v_u8m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i8> @llvm.riscv.th.vlbu.nxv8i8.i64(<vscale x 8 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i8> [[TMP0]]
+//
+vuint8m1_t test_th_vlbu_v_u8m1(const uint8_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u8m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i8> @test_th_vlbu_v_u8m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i8> @llvm.riscv.th.vlbu.nxv16i8.i64(<vscale x 16 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i8> [[TMP0]]
+//
+vuint8m2_t test_th_vlbu_v_u8m2(const uint8_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u8m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 32 x i8> @test_th_vlbu_v_u8m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 32 x i8> @llvm.riscv.th.vlbu.nxv32i8.i64(<vscale x 32 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 32 x i8> [[TMP0]]
+//
+vuint8m4_t test_th_vlbu_v_u8m4(const uint8_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u8m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 64 x i8> @test_th_vlbu_v_u8m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 64 x i8> @llvm.riscv.th.vlbu.nxv64i8.i64(<vscale x 64 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 64 x i8> [[TMP0]]
+//
+vuint8m8_t test_th_vlbu_v_u8m8(const uint8_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u8m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i16> @test_th_vlbu_v_u16m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i16> @llvm.riscv.th.vlbu.nxv4i16.i64(<vscale x 4 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i16> [[TMP0]]
+//
+vuint16m1_t test_th_vlbu_v_u16m1(const uint16_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u16m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i16> @test_th_vlbu_v_u16m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i16> @llvm.riscv.th.vlbu.nxv8i16.i64(<vscale x 8 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i16> [[TMP0]]
+//
+vuint16m2_t test_th_vlbu_v_u16m2(const uint16_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u16m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i16> @test_th_vlbu_v_u16m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i16> @llvm.riscv.th.vlbu.nxv16i16.i64(<vscale x 16 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i16> [[TMP0]]
+//
+vuint16m4_t test_th_vlbu_v_u16m4(const uint16_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u16m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 32 x i16> @test_th_vlbu_v_u16m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 32 x i16> @llvm.riscv.th.vlbu.nxv32i16.i64(<vscale x 32 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 32 x i16> [[TMP0]]
+//
+vuint16m8_t test_th_vlbu_v_u16m8(const uint16_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u16m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_th_vlbu_v_u32m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.th.vlbu.nxv2i32.i64(<vscale x 2 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
+//
+vuint32m1_t test_th_vlbu_v_u32m1(const uint32_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u32m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_th_vlbu_v_u32m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.th.vlbu.nxv4i32.i64(<vscale x 4 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
+//
+vuint32m2_t test_th_vlbu_v_u32m2(const uint32_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u32m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_th_vlbu_v_u32m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.th.vlbu.nxv8i32.i64(<vscale x 8 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
+//
+vuint32m4_t test_th_vlbu_v_u32m4(const uint32_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u32m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_th_vlbu_v_u32m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.th.vlbu.nxv16i32.i64(<vscale x 16 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
+//
+vuint32m8_t test_th_vlbu_v_u32m8(const uint32_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u32m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 1 x i64> @test_th_vlbu_v_u64m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i64> @llvm.riscv.th.vlbu.nxv1i64.i64(<vscale x 1 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 1 x i64> [[TMP0]]
+//
+vuint64m1_t test_th_vlbu_v_u64m1(const uint64_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u64m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 2 x i64> @test_th_vlbu_v_u64m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i64> @llvm.riscv.th.vlbu.nxv2i64.i64(<vscale x 2 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 2 x i64> [[TMP0]]
+//
+vuint64m2_t test_th_vlbu_v_u64m2(const uint64_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u64m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i64> @test_th_vlbu_v_u64m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i64> @llvm.riscv.th.vlbu.nxv4i64.i64(<vscale x 4 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i64> [[TMP0]]
+//
+vuint64m4_t test_th_vlbu_v_u64m4(const uint64_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u64m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i64> @test_th_vlbu_v_u64m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i64> @llvm.riscv.th.vlbu.nxv8i64.i64(<vscale x 8 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i64> [[TMP0]]
+//
+vuint64m8_t test_th_vlbu_v_u64m8(const uint64_t *base, size_t vl) {
+  return __riscv_th_vlbu_v_u64m8(base, vl);
+}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vlh.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vlh.c
@@ -1,0 +1,167 @@
+// RUN: %clang_cc1 -triple riscv64 -target-feature +xtheadvector \
+// RUN:   -disable-O0-optnone -emit-llvm %s -o - | \
+// RUN:   opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i8> @test_th_vlh_v_i8m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i8> @llvm.riscv.th.vlh.nxv8i8.i64(<vscale x 8 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i8> [[TMP0]]
+//
+vint8m1_t test_th_vlh_v_i8m1(const int8_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i8m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i8> @test_th_vlh_v_i8m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i8> @llvm.riscv.th.vlh.nxv16i8.i64(<vscale x 16 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i8> [[TMP0]]
+//
+vint8m2_t test_th_vlh_v_i8m2(const int8_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i8m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 32 x i8> @test_th_vlh_v_i8m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 32 x i8> @llvm.riscv.th.vlh.nxv32i8.i64(<vscale x 32 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 32 x i8> [[TMP0]]
+//
+vint8m4_t test_th_vlh_v_i8m4(const int8_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i8m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 64 x i8> @test_th_vlh_v_i8m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 64 x i8> @llvm.riscv.th.vlh.nxv64i8.i64(<vscale x 64 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 64 x i8> [[TMP0]]
+//
+vint8m8_t test_th_vlh_v_i8m8(const int8_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i8m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i16> @test_th_vlh_v_i16m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i16> @llvm.riscv.th.vlh.nxv4i16.i64(<vscale x 4 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i16> [[TMP0]]
+//
+vint16m1_t test_th_vlh_v_i16m1(const int16_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i16m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i16> @test_th_vlh_v_i16m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i16> @llvm.riscv.th.vlh.nxv8i16.i64(<vscale x 8 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i16> [[TMP0]]
+//
+vint16m2_t test_th_vlh_v_i16m2(const int16_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i16m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i16> @test_th_vlh_v_i16m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i16> @llvm.riscv.th.vlh.nxv16i16.i64(<vscale x 16 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i16> [[TMP0]]
+//
+vint16m4_t test_th_vlh_v_i16m4(const int16_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i16m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 32 x i16> @test_th_vlh_v_i16m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 32 x i16> @llvm.riscv.th.vlh.nxv32i16.i64(<vscale x 32 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 32 x i16> [[TMP0]]
+//
+vint16m8_t test_th_vlh_v_i16m8(const int16_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i16m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_th_vlh_v_i32m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.th.vlh.nxv2i32.i64(<vscale x 2 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
+//
+vint32m1_t test_th_vlh_v_i32m1(const int32_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i32m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_th_vlh_v_i32m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.th.vlh.nxv4i32.i64(<vscale x 4 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
+//
+vint32m2_t test_th_vlh_v_i32m2(const int32_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i32m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_th_vlh_v_i32m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.th.vlh.nxv8i32.i64(<vscale x 8 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
+//
+vint32m4_t test_th_vlh_v_i32m4(const int32_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i32m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_th_vlh_v_i32m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.th.vlh.nxv16i32.i64(<vscale x 16 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
+//
+vint32m8_t test_th_vlh_v_i32m8(const int32_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i32m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 1 x i64> @test_th_vlh_v_i64m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i64> @llvm.riscv.th.vlh.nxv1i64.i64(<vscale x 1 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 1 x i64> [[TMP0]]
+//
+vint64m1_t test_th_vlh_v_i64m1(const int64_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i64m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 2 x i64> @test_th_vlh_v_i64m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i64> @llvm.riscv.th.vlh.nxv2i64.i64(<vscale x 2 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 2 x i64> [[TMP0]]
+//
+vint64m2_t test_th_vlh_v_i64m2(const int64_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i64m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i64> @test_th_vlh_v_i64m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i64> @llvm.riscv.th.vlh.nxv4i64.i64(<vscale x 4 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i64> [[TMP0]]
+//
+vint64m4_t test_th_vlh_v_i64m4(const int64_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i64m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i64> @test_th_vlh_v_i64m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i64> @llvm.riscv.th.vlh.nxv8i64.i64(<vscale x 8 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i64> [[TMP0]]
+//
+vint64m8_t test_th_vlh_v_i64m8(const int64_t *base, size_t vl) {
+  return __riscv_th_vlh_v_i64m8(base, vl);
+}
+

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vlhu.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vlhu.c
@@ -1,0 +1,166 @@
+// RUN: %clang_cc1 -triple riscv64 -target-feature +xtheadvector \
+// RUN:   -disable-O0-optnone -emit-llvm %s -o - | \
+// RUN:   opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i8> @test_th_vlhu_v_u8m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i8> @llvm.riscv.th.vlhu.nxv8i8.i64(<vscale x 8 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i8> [[TMP0]]
+//
+vuint8m1_t test_th_vlhu_v_u8m1(const uint8_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u8m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i8> @test_th_vlhu_v_u8m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i8> @llvm.riscv.th.vlhu.nxv16i8.i64(<vscale x 16 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i8> [[TMP0]]
+//
+vuint8m2_t test_th_vlhu_v_u8m2(const uint8_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u8m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 32 x i8> @test_th_vlhu_v_u8m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 32 x i8> @llvm.riscv.th.vlhu.nxv32i8.i64(<vscale x 32 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 32 x i8> [[TMP0]]
+//
+vuint8m4_t test_th_vlhu_v_u8m4(const uint8_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u8m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 64 x i8> @test_th_vlhu_v_u8m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 64 x i8> @llvm.riscv.th.vlhu.nxv64i8.i64(<vscale x 64 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 64 x i8> [[TMP0]]
+//
+vuint8m8_t test_th_vlhu_v_u8m8(const uint8_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u8m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i16> @test_th_vlhu_v_u16m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i16> @llvm.riscv.th.vlhu.nxv4i16.i64(<vscale x 4 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i16> [[TMP0]]
+//
+vuint16m1_t test_th_vlhu_v_u16m1(const uint16_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u16m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i16> @test_th_vlhu_v_u16m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i16> @llvm.riscv.th.vlhu.nxv8i16.i64(<vscale x 8 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i16> [[TMP0]]
+//
+vuint16m2_t test_th_vlhu_v_u16m2(const uint16_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u16m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i16> @test_th_vlhu_v_u16m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i16> @llvm.riscv.th.vlhu.nxv16i16.i64(<vscale x 16 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i16> [[TMP0]]
+//
+vuint16m4_t test_th_vlhu_v_u16m4(const uint16_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u16m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 32 x i16> @test_th_vlhu_v_u16m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 32 x i16> @llvm.riscv.th.vlhu.nxv32i16.i64(<vscale x 32 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 32 x i16> [[TMP0]]
+//
+vuint16m8_t test_th_vlhu_v_u16m8(const uint16_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u16m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_th_vlhu_v_u32m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.th.vlhu.nxv2i32.i64(<vscale x 2 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
+//
+vuint32m1_t test_th_vlhu_v_u32m1(const uint32_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u32m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_th_vlhu_v_u32m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.th.vlhu.nxv4i32.i64(<vscale x 4 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
+//
+vuint32m2_t test_th_vlhu_v_u32m2(const uint32_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u32m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_th_vlhu_v_u32m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.th.vlhu.nxv8i32.i64(<vscale x 8 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
+//
+vuint32m4_t test_th_vlhu_v_u32m4(const uint32_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u32m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_th_vlhu_v_u32m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.th.vlhu.nxv16i32.i64(<vscale x 16 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
+//
+vuint32m8_t test_th_vlhu_v_u32m8(const uint32_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u32m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 1 x i64> @test_th_vlhu_v_u64m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i64> @llvm.riscv.th.vlhu.nxv1i64.i64(<vscale x 1 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 1 x i64> [[TMP0]]
+//
+vuint64m1_t test_th_vlhu_v_u64m1(const uint64_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u64m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 2 x i64> @test_th_vlhu_v_u64m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i64> @llvm.riscv.th.vlhu.nxv2i64.i64(<vscale x 2 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 2 x i64> [[TMP0]]
+//
+vuint64m2_t test_th_vlhu_v_u64m2(const uint64_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u64m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i64> @test_th_vlhu_v_u64m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i64> @llvm.riscv.th.vlhu.nxv4i64.i64(<vscale x 4 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i64> [[TMP0]]
+//
+vuint64m4_t test_th_vlhu_v_u64m4(const uint64_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u64m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i64> @test_th_vlhu_v_u64m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i64> @llvm.riscv.th.vlhu.nxv8i64.i64(<vscale x 8 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i64> [[TMP0]]
+//
+vuint64m8_t test_th_vlhu_v_u64m8(const uint64_t *base, size_t vl) {
+  return __riscv_th_vlhu_v_u64m8(base, vl);
+}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vlw.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vlw.c
@@ -1,0 +1,166 @@
+// RUN: %clang_cc1 -triple riscv64 -target-feature +xtheadvector \
+// RUN:   -disable-O0-optnone -emit-llvm %s -o - | \
+// RUN:   opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i8> @test_th_vlw_v_i8m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i8> @llvm.riscv.th.vlw.nxv8i8.i64(<vscale x 8 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i8> [[TMP0]]
+//
+vint8m1_t test_th_vlw_v_i8m1(const int8_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i8m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i8> @test_th_vlw_v_i8m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i8> @llvm.riscv.th.vlw.nxv16i8.i64(<vscale x 16 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i8> [[TMP0]]
+//
+vint8m2_t test_th_vlw_v_i8m2(const int8_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i8m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 32 x i8> @test_th_vlw_v_i8m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 32 x i8> @llvm.riscv.th.vlw.nxv32i8.i64(<vscale x 32 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 32 x i8> [[TMP0]]
+//
+vint8m4_t test_th_vlw_v_i8m4(const int8_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i8m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 64 x i8> @test_th_vlw_v_i8m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 64 x i8> @llvm.riscv.th.vlw.nxv64i8.i64(<vscale x 64 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 64 x i8> [[TMP0]]
+//
+vint8m8_t test_th_vlw_v_i8m8(const int8_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i8m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i16> @test_th_vlw_v_i16m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i16> @llvm.riscv.th.vlw.nxv4i16.i64(<vscale x 4 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i16> [[TMP0]]
+//
+vint16m1_t test_th_vlw_v_i16m1(const int16_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i16m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i16> @test_th_vlw_v_i16m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i16> @llvm.riscv.th.vlw.nxv8i16.i64(<vscale x 8 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i16> [[TMP0]]
+//
+vint16m2_t test_th_vlw_v_i16m2(const int16_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i16m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i16> @test_th_vlw_v_i16m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i16> @llvm.riscv.th.vlw.nxv16i16.i64(<vscale x 16 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i16> [[TMP0]]
+//
+vint16m4_t test_th_vlw_v_i16m4(const int16_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i16m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 32 x i16> @test_th_vlw_v_i16m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 32 x i16> @llvm.riscv.th.vlw.nxv32i16.i64(<vscale x 32 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 32 x i16> [[TMP0]]
+//
+vint16m8_t test_th_vlw_v_i16m8(const int16_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i16m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_th_vlw_v_i32m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.th.vlw.nxv2i32.i64(<vscale x 2 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
+//
+vint32m1_t test_th_vlw_v_i32m1(const int32_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i32m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_th_vlw_v_i32m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.th.vlw.nxv4i32.i64(<vscale x 4 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
+//
+vint32m2_t test_th_vlw_v_i32m2(const int32_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i32m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_th_vlw_v_i32m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.th.vlw.nxv8i32.i64(<vscale x 8 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
+//
+vint32m4_t test_th_vlw_v_i32m4(const int32_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i32m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_th_vlw_v_i32m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.th.vlw.nxv16i32.i64(<vscale x 16 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
+//
+vint32m8_t test_th_vlw_v_i32m8(const int32_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i32m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 1 x i64> @test_th_vlw_v_i64m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i64> @llvm.riscv.th.vlw.nxv1i64.i64(<vscale x 1 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 1 x i64> [[TMP0]]
+//
+vint64m1_t test_th_vlw_v_i64m1(const int64_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i64m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 2 x i64> @test_th_vlw_v_i64m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i64> @llvm.riscv.th.vlw.nxv2i64.i64(<vscale x 2 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 2 x i64> [[TMP0]]
+//
+vint64m2_t test_th_vlw_v_i64m2(const int64_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i64m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i64> @test_th_vlw_v_i64m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i64> @llvm.riscv.th.vlw.nxv4i64.i64(<vscale x 4 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i64> [[TMP0]]
+//
+vint64m4_t test_th_vlw_v_i64m4(const int64_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i64m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i64> @test_th_vlw_v_i64m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i64> @llvm.riscv.th.vlw.nxv8i64.i64(<vscale x 8 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i64> [[TMP0]]
+//
+vint64m8_t test_th_vlw_v_i64m8(const int64_t *base, size_t vl) {
+  return __riscv_th_vlw_v_i64m8(base, vl);
+}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vlwu.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vlwu.c
@@ -1,0 +1,166 @@
+// RUN: %clang_cc1 -triple riscv64 -target-feature +xtheadvector \
+// RUN:   -disable-O0-optnone -emit-llvm %s -o - | \
+// RUN:   opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i8> @test_th_vlwu_v_u8m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i8> @llvm.riscv.th.vlwu.nxv8i8.i64(<vscale x 8 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i8> [[TMP0]]
+//
+vuint8m1_t test_th_vlwu_v_u8m1(const uint8_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u8m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i8> @test_th_vlwu_v_u8m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i8> @llvm.riscv.th.vlwu.nxv16i8.i64(<vscale x 16 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i8> [[TMP0]]
+//
+vuint8m2_t test_th_vlwu_v_u8m2(const uint8_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u8m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 32 x i8> @test_th_vlwu_v_u8m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 32 x i8> @llvm.riscv.th.vlwu.nxv32i8.i64(<vscale x 32 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 32 x i8> [[TMP0]]
+//
+vuint8m4_t test_th_vlwu_v_u8m4(const uint8_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u8m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 64 x i8> @test_th_vlwu_v_u8m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 64 x i8> @llvm.riscv.th.vlwu.nxv64i8.i64(<vscale x 64 x i8> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 64 x i8> [[TMP0]]
+//
+vuint8m8_t test_th_vlwu_v_u8m8(const uint8_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u8m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i16> @test_th_vlwu_v_u16m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i16> @llvm.riscv.th.vlwu.nxv4i16.i64(<vscale x 4 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i16> [[TMP0]]
+//
+vuint16m1_t test_th_vlwu_v_u16m1(const uint16_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u16m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i16> @test_th_vlwu_v_u16m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i16> @llvm.riscv.th.vlwu.nxv8i16.i64(<vscale x 8 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i16> [[TMP0]]
+//
+vuint16m2_t test_th_vlwu_v_u16m2(const uint16_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u16m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i16> @test_th_vlwu_v_u16m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i16> @llvm.riscv.th.vlwu.nxv16i16.i64(<vscale x 16 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i16> [[TMP0]]
+//
+vuint16m4_t test_th_vlwu_v_u16m4(const uint16_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u16m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 32 x i16> @test_th_vlwu_v_u16m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 32 x i16> @llvm.riscv.th.vlwu.nxv32i16.i64(<vscale x 32 x i16> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 32 x i16> [[TMP0]]
+//
+vuint16m8_t test_th_vlwu_v_u16m8(const uint16_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u16m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_th_vlwu_v_u32m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.th.vlwu.nxv2i32.i64(<vscale x 2 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
+//
+vuint32m1_t test_th_vlwu_v_u32m1(const uint32_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u32m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_th_vlwu_v_u32m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.th.vlwu.nxv4i32.i64(<vscale x 4 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
+//
+vuint32m2_t test_th_vlwu_v_u32m2(const uint32_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u32m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_th_vlwu_v_u32m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.th.vlwu.nxv8i32.i64(<vscale x 8 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
+//
+vuint32m4_t test_th_vlwu_v_u32m4(const uint32_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u32m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_th_vlwu_v_u32m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.th.vlwu.nxv16i32.i64(<vscale x 16 x i32> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
+//
+vuint32m8_t test_th_vlwu_v_u32m8(const uint32_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u32m8(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 1 x i64> @test_th_vlwu_v_u64m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i64> @llvm.riscv.th.vlwu.nxv1i64.i64(<vscale x 1 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 1 x i64> [[TMP0]]
+//
+vuint64m1_t test_th_vlwu_v_u64m1(const uint64_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u64m1(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 2 x i64> @test_th_vlwu_v_u64m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i64> @llvm.riscv.th.vlwu.nxv2i64.i64(<vscale x 2 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 2 x i64> [[TMP0]]
+//
+vuint64m2_t test_th_vlwu_v_u64m2(const uint64_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u64m2(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 4 x i64> @test_th_vlwu_v_u64m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i64> @llvm.riscv.th.vlwu.nxv4i64.i64(<vscale x 4 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 4 x i64> [[TMP0]]
+//
+vuint64m4_t test_th_vlwu_v_u64m4(const uint64_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u64m4(base, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 8 x i64> @test_th_vlwu_v_u64m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i64> @llvm.riscv.th.vlwu.nxv8i64.i64(<vscale x 8 x i64> poison, ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 8 x i64> [[TMP0]]
+//
+vuint64m8_t test_th_vlwu_v_u64m8(const uint64_t *base, size_t vl) {
+  return __riscv_th_vlwu_v_u64m8(base, vl);
+}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vsb.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vsb.c
@@ -1,0 +1,327 @@
+// RUN: %clang_cc1 -triple riscv64 -target-feature +xtheadvector \
+// RUN:   -disable-O0-optnone -emit-llvm %s -o - | \
+// RUN:   opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i8m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv8i8.i64(<vscale x 8 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i8m1(int8_t *base, vint8m1_t value, size_t vl) {
+  return __riscv_th_vsb_v_i8m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i8m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv16i8.i64(<vscale x 16 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i8m2(int8_t *base, vint8m2_t value, size_t vl) {
+  return __riscv_th_vsb_v_i8m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i8m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 32 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv32i8.i64(<vscale x 32 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i8m4(int8_t *base, vint8m4_t value, size_t vl) {
+  return __riscv_th_vsb_v_i8m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i8m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 64 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv64i8.i64(<vscale x 64 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i8m8(int8_t *base, vint8m8_t value, size_t vl) {
+  return __riscv_th_vsb_v_i8m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i16m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv4i16.i64(<vscale x 4 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i16m1(int16_t *base, vint16m1_t value, size_t vl) {
+  return __riscv_th_vsb_v_i16m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i16m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv8i16.i64(<vscale x 8 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i16m2(int16_t *base, vint16m2_t value, size_t vl) {
+  return __riscv_th_vsb_v_i16m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i16m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv16i16.i64(<vscale x 16 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i16m4(int16_t *base, vint16m4_t value, size_t vl) {
+  return __riscv_th_vsb_v_i16m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i16m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 32 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv32i16.i64(<vscale x 32 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i16m8(int16_t *base, vint16m8_t value, size_t vl) {
+  return __riscv_th_vsb_v_i16m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i32m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 2 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv2i32.i64(<vscale x 2 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i32m1(int32_t *base, vint32m1_t value, size_t vl) {
+  return __riscv_th_vsb_v_i32m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i32m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv4i32.i64(<vscale x 4 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i32m2(int32_t *base, vint32m2_t value, size_t vl) {
+  return __riscv_th_vsb_v_i32m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i32m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv8i32.i64(<vscale x 8 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i32m4(int32_t *base, vint32m4_t value, size_t vl) {
+  return __riscv_th_vsb_v_i32m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i32m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv16i32.i64(<vscale x 16 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i32m8(int32_t *base, vint32m8_t value, size_t vl) {
+  return __riscv_th_vsb_v_i32m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i64m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 1 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv1i64.i64(<vscale x 1 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i64m1(int64_t *base, vint64m1_t value, size_t vl) {
+  return __riscv_th_vsb_v_i64m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i64m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 2 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv2i64.i64(<vscale x 2 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i64m2(int64_t *base, vint64m2_t value, size_t vl) {
+  return __riscv_th_vsb_v_i64m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i64m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv4i64.i64(<vscale x 4 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i64m4(int64_t *base, vint64m4_t value, size_t vl) {
+  return __riscv_th_vsb_v_i64m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_i64m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv8i64.i64(<vscale x 8 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_i64m8(int64_t *base, vint64m8_t value, size_t vl) {
+  return __riscv_th_vsb_v_i64m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u8m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv8i8.i64(<vscale x 8 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u8m1(uint8_t *base, vuint8m1_t value, size_t vl) {
+  return __riscv_th_vsb_v_u8m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u8m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv16i8.i64(<vscale x 16 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u8m2(uint8_t *base, vuint8m2_t value, size_t vl) {
+  return __riscv_th_vsb_v_u8m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u8m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 32 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv32i8.i64(<vscale x 32 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u8m4(uint8_t *base, vuint8m4_t value, size_t vl) {
+  return __riscv_th_vsb_v_u8m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u8m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 64 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv64i8.i64(<vscale x 64 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u8m8(uint8_t *base, vuint8m8_t value, size_t vl) {
+  return __riscv_th_vsb_v_u8m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u16m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv4i16.i64(<vscale x 4 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u16m1(uint16_t *base, vuint16m1_t value, size_t vl) {
+  return __riscv_th_vsb_v_u16m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u16m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv8i16.i64(<vscale x 8 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u16m2(uint16_t *base, vuint16m2_t value, size_t vl) {
+  return __riscv_th_vsb_v_u16m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u16m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv16i16.i64(<vscale x 16 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u16m4(uint16_t *base, vuint16m4_t value, size_t vl) {
+  return __riscv_th_vsb_v_u16m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u16m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 32 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv32i16.i64(<vscale x 32 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u16m8(uint16_t *base, vuint16m8_t value, size_t vl) {
+  return __riscv_th_vsb_v_u16m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u32m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 2 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv2i32.i64(<vscale x 2 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u32m1(uint32_t *base, vuint32m1_t value, size_t vl) {
+  return __riscv_th_vsb_v_u32m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u32m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv4i32.i64(<vscale x 4 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u32m2(uint32_t *base, vuint32m2_t value, size_t vl) {
+  return __riscv_th_vsb_v_u32m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u32m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv8i32.i64(<vscale x 8 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u32m4(uint32_t *base, vuint32m4_t value, size_t vl) {
+  return __riscv_th_vsb_v_u32m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u32m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv16i32.i64(<vscale x 16 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u32m8(uint32_t *base, vuint32m8_t value, size_t vl) {
+  return __riscv_th_vsb_v_u32m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u64m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 1 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv1i64.i64(<vscale x 1 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u64m1(uint64_t *base, vuint64m1_t value, size_t vl) {
+  return __riscv_th_vsb_v_u64m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u64m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 2 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv2i64.i64(<vscale x 2 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u64m2(uint64_t *base, vuint64m2_t value, size_t vl) {
+  return __riscv_th_vsb_v_u64m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u64m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv4i64.i64(<vscale x 4 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u64m4(uint64_t *base, vuint64m4_t value, size_t vl) {
+  return __riscv_th_vsb_v_u64m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsb_v_u64m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsb.nxv8i64.i64(<vscale x 8 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsb_v_u64m8(uint64_t *base, vuint64m8_t value, size_t vl) {
+  return __riscv_th_vsb_v_u64m8(base, value, vl);
+}
+

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vsh.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vsh.c
@@ -1,0 +1,326 @@
+// RUN: %clang_cc1 -triple riscv64 -target-feature +xtheadvector \
+// RUN:   -disable-O0-optnone -emit-llvm %s -o - | \
+// RUN:   opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i8m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv8i8.i64(<vscale x 8 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i8m1(int8_t *base, vint8m1_t value, size_t vl) {
+  return __riscv_th_vsh_v_i8m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i8m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv16i8.i64(<vscale x 16 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i8m2(int8_t *base, vint8m2_t value, size_t vl) {
+  return __riscv_th_vsh_v_i8m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i8m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 32 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv32i8.i64(<vscale x 32 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i8m4(int8_t *base, vint8m4_t value, size_t vl) {
+  return __riscv_th_vsh_v_i8m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i8m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 64 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv64i8.i64(<vscale x 64 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i8m8(int8_t *base, vint8m8_t value, size_t vl) {
+  return __riscv_th_vsh_v_i8m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i16m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv4i16.i64(<vscale x 4 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i16m1(int16_t *base, vint16m1_t value, size_t vl) {
+  return __riscv_th_vsh_v_i16m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i16m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv8i16.i64(<vscale x 8 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i16m2(int16_t *base, vint16m2_t value, size_t vl) {
+  return __riscv_th_vsh_v_i16m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i16m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv16i16.i64(<vscale x 16 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i16m4(int16_t *base, vint16m4_t value, size_t vl) {
+  return __riscv_th_vsh_v_i16m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i16m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 32 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv32i16.i64(<vscale x 32 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i16m8(int16_t *base, vint16m8_t value, size_t vl) {
+  return __riscv_th_vsh_v_i16m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i32m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 2 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv2i32.i64(<vscale x 2 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i32m1(int32_t *base, vint32m1_t value, size_t vl) {
+  return __riscv_th_vsh_v_i32m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i32m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv4i32.i64(<vscale x 4 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i32m2(int32_t *base, vint32m2_t value, size_t vl) {
+  return __riscv_th_vsh_v_i32m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i32m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv8i32.i64(<vscale x 8 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i32m4(int32_t *base, vint32m4_t value, size_t vl) {
+  return __riscv_th_vsh_v_i32m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i32m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv16i32.i64(<vscale x 16 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i32m8(int32_t *base, vint32m8_t value, size_t vl) {
+  return __riscv_th_vsh_v_i32m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i64m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 1 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv1i64.i64(<vscale x 1 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i64m1(int64_t *base, vint64m1_t value, size_t vl) {
+  return __riscv_th_vsh_v_i64m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i64m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 2 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv2i64.i64(<vscale x 2 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i64m2(int64_t *base, vint64m2_t value, size_t vl) {
+  return __riscv_th_vsh_v_i64m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i64m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv4i64.i64(<vscale x 4 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i64m4(int64_t *base, vint64m4_t value, size_t vl) {
+  return __riscv_th_vsh_v_i64m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_i64m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv8i64.i64(<vscale x 8 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_i64m8(int64_t *base, vint64m8_t value, size_t vl) {
+  return __riscv_th_vsh_v_i64m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u8m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv8i8.i64(<vscale x 8 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u8m1(uint8_t *base, vuint8m1_t value, size_t vl) {
+  return __riscv_th_vsh_v_u8m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u8m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv16i8.i64(<vscale x 16 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u8m2(uint8_t *base, vuint8m2_t value, size_t vl) {
+  return __riscv_th_vsh_v_u8m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u8m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 32 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv32i8.i64(<vscale x 32 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u8m4(uint8_t *base, vuint8m4_t value, size_t vl) {
+  return __riscv_th_vsh_v_u8m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u8m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 64 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv64i8.i64(<vscale x 64 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u8m8(uint8_t *base, vuint8m8_t value, size_t vl) {
+  return __riscv_th_vsh_v_u8m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u16m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv4i16.i64(<vscale x 4 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u16m1(uint16_t *base, vuint16m1_t value, size_t vl) {
+  return __riscv_th_vsh_v_u16m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u16m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv8i16.i64(<vscale x 8 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u16m2(uint16_t *base, vuint16m2_t value, size_t vl) {
+  return __riscv_th_vsh_v_u16m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u16m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv16i16.i64(<vscale x 16 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u16m4(uint16_t *base, vuint16m4_t value, size_t vl) {
+  return __riscv_th_vsh_v_u16m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u16m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 32 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv32i16.i64(<vscale x 32 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u16m8(uint16_t *base, vuint16m8_t value, size_t vl) {
+  return __riscv_th_vsh_v_u16m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u32m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 2 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv2i32.i64(<vscale x 2 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u32m1(uint32_t *base, vuint32m1_t value, size_t vl) {
+  return __riscv_th_vsh_v_u32m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u32m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv4i32.i64(<vscale x 4 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u32m2(uint32_t *base, vuint32m2_t value, size_t vl) {
+  return __riscv_th_vsh_v_u32m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u32m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv8i32.i64(<vscale x 8 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u32m4(uint32_t *base, vuint32m4_t value, size_t vl) {
+  return __riscv_th_vsh_v_u32m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u32m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv16i32.i64(<vscale x 16 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u32m8(uint32_t *base, vuint32m8_t value, size_t vl) {
+  return __riscv_th_vsh_v_u32m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u64m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 1 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv1i64.i64(<vscale x 1 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u64m1(uint64_t *base, vuint64m1_t value, size_t vl) {
+  return __riscv_th_vsh_v_u64m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u64m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 2 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv2i64.i64(<vscale x 2 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u64m2(uint64_t *base, vuint64m2_t value, size_t vl) {
+  return __riscv_th_vsh_v_u64m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u64m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv4i64.i64(<vscale x 4 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u64m4(uint64_t *base, vuint64m4_t value, size_t vl) {
+  return __riscv_th_vsh_v_u64m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsh_v_u64m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsh.nxv8i64.i64(<vscale x 8 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsh_v_u64m8(uint64_t *base, vuint64m8_t value, size_t vl) {
+  return __riscv_th_vsh_v_u64m8(base, value, vl);
+}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vsw.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vsw.c
@@ -1,0 +1,326 @@
+// RUN: %clang_cc1 -triple riscv64 -target-feature +xtheadvector \
+// RUN:   -disable-O0-optnone -emit-llvm %s -o - | \
+// RUN:   opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i8m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv8i8.i64(<vscale x 8 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i8m1(int8_t *base, vint8m1_t value, size_t vl) {
+  return __riscv_th_vsw_v_i8m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i8m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv16i8.i64(<vscale x 16 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i8m2(int8_t *base, vint8m2_t value, size_t vl) {
+  return __riscv_th_vsw_v_i8m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i8m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 32 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv32i8.i64(<vscale x 32 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i8m4(int8_t *base, vint8m4_t value, size_t vl) {
+  return __riscv_th_vsw_v_i8m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i8m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 64 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv64i8.i64(<vscale x 64 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i8m8(int8_t *base, vint8m8_t value, size_t vl) {
+  return __riscv_th_vsw_v_i8m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i16m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv4i16.i64(<vscale x 4 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i16m1(int16_t *base, vint16m1_t value, size_t vl) {
+  return __riscv_th_vsw_v_i16m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i16m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv8i16.i64(<vscale x 8 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i16m2(int16_t *base, vint16m2_t value, size_t vl) {
+  return __riscv_th_vsw_v_i16m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i16m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv16i16.i64(<vscale x 16 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i16m4(int16_t *base, vint16m4_t value, size_t vl) {
+  return __riscv_th_vsw_v_i16m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i16m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 32 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv32i16.i64(<vscale x 32 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i16m8(int16_t *base, vint16m8_t value, size_t vl) {
+  return __riscv_th_vsw_v_i16m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i32m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 2 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv2i32.i64(<vscale x 2 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i32m1(int32_t *base, vint32m1_t value, size_t vl) {
+  return __riscv_th_vsw_v_i32m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i32m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv4i32.i64(<vscale x 4 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i32m2(int32_t *base, vint32m2_t value, size_t vl) {
+  return __riscv_th_vsw_v_i32m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i32m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv8i32.i64(<vscale x 8 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i32m4(int32_t *base, vint32m4_t value, size_t vl) {
+  return __riscv_th_vsw_v_i32m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i32m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv16i32.i64(<vscale x 16 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i32m8(int32_t *base, vint32m8_t value, size_t vl) {
+  return __riscv_th_vsw_v_i32m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i64m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 1 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv1i64.i64(<vscale x 1 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i64m1(int64_t *base, vint64m1_t value, size_t vl) {
+  return __riscv_th_vsw_v_i64m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i64m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 2 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv2i64.i64(<vscale x 2 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i64m2(int64_t *base, vint64m2_t value, size_t vl) {
+  return __riscv_th_vsw_v_i64m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i64m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv4i64.i64(<vscale x 4 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i64m4(int64_t *base, vint64m4_t value, size_t vl) {
+  return __riscv_th_vsw_v_i64m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_i64m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv8i64.i64(<vscale x 8 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_i64m8(int64_t *base, vint64m8_t value, size_t vl) {
+  return __riscv_th_vsw_v_i64m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u8m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv8i8.i64(<vscale x 8 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u8m1(uint8_t *base, vuint8m1_t value, size_t vl) {
+  return __riscv_th_vsw_v_u8m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u8m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv16i8.i64(<vscale x 16 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u8m2(uint8_t *base, vuint8m2_t value, size_t vl) {
+  return __riscv_th_vsw_v_u8m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u8m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 32 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv32i8.i64(<vscale x 32 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u8m4(uint8_t *base, vuint8m4_t value, size_t vl) {
+  return __riscv_th_vsw_v_u8m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u8m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 64 x i8> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv64i8.i64(<vscale x 64 x i8> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u8m8(uint8_t *base, vuint8m8_t value, size_t vl) {
+  return __riscv_th_vsw_v_u8m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u16m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv4i16.i64(<vscale x 4 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u16m1(uint16_t *base, vuint16m1_t value, size_t vl) {
+  return __riscv_th_vsw_v_u16m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u16m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv8i16.i64(<vscale x 8 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u16m2(uint16_t *base, vuint16m2_t value, size_t vl) {
+  return __riscv_th_vsw_v_u16m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u16m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv16i16.i64(<vscale x 16 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u16m4(uint16_t *base, vuint16m4_t value, size_t vl) {
+  return __riscv_th_vsw_v_u16m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u16m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 32 x i16> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv32i16.i64(<vscale x 32 x i16> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u16m8(uint16_t *base, vuint16m8_t value, size_t vl) {
+  return __riscv_th_vsw_v_u16m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u32m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 2 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv2i32.i64(<vscale x 2 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u32m1(uint32_t *base, vuint32m1_t value, size_t vl) {
+  return __riscv_th_vsw_v_u32m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u32m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv4i32.i64(<vscale x 4 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u32m2(uint32_t *base, vuint32m2_t value, size_t vl) {
+  return __riscv_th_vsw_v_u32m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u32m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv8i32.i64(<vscale x 8 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u32m4(uint32_t *base, vuint32m4_t value, size_t vl) {
+  return __riscv_th_vsw_v_u32m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u32m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 16 x i32> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv16i32.i64(<vscale x 16 x i32> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u32m8(uint32_t *base, vuint32m8_t value, size_t vl) {
+  return __riscv_th_vsw_v_u32m8(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u64m1
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 1 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv1i64.i64(<vscale x 1 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u64m1(uint64_t *base, vuint64m1_t value, size_t vl) {
+  return __riscv_th_vsw_v_u64m1(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u64m2
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 2 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv2i64.i64(<vscale x 2 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u64m2(uint64_t *base, vuint64m2_t value, size_t vl) {
+  return __riscv_th_vsw_v_u64m2(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u64m4
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 4 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv4i64.i64(<vscale x 4 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u64m4(uint64_t *base, vuint64m4_t value, size_t vl) {
+  return __riscv_th_vsw_v_u64m4(base, value, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_th_vsw_v_u64m8
+// CHECK-RV64-SAME: (ptr noundef [[BASE:%.*]], <vscale x 8 x i64> [[VALUE:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.th.vsw.nxv8i64.i64(<vscale x 8 x i64> [[VALUE]], ptr [[BASE]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_th_vsw_v_u64m8(uint64_t *base, vuint64m8_t value, size_t vl) {
+  return __riscv_th_vsw_v_u64m8(base, value, vl);
+}


### PR DESCRIPTION
Follow-up of #33 