### PR TITLE
[LLVM][XTHeadVector] Check if either operands of a COPY node is a physical one in `needVSETVLIForCOPY`.

### DIFF
--- a/llvm/test/CodeGen/RISCV/rvv0p71/vadd.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vadd.ll
@@ -60,6 +60,10 @@ define <vscale x 8 x i8> @intrinsic_xvadd_mask_vv_nxv8i8_nxv8i8_nxv8i8(<vscale x
 ; CHECK-NEXT:    csrr a2, vtype
 ; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
 ; CHECK-NEXT:    th.vsetvli zero, a0, e8, m1, d1
 ; CHECK-NEXT:    th.vadd.vv v8, v9, v10, v0.t
 ; CHECK-NEXT:    ret

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vleff.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vleff.ll
@@ -16,6 +16,10 @@ define <vscale x 8 x i8> @intrinsic_vleff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0,
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv8i8_nxv8i8:
@@ -24,6 +28,10 @@ define <vscale x 8 x i8> @intrinsic_vleff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0,
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vleff.nxv8i8.nxv8i8(
@@ -54,10 +62,18 @@ define <vscale x 8 x i8> @intrinsic_vleff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv8i8_nxv8i8:
@@ -70,10 +86,18 @@ define <vscale x 8 x i8> @intrinsic_vleff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vleff.mask.nxv8i8.nxv8i8(
@@ -100,6 +124,10 @@ define <vscale x 16 x i8> @intrinsic_vleff_v_nxv16i8_nxv16i8(<vscale x 16 x i8>*
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv16i8_nxv16i8:
@@ -108,6 +136,10 @@ define <vscale x 16 x i8> @intrinsic_vleff_v_nxv16i8_nxv16i8(<vscale x 16 x i8>*
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, iXLen } @llvm.riscv.th.vleff.nxv16i8.nxv16i8(
@@ -138,10 +170,18 @@ define <vscale x 16 x i8> @intrinsic_vleff_mask_v_nxv16i8_nxv16i8(<vscale x 16 x
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m2, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv16i8_nxv16i8:
@@ -154,10 +194,18 @@ define <vscale x 16 x i8> @intrinsic_vleff_mask_v_nxv16i8_nxv16i8(<vscale x 16 x
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m2, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, iXLen } @llvm.riscv.th.vleff.mask.nxv16i8.nxv16i8(
@@ -184,6 +232,10 @@ define <vscale x 32 x i8> @intrinsic_vleff_v_nxv32i8_nxv32i8(<vscale x 32 x i8>*
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv32i8_nxv32i8:
@@ -192,6 +244,10 @@ define <vscale x 32 x i8> @intrinsic_vleff_v_nxv32i8_nxv32i8(<vscale x 32 x i8>*
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 32 x i8>, iXLen } @llvm.riscv.th.vleff.nxv32i8.nxv32i8(
@@ -222,10 +278,18 @@ define <vscale x 32 x i8> @intrinsic_vleff_mask_v_nxv32i8_nxv32i8(<vscale x 32 x
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m4, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv32i8_nxv32i8:
@@ -238,10 +302,18 @@ define <vscale x 32 x i8> @intrinsic_vleff_mask_v_nxv32i8_nxv32i8(<vscale x 32 x
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m4, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 32 x i8>, iXLen } @llvm.riscv.th.vleff.mask.nxv32i8.nxv32i8(
@@ -268,6 +340,10 @@ define <vscale x 64 x i8> @intrinsic_vleff_v_nxv64i8_nxv64i8(<vscale x 64 x i8>*
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv64i8_nxv64i8:
@@ -276,6 +352,10 @@ define <vscale x 64 x i8> @intrinsic_vleff_v_nxv64i8_nxv64i8(<vscale x 64 x i8>*
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 64 x i8>, iXLen } @llvm.riscv.th.vleff.nxv64i8.nxv64i8(
@@ -306,10 +386,18 @@ define <vscale x 64 x i8> @intrinsic_vleff_mask_v_nxv64i8_nxv64i8(<vscale x 64 x
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m8, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv64i8_nxv64i8:
@@ -322,10 +410,18 @@ define <vscale x 64 x i8> @intrinsic_vleff_mask_v_nxv64i8_nxv64i8(<vscale x 64 x
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m8, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 64 x i8>, iXLen } @llvm.riscv.th.vleff.mask.nxv64i8.nxv64i8(
@@ -352,6 +448,10 @@ define <vscale x 4 x i16> @intrinsic_vleff_v_nxv4i16_nxv4i16(<vscale x 4 x i16>*
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv4i16_nxv4i16:
@@ -360,6 +460,10 @@ define <vscale x 4 x i16> @intrinsic_vleff_v_nxv4i16_nxv4i16(<vscale x 4 x i16>*
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vleff.nxv4i16.nxv4i16(
@@ -390,10 +494,18 @@ define <vscale x 4 x i16> @intrinsic_vleff_mask_v_nxv4i16_nxv4i16(<vscale x 4 x 
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv4i16_nxv4i16:
@@ -406,10 +518,18 @@ define <vscale x 4 x i16> @intrinsic_vleff_mask_v_nxv4i16_nxv4i16(<vscale x 4 x 
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vleff.mask.nxv4i16.nxv4i16(
@@ -436,6 +556,10 @@ define <vscale x 8 x i16> @intrinsic_vleff_v_nxv8i16_nxv8i16(<vscale x 8 x i16>*
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv8i16_nxv8i16:
@@ -444,6 +568,10 @@ define <vscale x 8 x i16> @intrinsic_vleff_v_nxv8i16_nxv8i16(<vscale x 8 x i16>*
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, iXLen } @llvm.riscv.th.vleff.nxv8i16.nxv8i16(
@@ -474,10 +602,18 @@ define <vscale x 8 x i16> @intrinsic_vleff_mask_v_nxv8i16_nxv8i16(<vscale x 8 x 
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv8i16_nxv8i16:
@@ -490,10 +626,18 @@ define <vscale x 8 x i16> @intrinsic_vleff_mask_v_nxv8i16_nxv8i16(<vscale x 8 x 
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, iXLen } @llvm.riscv.th.vleff.mask.nxv8i16.nxv8i16(
@@ -520,6 +664,10 @@ define <vscale x 16 x i16> @intrinsic_vleff_v_nxv16i16_nxv16i16(<vscale x 16 x i
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv16i16_nxv16i16:
@@ -528,6 +676,10 @@ define <vscale x 16 x i16> @intrinsic_vleff_v_nxv16i16_nxv16i16(<vscale x 16 x i
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i16>, iXLen } @llvm.riscv.th.vleff.nxv16i16.nxv16i16(
@@ -558,10 +710,18 @@ define <vscale x 16 x i16> @intrinsic_vleff_mask_v_nxv16i16_nxv16i16(<vscale x 1
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m4, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv16i16_nxv16i16:
@@ -574,10 +734,18 @@ define <vscale x 16 x i16> @intrinsic_vleff_mask_v_nxv16i16_nxv16i16(<vscale x 1
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m4, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i16>, iXLen } @llvm.riscv.th.vleff.mask.nxv16i16.nxv16i16(
@@ -604,6 +772,10 @@ define <vscale x 32 x i16> @intrinsic_vleff_v_nxv32i16_nxv32i16(<vscale x 32 x i
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv32i16_nxv32i16:
@@ -612,6 +784,10 @@ define <vscale x 32 x i16> @intrinsic_vleff_v_nxv32i16_nxv32i16(<vscale x 32 x i
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 32 x i16>, iXLen } @llvm.riscv.th.vleff.nxv32i16.nxv32i16(
@@ -642,10 +818,18 @@ define <vscale x 32 x i16> @intrinsic_vleff_mask_v_nxv32i16_nxv32i16(<vscale x 3
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m8, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv32i16_nxv32i16:
@@ -658,10 +842,18 @@ define <vscale x 32 x i16> @intrinsic_vleff_mask_v_nxv32i16_nxv32i16(<vscale x 3
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m8, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 32 x i16>, iXLen } @llvm.riscv.th.vleff.mask.nxv32i16.nxv32i16(
@@ -688,6 +880,10 @@ define <vscale x 4 x half> @intrinsic_vleff_v_nxv4f16_nxv4f16(<vscale x 4 x half
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv4f16_nxv4f16:
@@ -696,6 +892,10 @@ define <vscale x 4 x half> @intrinsic_vleff_v_nxv4f16_nxv4f16(<vscale x 4 x half
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, iXLen } @llvm.riscv.th.vleff.nxv4f16.nxv4f16(
@@ -726,10 +926,18 @@ define <vscale x 4 x half> @intrinsic_vleff_mask_v_nxv4f16_nxv4f16(<vscale x 4 x
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv4f16_nxv4f16:
@@ -742,10 +950,18 @@ define <vscale x 4 x half> @intrinsic_vleff_mask_v_nxv4f16_nxv4f16(<vscale x 4 x
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, iXLen } @llvm.riscv.th.vleff.mask.nxv4f16.nxv4f16(
@@ -772,6 +988,10 @@ define <vscale x 8 x half> @intrinsic_vleff_v_nxv8f16_nxv8f16(<vscale x 8 x half
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv8f16_nxv8f16:
@@ -780,6 +1000,10 @@ define <vscale x 8 x half> @intrinsic_vleff_v_nxv8f16_nxv8f16(<vscale x 8 x half
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x half>, iXLen } @llvm.riscv.th.vleff.nxv8f16.nxv8f16(
@@ -810,10 +1034,18 @@ define <vscale x 8 x half> @intrinsic_vleff_mask_v_nxv8f16_nxv8f16(<vscale x 8 x
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv8f16_nxv8f16:
@@ -826,10 +1058,18 @@ define <vscale x 8 x half> @intrinsic_vleff_mask_v_nxv8f16_nxv8f16(<vscale x 8 x
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x half>, iXLen } @llvm.riscv.th.vleff.mask.nxv8f16.nxv8f16(
@@ -856,6 +1096,10 @@ define <vscale x 16 x half> @intrinsic_vleff_v_nxv16f16_nxv16f16(<vscale x 16 x 
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv16f16_nxv16f16:
@@ -864,6 +1108,10 @@ define <vscale x 16 x half> @intrinsic_vleff_v_nxv16f16_nxv16f16(<vscale x 16 x 
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x half>, iXLen } @llvm.riscv.th.vleff.nxv16f16.nxv16f16(
@@ -894,10 +1142,18 @@ define <vscale x 16 x half> @intrinsic_vleff_mask_v_nxv16f16_nxv16f16(<vscale x 
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m4, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv16f16_nxv16f16:
@@ -910,10 +1166,18 @@ define <vscale x 16 x half> @intrinsic_vleff_mask_v_nxv16f16_nxv16f16(<vscale x 
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m4, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x half>, iXLen } @llvm.riscv.th.vleff.mask.nxv16f16.nxv16f16(
@@ -940,6 +1204,10 @@ define <vscale x 32 x half> @intrinsic_vleff_v_nxv32f16_nxv32f16(<vscale x 32 x 
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv32f16_nxv32f16:
@@ -948,6 +1216,10 @@ define <vscale x 32 x half> @intrinsic_vleff_v_nxv32f16_nxv32f16(<vscale x 32 x 
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 32 x half>, iXLen } @llvm.riscv.th.vleff.nxv32f16.nxv32f16(
@@ -978,10 +1250,18 @@ define <vscale x 32 x half> @intrinsic_vleff_mask_v_nxv32f16_nxv32f16(<vscale x 
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m8, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv32f16_nxv32f16:
@@ -994,10 +1274,18 @@ define <vscale x 32 x half> @intrinsic_vleff_mask_v_nxv32f16_nxv32f16(<vscale x 
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m8, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 32 x half>, iXLen } @llvm.riscv.th.vleff.mask.nxv32f16.nxv32f16(
@@ -1024,6 +1312,10 @@ define <vscale x 2 x i32> @intrinsic_vleff_v_nxv2i32_nxv2i32(<vscale x 2 x i32>*
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv2i32_nxv2i32:
@@ -1032,6 +1324,10 @@ define <vscale x 2 x i32> @intrinsic_vleff_v_nxv2i32_nxv2i32(<vscale x 2 x i32>*
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vleff.nxv2i32.nxv2i32(
@@ -1062,10 +1358,18 @@ define <vscale x 2 x i32> @intrinsic_vleff_mask_v_nxv2i32_nxv2i32(<vscale x 2 x 
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv2i32_nxv2i32:
@@ -1078,10 +1382,18 @@ define <vscale x 2 x i32> @intrinsic_vleff_mask_v_nxv2i32_nxv2i32(<vscale x 2 x 
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vleff.mask.nxv2i32.nxv2i32(
@@ -1108,6 +1420,10 @@ define <vscale x 4 x i32> @intrinsic_vleff_v_nxv4i32_nxv4i32(<vscale x 4 x i32>*
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv4i32_nxv4i32:
@@ -1116,6 +1432,10 @@ define <vscale x 4 x i32> @intrinsic_vleff_v_nxv4i32_nxv4i32(<vscale x 4 x i32>*
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, iXLen } @llvm.riscv.th.vleff.nxv4i32.nxv4i32(
@@ -1146,10 +1466,18 @@ define <vscale x 4 x i32> @intrinsic_vleff_mask_v_nxv4i32_nxv4i32(<vscale x 4 x 
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv4i32_nxv4i32:
@@ -1162,10 +1490,18 @@ define <vscale x 4 x i32> @intrinsic_vleff_mask_v_nxv4i32_nxv4i32(<vscale x 4 x 
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, iXLen } @llvm.riscv.th.vleff.mask.nxv4i32.nxv4i32(
@@ -1192,6 +1528,10 @@ define <vscale x 8 x i32> @intrinsic_vleff_v_nxv8i32_nxv8i32(<vscale x 8 x i32>*
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv8i32_nxv8i32:
@@ -1200,6 +1540,10 @@ define <vscale x 8 x i32> @intrinsic_vleff_v_nxv8i32_nxv8i32(<vscale x 8 x i32>*
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, iXLen } @llvm.riscv.th.vleff.nxv8i32.nxv8i32(
@@ -1230,10 +1574,18 @@ define <vscale x 8 x i32> @intrinsic_vleff_mask_v_nxv8i32_nxv8i32(<vscale x 8 x 
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m4, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv8i32_nxv8i32:
@@ -1246,10 +1598,18 @@ define <vscale x 8 x i32> @intrinsic_vleff_mask_v_nxv8i32_nxv8i32(<vscale x 8 x 
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m4, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, iXLen } @llvm.riscv.th.vleff.mask.nxv8i32.nxv8i32(
@@ -1276,6 +1636,10 @@ define <vscale x 16 x i32> @intrinsic_vleff_v_nxv16i32_nxv16i32(<vscale x 16 x i
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv16i32_nxv16i32:
@@ -1284,6 +1648,10 @@ define <vscale x 16 x i32> @intrinsic_vleff_v_nxv16i32_nxv16i32(<vscale x 16 x i
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i32>, iXLen } @llvm.riscv.th.vleff.nxv16i32.nxv16i32(
@@ -1314,10 +1682,18 @@ define <vscale x 16 x i32> @intrinsic_vleff_mask_v_nxv16i32_nxv16i32(<vscale x 1
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m8, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv16i32_nxv16i32:
@@ -1330,10 +1706,18 @@ define <vscale x 16 x i32> @intrinsic_vleff_mask_v_nxv16i32_nxv16i32(<vscale x 1
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m8, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i32>, iXLen } @llvm.riscv.th.vleff.mask.nxv16i32.nxv16i32(
@@ -1360,6 +1744,10 @@ define <vscale x 2 x float> @intrinsic_vleff_v_nxv2f32_nxv2f32(<vscale x 2 x flo
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv2f32_nxv2f32:
@@ -1368,6 +1756,10 @@ define <vscale x 2 x float> @intrinsic_vleff_v_nxv2f32_nxv2f32(<vscale x 2 x flo
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, iXLen } @llvm.riscv.th.vleff.nxv2f32.nxv2f32(
@@ -1398,10 +1790,18 @@ define <vscale x 2 x float> @intrinsic_vleff_mask_v_nxv2f32_nxv2f32(<vscale x 2 
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv2f32_nxv2f32:
@@ -1414,10 +1814,18 @@ define <vscale x 2 x float> @intrinsic_vleff_mask_v_nxv2f32_nxv2f32(<vscale x 2 
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, iXLen } @llvm.riscv.th.vleff.mask.nxv2f32.nxv2f32(
@@ -1444,6 +1852,10 @@ define <vscale x 4 x float> @intrinsic_vleff_v_nxv4f32_nxv4f32(<vscale x 4 x flo
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv4f32_nxv4f32:
@@ -1452,6 +1864,10 @@ define <vscale x 4 x float> @intrinsic_vleff_v_nxv4f32_nxv4f32(<vscale x 4 x flo
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x float>, iXLen } @llvm.riscv.th.vleff.nxv4f32.nxv4f32(
@@ -1482,10 +1898,18 @@ define <vscale x 4 x float> @intrinsic_vleff_mask_v_nxv4f32_nxv4f32(<vscale x 4 
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv4f32_nxv4f32:
@@ -1498,10 +1922,18 @@ define <vscale x 4 x float> @intrinsic_vleff_mask_v_nxv4f32_nxv4f32(<vscale x 4 
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x float>, iXLen } @llvm.riscv.th.vleff.mask.nxv4f32.nxv4f32(
@@ -1528,6 +1960,10 @@ define <vscale x 8 x float> @intrinsic_vleff_v_nxv8f32_nxv8f32(<vscale x 8 x flo
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv8f32_nxv8f32:
@@ -1536,6 +1972,10 @@ define <vscale x 8 x float> @intrinsic_vleff_v_nxv8f32_nxv8f32(<vscale x 8 x flo
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x float>, iXLen } @llvm.riscv.th.vleff.nxv8f32.nxv8f32(
@@ -1566,10 +2006,18 @@ define <vscale x 8 x float> @intrinsic_vleff_mask_v_nxv8f32_nxv8f32(<vscale x 8 
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m4, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv8f32_nxv8f32:
@@ -1582,10 +2030,18 @@ define <vscale x 8 x float> @intrinsic_vleff_mask_v_nxv8f32_nxv8f32(<vscale x 8 
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m4, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x float>, iXLen } @llvm.riscv.th.vleff.mask.nxv8f32.nxv8f32(
@@ -1612,6 +2068,10 @@ define <vscale x 16 x float> @intrinsic_vleff_v_nxv16f32_nxv16f32(<vscale x 16 x
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv16f32_nxv16f32:
@@ -1620,6 +2080,10 @@ define <vscale x 16 x float> @intrinsic_vleff_v_nxv16f32_nxv16f32(<vscale x 16 x
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x float>, iXLen } @llvm.riscv.th.vleff.nxv16f32.nxv16f32(
@@ -1650,10 +2114,18 @@ define <vscale x 16 x float> @intrinsic_vleff_mask_v_nxv16f32_nxv16f32(<vscale x
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m8, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv16f32_nxv16f32:
@@ -1666,10 +2138,18 @@ define <vscale x 16 x float> @intrinsic_vleff_mask_v_nxv16f32_nxv16f32(<vscale x
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m8, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x float>, iXLen } @llvm.riscv.th.vleff.mask.nxv16f32.nxv16f32(
@@ -1696,6 +2176,10 @@ define <vscale x 1 x i64> @intrinsic_vleff_v_nxv1i64_nxv1i64(<vscale x 1 x i64>*
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv1i64_nxv1i64:
@@ -1704,6 +2188,10 @@ define <vscale x 1 x i64> @intrinsic_vleff_v_nxv1i64_nxv1i64(<vscale x 1 x i64>*
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vleff.nxv1i64.nxv1i64(
@@ -1734,10 +2222,18 @@ define <vscale x 1 x i64> @intrinsic_vleff_mask_v_nxv1i64_nxv1i64(<vscale x 1 x 
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv1i64_nxv1i64:
@@ -1750,10 +2246,18 @@ define <vscale x 1 x i64> @intrinsic_vleff_mask_v_nxv1i64_nxv1i64(<vscale x 1 x 
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vleff.mask.nxv1i64.nxv1i64(
@@ -1780,6 +2284,10 @@ define <vscale x 2 x i64> @intrinsic_vleff_v_nxv2i64_nxv2i64(<vscale x 2 x i64>*
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv2i64_nxv2i64:
@@ -1788,6 +2296,10 @@ define <vscale x 2 x i64> @intrinsic_vleff_v_nxv2i64_nxv2i64(<vscale x 2 x i64>*
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, iXLen } @llvm.riscv.th.vleff.nxv2i64.nxv2i64(
@@ -1818,10 +2330,18 @@ define <vscale x 2 x i64> @intrinsic_vleff_mask_v_nxv2i64_nxv2i64(<vscale x 2 x 
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv2i64_nxv2i64:
@@ -1834,10 +2354,18 @@ define <vscale x 2 x i64> @intrinsic_vleff_mask_v_nxv2i64_nxv2i64(<vscale x 2 x 
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, iXLen } @llvm.riscv.th.vleff.mask.nxv2i64.nxv2i64(
@@ -1864,6 +2392,10 @@ define <vscale x 4 x i64> @intrinsic_vleff_v_nxv4i64_nxv4i64(<vscale x 4 x i64>*
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv4i64_nxv4i64:
@@ -1872,6 +2404,10 @@ define <vscale x 4 x i64> @intrinsic_vleff_v_nxv4i64_nxv4i64(<vscale x 4 x i64>*
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, iXLen } @llvm.riscv.th.vleff.nxv4i64.nxv4i64(
@@ -1902,10 +2438,18 @@ define <vscale x 4 x i64> @intrinsic_vleff_mask_v_nxv4i64_nxv4i64(<vscale x 4 x 
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m4, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv4i64_nxv4i64:
@@ -1918,10 +2462,18 @@ define <vscale x 4 x i64> @intrinsic_vleff_mask_v_nxv4i64_nxv4i64(<vscale x 4 x 
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m4, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, iXLen } @llvm.riscv.th.vleff.mask.nxv4i64.nxv4i64(
@@ -1948,6 +2500,10 @@ define <vscale x 8 x i64> @intrinsic_vleff_v_nxv8i64_nxv8i64(<vscale x 8 x i64>*
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv8i64_nxv8i64:
@@ -1956,6 +2512,10 @@ define <vscale x 8 x i64> @intrinsic_vleff_v_nxv8i64_nxv8i64(<vscale x 8 x i64>*
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i64>, iXLen } @llvm.riscv.th.vleff.nxv8i64.nxv8i64(
@@ -1986,10 +2546,18 @@ define <vscale x 8 x i64> @intrinsic_vleff_mask_v_nxv8i64_nxv8i64(<vscale x 8 x 
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m8, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv8i64_nxv8i64:
@@ -2002,10 +2570,18 @@ define <vscale x 8 x i64> @intrinsic_vleff_mask_v_nxv8i64_nxv8i64(<vscale x 8 x 
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m8, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i64>, iXLen } @llvm.riscv.th.vleff.mask.nxv8i64.nxv8i64(
@@ -2032,6 +2608,10 @@ define <vscale x 1 x double> @intrinsic_vleff_v_nxv1f64_nxv1f64(<vscale x 1 x do
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv1f64_nxv1f64:
@@ -2040,6 +2620,10 @@ define <vscale x 1 x double> @intrinsic_vleff_v_nxv1f64_nxv1f64(<vscale x 1 x do
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, iXLen } @llvm.riscv.th.vleff.nxv1f64.nxv1f64(
@@ -2070,10 +2654,18 @@ define <vscale x 1 x double> @intrinsic_vleff_mask_v_nxv1f64_nxv1f64(<vscale x 1
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv1f64_nxv1f64:
@@ -2086,10 +2678,18 @@ define <vscale x 1 x double> @intrinsic_vleff_mask_v_nxv1f64_nxv1f64(<vscale x 1
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, iXLen } @llvm.riscv.th.vleff.mask.nxv1f64.nxv1f64(
@@ -2116,6 +2716,10 @@ define <vscale x 2 x double> @intrinsic_vleff_v_nxv2f64_nxv2f64(<vscale x 2 x do
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv2f64_nxv2f64:
@@ -2124,6 +2728,10 @@ define <vscale x 2 x double> @intrinsic_vleff_v_nxv2f64_nxv2f64(<vscale x 2 x do
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x double>, iXLen } @llvm.riscv.th.vleff.nxv2f64.nxv2f64(
@@ -2154,10 +2762,18 @@ define <vscale x 2 x double> @intrinsic_vleff_mask_v_nxv2f64_nxv2f64(<vscale x 2
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv2f64_nxv2f64:
@@ -2170,10 +2786,18 @@ define <vscale x 2 x double> @intrinsic_vleff_mask_v_nxv2f64_nxv2f64(<vscale x 2
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x double>, iXLen } @llvm.riscv.th.vleff.mask.nxv2f64.nxv2f64(
@@ -2200,6 +2824,10 @@ define <vscale x 4 x double> @intrinsic_vleff_v_nxv4f64_nxv4f64(<vscale x 4 x do
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv4f64_nxv4f64:
@@ -2208,6 +2836,10 @@ define <vscale x 4 x double> @intrinsic_vleff_v_nxv4f64_nxv4f64(<vscale x 4 x do
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x double>, iXLen } @llvm.riscv.th.vleff.nxv4f64.nxv4f64(
@@ -2238,10 +2870,18 @@ define <vscale x 4 x double> @intrinsic_vleff_mask_v_nxv4f64_nxv4f64(<vscale x 4
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m4, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv4f64_nxv4f64:
@@ -2254,10 +2894,18 @@ define <vscale x 4 x double> @intrinsic_vleff_mask_v_nxv4f64_nxv4f64(<vscale x 4
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m4, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x double>, iXLen } @llvm.riscv.th.vleff.mask.nxv4f64.nxv4f64(
@@ -2284,6 +2932,10 @@ define <vscale x 8 x double> @intrinsic_vleff_v_nxv8f64_nxv8f64(<vscale x 8 x do
 ; RV32-NEXT:    th.vleff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_v_nxv8f64_nxv8f64:
@@ -2292,6 +2944,10 @@ define <vscale x 8 x double> @intrinsic_vleff_v_nxv8f64_nxv8f64(<vscale x 8 x do
 ; RV64-NEXT:    th.vleff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x double>, iXLen } @llvm.riscv.th.vleff.nxv8f64.nxv8f64(
@@ -2322,10 +2978,18 @@ define <vscale x 8 x double> @intrinsic_vleff_mask_v_nxv8f64_nxv8f64(<vscale x 8
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m8, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_v_nxv8f64_nxv8f64:
@@ -2338,10 +3002,18 @@ define <vscale x 8 x double> @intrinsic_vleff_mask_v_nxv8f64_nxv8f64(<vscale x 8
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m8, d1
 ; RV64-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x double>, iXLen } @llvm.riscv.th.vleff.mask.nxv8f64.nxv8f64(
@@ -2362,6 +3034,10 @@ define <vscale x 1 x double> @intrinsic_vleff_dead_vl(<vscale x 1 x double>* %0,
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; CHECK-NEXT:    th.vleff.v v8, (a0)
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, iXLen } @llvm.riscv.th.vleff.nxv1f64.nxv1f64(
@@ -2383,8 +3059,16 @@ define <vscale x 1 x double> @intrinsic_vleff_mask_dead_vl(<vscale x 1 x double>
 ; CHECK-NEXT:    csrr a3, vtype
 ; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; CHECK-NEXT:    th.vsetvl zero, a2, a3
+; CHECK-NEXT:    csrr a2, vl
+; CHECK-NEXT:    csrr a3, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a2, a3
 ; CHECK-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; CHECK-NEXT:    th.vleff.v v8, (a0), v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, iXLen } @llvm.riscv.th.vleff.mask.nxv1f64.nxv1f64(
@@ -2435,6 +3119,10 @@ define void @intrinsic_vleff_mask_dead_value(<vscale x 1 x double> %0, <vscale x
 ; RV32-NEXT:    csrr a4, vtype
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vleff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
@@ -2443,6 +3131,10 @@ define void @intrinsic_vleff_mask_dead_value(<vscale x 1 x double> %0, <vscale x
 ;
 ; RV64-LABEL: intrinsic_vleff_mask_dead_value:
 ; RV64:       # %bb.0: # %entry
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    csrr a3, vl
 ; RV64-NEXT:    csrr a4, vtype
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
@@ -2486,6 +3178,10 @@ entry:
 define void @intrinsic_vleff_mask_dead_all(<vscale x 1 x double> %0, <vscale x 1 x double>* %1, <vscale x 1 x i1> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vleff_mask_dead_all:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a2, vl
+; CHECK-NEXT:    csrr a3, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a2, a3
 ; CHECK-NEXT:    csrr a2, vl
 ; CHECK-NEXT:    csrr a3, vtype
 ; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vlsegeff.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vlsegeff.ll
@@ -16,6 +16,10 @@ define <vscale x 8 x i8> @intrinsic_vlseg2eff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; RV32-NEXT:    th.vlseg2eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv8i8_nxv8i8:
@@ -24,6 +28,10 @@ define <vscale x 8 x i8> @intrinsic_vlseg2eff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; RV64-NEXT:    th.vlseg2eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vlseg2eff.nxv8i8.nxv8i8(
@@ -55,10 +63,18 @@ define <vscale x 8 x i8> @intrinsic_vlseg2eff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vmv.v.v v7, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV32-NEXT:    th.vlseg2eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv8i8_nxv8i8:
@@ -72,10 +88,18 @@ define <vscale x 8 x i8> @intrinsic_vlseg2eff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vmv.v.v v7, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV64-NEXT:    th.vlseg2eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv8i8.nxv8i8(
@@ -102,6 +126,10 @@ define <vscale x 8 x i8> @intrinsic_vlseg3eff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; RV32-NEXT:    th.vlseg3eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_v_nxv8i8_nxv8i8:
@@ -110,6 +138,10 @@ define <vscale x 8 x i8> @intrinsic_vlseg3eff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; RV64-NEXT:    th.vlseg3eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vlseg3eff.nxv8i8.nxv8i8(
@@ -142,10 +174,18 @@ define <vscale x 8 x i8> @intrinsic_vlseg3eff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x
 ; RV32-NEXT:    th.vmv.v.v v7, v8
 ; RV32-NEXT:    th.vmv.v.v v9, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV32-NEXT:    th.vlseg3eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_mask_v_nxv8i8_nxv8i8:
@@ -160,10 +200,18 @@ define <vscale x 8 x i8> @intrinsic_vlseg3eff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x
 ; RV64-NEXT:    th.vmv.v.v v7, v8
 ; RV64-NEXT:    th.vmv.v.v v9, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV64-NEXT:    th.vlseg3eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vlseg3eff.mask.nxv8i8.nxv8i8(
@@ -190,6 +238,10 @@ define <vscale x 8 x i8> @intrinsic_vlseg4eff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; RV32-NEXT:    th.vlseg4eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_v_nxv8i8_nxv8i8:
@@ -198,6 +250,10 @@ define <vscale x 8 x i8> @intrinsic_vlseg4eff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; RV64-NEXT:    th.vlseg4eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vlseg4eff.nxv8i8.nxv8i8(
@@ -231,10 +287,18 @@ define <vscale x 8 x i8> @intrinsic_vlseg4eff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x
 ; RV32-NEXT:    th.vmv.v.v v9, v8
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV32-NEXT:    th.vlseg4eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_mask_v_nxv8i8_nxv8i8:
@@ -250,10 +314,18 @@ define <vscale x 8 x i8> @intrinsic_vlseg4eff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x
 ; RV64-NEXT:    th.vmv.v.v v9, v8
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV64-NEXT:    th.vlseg4eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vlseg4eff.mask.nxv8i8.nxv8i8(
@@ -280,6 +352,10 @@ define <vscale x 8 x i8> @intrinsic_vlseg5eff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; RV32-NEXT:    th.vlseg5eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg5eff_v_nxv8i8_nxv8i8:
@@ -288,6 +364,10 @@ define <vscale x 8 x i8> @intrinsic_vlseg5eff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; RV64-NEXT:    th.vlseg5eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vlseg5eff.nxv8i8.nxv8i8(
@@ -322,10 +402,18 @@ define <vscale x 8 x i8> @intrinsic_vlseg5eff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vmv.v.v v11, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV32-NEXT:    th.vlseg5eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg5eff_mask_v_nxv8i8_nxv8i8:
@@ -342,10 +430,18 @@ define <vscale x 8 x i8> @intrinsic_vlseg5eff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vmv.v.v v11, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV64-NEXT:    th.vlseg5eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vlseg5eff.mask.nxv8i8.nxv8i8(
@@ -372,6 +468,10 @@ define <vscale x 8 x i8> @intrinsic_vlseg6eff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; RV32-NEXT:    th.vlseg6eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg6eff_v_nxv8i8_nxv8i8:
@@ -380,6 +480,10 @@ define <vscale x 8 x i8> @intrinsic_vlseg6eff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; RV64-NEXT:    th.vlseg6eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vlseg6eff.nxv8i8.nxv8i8(
@@ -415,10 +519,18 @@ define <vscale x 8 x i8> @intrinsic_vlseg6eff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x
 ; RV32-NEXT:    th.vmv.v.v v11, v8
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV32-NEXT:    th.vlseg6eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg6eff_mask_v_nxv8i8_nxv8i8:
@@ -436,10 +548,18 @@ define <vscale x 8 x i8> @intrinsic_vlseg6eff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x
 ; RV64-NEXT:    th.vmv.v.v v11, v8
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV64-NEXT:    th.vlseg6eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vlseg6eff.mask.nxv8i8.nxv8i8(
@@ -466,6 +586,10 @@ define <vscale x 8 x i8> @intrinsic_vlseg7eff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; RV32-NEXT:    th.vlseg7eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg7eff_v_nxv8i8_nxv8i8:
@@ -474,6 +598,10 @@ define <vscale x 8 x i8> @intrinsic_vlseg7eff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; RV64-NEXT:    th.vlseg7eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vlseg7eff.nxv8i8.nxv8i8(
@@ -510,10 +638,18 @@ define <vscale x 8 x i8> @intrinsic_vlseg7eff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vmv.v.v v13, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV32-NEXT:    th.vlseg7eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg7eff_mask_v_nxv8i8_nxv8i8:
@@ -532,10 +668,18 @@ define <vscale x 8 x i8> @intrinsic_vlseg7eff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vmv.v.v v13, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV64-NEXT:    th.vlseg7eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vlseg7eff.mask.nxv8i8.nxv8i8(
@@ -562,6 +706,10 @@ define <vscale x 8 x i8> @intrinsic_vlseg8eff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; RV32-NEXT:    th.vlseg8eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg8eff_v_nxv8i8_nxv8i8:
@@ -570,6 +718,10 @@ define <vscale x 8 x i8> @intrinsic_vlseg8eff_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; RV64-NEXT:    th.vlseg8eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vlseg8eff.nxv8i8.nxv8i8(
@@ -607,10 +759,18 @@ define <vscale x 8 x i8> @intrinsic_vlseg8eff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x
 ; RV32-NEXT:    th.vmv.v.v v13, v8
 ; RV32-NEXT:    th.vmv.v.v v14, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV32-NEXT:    th.vlseg8eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg8eff_mask_v_nxv8i8_nxv8i8:
@@ -630,10 +790,18 @@ define <vscale x 8 x i8> @intrinsic_vlseg8eff_mask_v_nxv8i8_nxv8i8(<vscale x 8 x
 ; RV64-NEXT:    th.vmv.v.v v13, v8
 ; RV64-NEXT:    th.vmv.v.v v14, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m1, d1
 ; RV64-NEXT:    th.vlseg8eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, iXLen } @llvm.riscv.th.vlseg8eff.mask.nxv8i8.nxv8i8(
@@ -660,6 +828,10 @@ define <vscale x 16 x i8> @intrinsic_vlseg2eff_v_nxv16i8_nxv16i8(<vscale x 16 x 
 ; RV32-NEXT:    th.vlseg2eff.v v6, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv16i8_nxv16i8:
@@ -668,6 +840,10 @@ define <vscale x 16 x i8> @intrinsic_vlseg2eff_v_nxv16i8_nxv16i8(<vscale x 16 x 
 ; RV64-NEXT:    th.vlseg2eff.v v6, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, iXLen } @llvm.riscv.th.vlseg2eff.nxv16i8.nxv16i8(
@@ -700,10 +876,18 @@ define <vscale x 16 x i8> @intrinsic_vlseg2eff_mask_v_nxv16i8_nxv16i8(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v6, v8
 ; RV32-NEXT:    th.vmv.v.v v7, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m2, d1
 ; RV32-NEXT:    th.vlseg2eff.v v6, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv16i8_nxv16i8:
@@ -718,10 +902,18 @@ define <vscale x 16 x i8> @intrinsic_vlseg2eff_mask_v_nxv16i8_nxv16i8(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v6, v8
 ; RV64-NEXT:    th.vmv.v.v v7, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m2, d1
 ; RV64-NEXT:    th.vlseg2eff.v v6, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv16i8.nxv16i8(
@@ -748,6 +940,10 @@ define <vscale x 16 x i8> @intrinsic_vlseg3eff_v_nxv16i8_nxv16i8(<vscale x 16 x 
 ; RV32-NEXT:    th.vlseg3eff.v v6, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_v_nxv16i8_nxv16i8:
@@ -756,6 +952,10 @@ define <vscale x 16 x i8> @intrinsic_vlseg3eff_v_nxv16i8_nxv16i8(<vscale x 16 x 
 ; RV64-NEXT:    th.vlseg3eff.v v6, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, iXLen } @llvm.riscv.th.vlseg3eff.nxv16i8.nxv16i8(
@@ -790,10 +990,18 @@ define <vscale x 16 x i8> @intrinsic_vlseg3eff_mask_v_nxv16i8_nxv16i8(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vmv.v.v v11, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m2, d1
 ; RV32-NEXT:    th.vlseg3eff.v v6, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_mask_v_nxv16i8_nxv16i8:
@@ -810,10 +1018,18 @@ define <vscale x 16 x i8> @intrinsic_vlseg3eff_mask_v_nxv16i8_nxv16i8(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vmv.v.v v11, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m2, d1
 ; RV64-NEXT:    th.vlseg3eff.v v6, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, iXLen } @llvm.riscv.th.vlseg3eff.mask.nxv16i8.nxv16i8(
@@ -840,6 +1056,10 @@ define <vscale x 16 x i8> @intrinsic_vlseg4eff_v_nxv16i8_nxv16i8(<vscale x 16 x 
 ; RV32-NEXT:    th.vlseg4eff.v v6, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_v_nxv16i8_nxv16i8:
@@ -848,6 +1068,10 @@ define <vscale x 16 x i8> @intrinsic_vlseg4eff_v_nxv16i8_nxv16i8(<vscale x 16 x 
 ; RV64-NEXT:    th.vlseg4eff.v v6, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, iXLen } @llvm.riscv.th.vlseg4eff.nxv16i8.nxv16i8(
@@ -884,10 +1108,18 @@ define <vscale x 16 x i8> @intrinsic_vlseg4eff_mask_v_nxv16i8_nxv16i8(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vmv.v.v v13, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m2, d1
 ; RV32-NEXT:    th.vlseg4eff.v v6, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_mask_v_nxv16i8_nxv16i8:
@@ -906,10 +1138,18 @@ define <vscale x 16 x i8> @intrinsic_vlseg4eff_mask_v_nxv16i8_nxv16i8(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vmv.v.v v13, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m2, d1
 ; RV64-NEXT:    th.vlseg4eff.v v6, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, iXLen } @llvm.riscv.th.vlseg4eff.mask.nxv16i8.nxv16i8(
@@ -936,6 +1176,10 @@ define <vscale x 32 x i8> @intrinsic_vlseg2eff_v_nxv32i8_nxv32i8(<vscale x 32 x 
 ; RV32-NEXT:    th.vlseg2eff.v v4, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv32i8_nxv32i8:
@@ -944,6 +1188,10 @@ define <vscale x 32 x i8> @intrinsic_vlseg2eff_v_nxv32i8_nxv32i8(<vscale x 32 x 
 ; RV64-NEXT:    th.vlseg2eff.v v4, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 32 x i8>, <vscale x 32 x i8>, iXLen } @llvm.riscv.th.vlseg2eff.nxv32i8.nxv32i8(
@@ -978,10 +1226,18 @@ define <vscale x 32 x i8> @intrinsic_vlseg2eff_mask_v_nxv32i8_nxv32i8(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v6, v10
 ; RV32-NEXT:    th.vmv.v.v v7, v11
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e8, m4, d1
 ; RV32-NEXT:    th.vlseg2eff.v v4, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv32i8_nxv32i8:
@@ -998,10 +1254,18 @@ define <vscale x 32 x i8> @intrinsic_vlseg2eff_mask_v_nxv32i8_nxv32i8(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v6, v10
 ; RV64-NEXT:    th.vmv.v.v v7, v11
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e8, m4, d1
 ; RV64-NEXT:    th.vlseg2eff.v v4, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 32 x i8>, <vscale x 32 x i8>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv32i8.nxv32i8(
@@ -1028,6 +1292,10 @@ define <vscale x 4 x i16> @intrinsic_vlseg2eff_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; RV32-NEXT:    th.vlseg2eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv4i16_nxv4i16:
@@ -1036,6 +1304,10 @@ define <vscale x 4 x i16> @intrinsic_vlseg2eff_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; RV64-NEXT:    th.vlseg2eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vlseg2eff.nxv4i16.nxv4i16(
@@ -1067,10 +1339,18 @@ define <vscale x 4 x i16> @intrinsic_vlseg2eff_mask_v_nxv4i16_nxv4i16(<vscale x 
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vmv.v.v v7, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vlseg2eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv4i16_nxv4i16:
@@ -1084,10 +1364,18 @@ define <vscale x 4 x i16> @intrinsic_vlseg2eff_mask_v_nxv4i16_nxv4i16(<vscale x 
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vmv.v.v v7, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vlseg2eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv4i16.nxv4i16(
@@ -1114,6 +1402,10 @@ define <vscale x 4 x i16> @intrinsic_vlseg3eff_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; RV32-NEXT:    th.vlseg3eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_v_nxv4i16_nxv4i16:
@@ -1122,6 +1414,10 @@ define <vscale x 4 x i16> @intrinsic_vlseg3eff_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; RV64-NEXT:    th.vlseg3eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vlseg3eff.nxv4i16.nxv4i16(
@@ -1154,10 +1450,18 @@ define <vscale x 4 x i16> @intrinsic_vlseg3eff_mask_v_nxv4i16_nxv4i16(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v7, v8
 ; RV32-NEXT:    th.vmv.v.v v9, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vlseg3eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_mask_v_nxv4i16_nxv4i16:
@@ -1172,10 +1476,18 @@ define <vscale x 4 x i16> @intrinsic_vlseg3eff_mask_v_nxv4i16_nxv4i16(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v7, v8
 ; RV64-NEXT:    th.vmv.v.v v9, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vlseg3eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vlseg3eff.mask.nxv4i16.nxv4i16(
@@ -1202,6 +1514,10 @@ define <vscale x 4 x i16> @intrinsic_vlseg4eff_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; RV32-NEXT:    th.vlseg4eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_v_nxv4i16_nxv4i16:
@@ -1210,6 +1526,10 @@ define <vscale x 4 x i16> @intrinsic_vlseg4eff_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; RV64-NEXT:    th.vlseg4eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vlseg4eff.nxv4i16.nxv4i16(
@@ -1243,10 +1563,18 @@ define <vscale x 4 x i16> @intrinsic_vlseg4eff_mask_v_nxv4i16_nxv4i16(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v9, v8
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vlseg4eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_mask_v_nxv4i16_nxv4i16:
@@ -1262,10 +1590,18 @@ define <vscale x 4 x i16> @intrinsic_vlseg4eff_mask_v_nxv4i16_nxv4i16(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v9, v8
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vlseg4eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vlseg4eff.mask.nxv4i16.nxv4i16(
@@ -1292,6 +1628,10 @@ define <vscale x 4 x i16> @intrinsic_vlseg5eff_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; RV32-NEXT:    th.vlseg5eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg5eff_v_nxv4i16_nxv4i16:
@@ -1300,6 +1640,10 @@ define <vscale x 4 x i16> @intrinsic_vlseg5eff_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; RV64-NEXT:    th.vlseg5eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vlseg5eff.nxv4i16.nxv4i16(
@@ -1334,10 +1678,18 @@ define <vscale x 4 x i16> @intrinsic_vlseg5eff_mask_v_nxv4i16_nxv4i16(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vmv.v.v v11, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vlseg5eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg5eff_mask_v_nxv4i16_nxv4i16:
@@ -1354,10 +1706,18 @@ define <vscale x 4 x i16> @intrinsic_vlseg5eff_mask_v_nxv4i16_nxv4i16(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vmv.v.v v11, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vlseg5eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vlseg5eff.mask.nxv4i16.nxv4i16(
@@ -1384,6 +1744,10 @@ define <vscale x 4 x i16> @intrinsic_vlseg6eff_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; RV32-NEXT:    th.vlseg6eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg6eff_v_nxv4i16_nxv4i16:
@@ -1392,6 +1756,10 @@ define <vscale x 4 x i16> @intrinsic_vlseg6eff_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; RV64-NEXT:    th.vlseg6eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vlseg6eff.nxv4i16.nxv4i16(
@@ -1427,10 +1795,18 @@ define <vscale x 4 x i16> @intrinsic_vlseg6eff_mask_v_nxv4i16_nxv4i16(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v11, v8
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vlseg6eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg6eff_mask_v_nxv4i16_nxv4i16:
@@ -1448,10 +1824,18 @@ define <vscale x 4 x i16> @intrinsic_vlseg6eff_mask_v_nxv4i16_nxv4i16(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v11, v8
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vlseg6eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vlseg6eff.mask.nxv4i16.nxv4i16(
@@ -1478,6 +1862,10 @@ define <vscale x 4 x i16> @intrinsic_vlseg7eff_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; RV32-NEXT:    th.vlseg7eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg7eff_v_nxv4i16_nxv4i16:
@@ -1486,6 +1874,10 @@ define <vscale x 4 x i16> @intrinsic_vlseg7eff_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; RV64-NEXT:    th.vlseg7eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vlseg7eff.nxv4i16.nxv4i16(
@@ -1522,10 +1914,18 @@ define <vscale x 4 x i16> @intrinsic_vlseg7eff_mask_v_nxv4i16_nxv4i16(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vmv.v.v v13, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vlseg7eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg7eff_mask_v_nxv4i16_nxv4i16:
@@ -1544,10 +1944,18 @@ define <vscale x 4 x i16> @intrinsic_vlseg7eff_mask_v_nxv4i16_nxv4i16(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vmv.v.v v13, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vlseg7eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vlseg7eff.mask.nxv4i16.nxv4i16(
@@ -1574,6 +1982,10 @@ define <vscale x 4 x i16> @intrinsic_vlseg8eff_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; RV32-NEXT:    th.vlseg8eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg8eff_v_nxv4i16_nxv4i16:
@@ -1582,6 +1994,10 @@ define <vscale x 4 x i16> @intrinsic_vlseg8eff_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; RV64-NEXT:    th.vlseg8eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vlseg8eff.nxv4i16.nxv4i16(
@@ -1619,10 +2035,18 @@ define <vscale x 4 x i16> @intrinsic_vlseg8eff_mask_v_nxv4i16_nxv4i16(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v13, v8
 ; RV32-NEXT:    th.vmv.v.v v14, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vlseg8eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg8eff_mask_v_nxv4i16_nxv4i16:
@@ -1642,10 +2066,18 @@ define <vscale x 4 x i16> @intrinsic_vlseg8eff_mask_v_nxv4i16_nxv4i16(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v13, v8
 ; RV64-NEXT:    th.vmv.v.v v14, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vlseg8eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, iXLen } @llvm.riscv.th.vlseg8eff.mask.nxv4i16.nxv4i16(
@@ -1672,6 +2104,10 @@ define <vscale x 8 x i16> @intrinsic_vlseg2eff_v_nxv8i16_nxv8i16(<vscale x 8 x i
 ; RV32-NEXT:    th.vlseg2eff.v v6, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv8i16_nxv8i16:
@@ -1680,6 +2116,10 @@ define <vscale x 8 x i16> @intrinsic_vlseg2eff_v_nxv8i16_nxv8i16(<vscale x 8 x i
 ; RV64-NEXT:    th.vlseg2eff.v v6, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, iXLen } @llvm.riscv.th.vlseg2eff.nxv8i16.nxv8i16(
@@ -1712,10 +2152,18 @@ define <vscale x 8 x i16> @intrinsic_vlseg2eff_mask_v_nxv8i16_nxv8i16(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v6, v8
 ; RV32-NEXT:    th.vmv.v.v v7, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV32-NEXT:    th.vlseg2eff.v v6, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv8i16_nxv8i16:
@@ -1730,10 +2178,18 @@ define <vscale x 8 x i16> @intrinsic_vlseg2eff_mask_v_nxv8i16_nxv8i16(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v6, v8
 ; RV64-NEXT:    th.vmv.v.v v7, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV64-NEXT:    th.vlseg2eff.v v6, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv8i16.nxv8i16(
@@ -1760,6 +2216,10 @@ define <vscale x 8 x i16> @intrinsic_vlseg3eff_v_nxv8i16_nxv8i16(<vscale x 8 x i
 ; RV32-NEXT:    th.vlseg3eff.v v6, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_v_nxv8i16_nxv8i16:
@@ -1768,6 +2228,10 @@ define <vscale x 8 x i16> @intrinsic_vlseg3eff_v_nxv8i16_nxv8i16(<vscale x 8 x i
 ; RV64-NEXT:    th.vlseg3eff.v v6, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, iXLen } @llvm.riscv.th.vlseg3eff.nxv8i16.nxv8i16(
@@ -1802,10 +2266,18 @@ define <vscale x 8 x i16> @intrinsic_vlseg3eff_mask_v_nxv8i16_nxv8i16(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vmv.v.v v11, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV32-NEXT:    th.vlseg3eff.v v6, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_mask_v_nxv8i16_nxv8i16:
@@ -1822,10 +2294,18 @@ define <vscale x 8 x i16> @intrinsic_vlseg3eff_mask_v_nxv8i16_nxv8i16(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vmv.v.v v11, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV64-NEXT:    th.vlseg3eff.v v6, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, iXLen } @llvm.riscv.th.vlseg3eff.mask.nxv8i16.nxv8i16(
@@ -1852,6 +2332,10 @@ define <vscale x 8 x i16> @intrinsic_vlseg4eff_v_nxv8i16_nxv8i16(<vscale x 8 x i
 ; RV32-NEXT:    th.vlseg4eff.v v6, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_v_nxv8i16_nxv8i16:
@@ -1860,6 +2344,10 @@ define <vscale x 8 x i16> @intrinsic_vlseg4eff_v_nxv8i16_nxv8i16(<vscale x 8 x i
 ; RV64-NEXT:    th.vlseg4eff.v v6, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, iXLen } @llvm.riscv.th.vlseg4eff.nxv8i16.nxv8i16(
@@ -1896,10 +2384,18 @@ define <vscale x 8 x i16> @intrinsic_vlseg4eff_mask_v_nxv8i16_nxv8i16(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vmv.v.v v13, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV32-NEXT:    th.vlseg4eff.v v6, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_mask_v_nxv8i16_nxv8i16:
@@ -1918,10 +2414,18 @@ define <vscale x 8 x i16> @intrinsic_vlseg4eff_mask_v_nxv8i16_nxv8i16(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vmv.v.v v13, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV64-NEXT:    th.vlseg4eff.v v6, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, iXLen } @llvm.riscv.th.vlseg4eff.mask.nxv8i16.nxv8i16(
@@ -1948,6 +2452,10 @@ define <vscale x 16 x i16> @intrinsic_vlseg2eff_v_nxv16i16_nxv16i16(<vscale x 16
 ; RV32-NEXT:    th.vlseg2eff.v v4, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv16i16_nxv16i16:
@@ -1956,6 +2464,10 @@ define <vscale x 16 x i16> @intrinsic_vlseg2eff_v_nxv16i16_nxv16i16(<vscale x 16
 ; RV64-NEXT:    th.vlseg2eff.v v4, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i16>, <vscale x 16 x i16>, iXLen } @llvm.riscv.th.vlseg2eff.nxv16i16.nxv16i16(
@@ -1990,10 +2502,18 @@ define <vscale x 16 x i16> @intrinsic_vlseg2eff_mask_v_nxv16i16_nxv16i16(<vscale
 ; RV32-NEXT:    th.vmv.v.v v6, v10
 ; RV32-NEXT:    th.vmv.v.v v7, v11
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m4, d1
 ; RV32-NEXT:    th.vlseg2eff.v v4, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv16i16_nxv16i16:
@@ -2010,10 +2530,18 @@ define <vscale x 16 x i16> @intrinsic_vlseg2eff_mask_v_nxv16i16_nxv16i16(<vscale
 ; RV64-NEXT:    th.vmv.v.v v6, v10
 ; RV64-NEXT:    th.vmv.v.v v7, v11
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m4, d1
 ; RV64-NEXT:    th.vlseg2eff.v v4, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i16>, <vscale x 16 x i16>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv16i16.nxv16i16(
@@ -2040,6 +2568,10 @@ define <vscale x 4 x half> @intrinsic_vlseg2eff_v_nxv4f16_nxv4f16(<vscale x 4 x 
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv4f16_nxv4f16:
@@ -2048,6 +2580,10 @@ define <vscale x 4 x half> @intrinsic_vlseg2eff_v_nxv4f16_nxv4f16(<vscale x 4 x 
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, iXLen } @llvm.riscv.th.vlseg2eff.nxv4f16.nxv4f16(
@@ -2079,10 +2615,18 @@ define <vscale x 4 x half> @intrinsic_vlseg2eff_mask_v_nxv4f16_nxv4f16( <vscale 
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vmv.v.v v9, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv4f16_nxv4f16:
@@ -2096,10 +2640,18 @@ define <vscale x 4 x half> @intrinsic_vlseg2eff_mask_v_nxv4f16_nxv4f16( <vscale 
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vmv.v.v v9, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv4f16.nxv4f16(
@@ -2126,6 +2678,10 @@ define <vscale x 4 x half> @intrinsic_vlseg3eff_v_nxv4f16_nxv4f16(<vscale x 4 x 
 ; RV32-NEXT:    th.vlseg3eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_v_nxv4f16_nxv4f16:
@@ -2134,6 +2690,10 @@ define <vscale x 4 x half> @intrinsic_vlseg3eff_v_nxv4f16_nxv4f16(<vscale x 4 x 
 ; RV64-NEXT:    th.vlseg3eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, iXLen } @llvm.riscv.th.vlseg3eff.nxv4f16.nxv4f16(
@@ -2166,10 +2726,18 @@ define <vscale x 4 x half> @intrinsic_vlseg3eff_mask_v_nxv4f16_nxv4f16( <vscale 
 ; RV32-NEXT:    th.vmv.v.v v9, v8
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vlseg3eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_mask_v_nxv4f16_nxv4f16:
@@ -2184,10 +2752,18 @@ define <vscale x 4 x half> @intrinsic_vlseg3eff_mask_v_nxv4f16_nxv4f16( <vscale 
 ; RV64-NEXT:    th.vmv.v.v v9, v8
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vlseg3eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, iXLen } @llvm.riscv.th.vlseg3eff.mask.nxv4f16.nxv4f16(
@@ -2214,6 +2790,10 @@ define <vscale x 4 x half> @intrinsic_vlseg4eff_v_nxv4f16_nxv4f16(<vscale x 4 x 
 ; RV32-NEXT:    th.vlseg4eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_v_nxv4f16_nxv4f16:
@@ -2222,6 +2802,10 @@ define <vscale x 4 x half> @intrinsic_vlseg4eff_v_nxv4f16_nxv4f16(<vscale x 4 x 
 ; RV64-NEXT:    th.vlseg4eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, iXLen } @llvm.riscv.th.vlseg4eff.nxv4f16.nxv4f16(
@@ -2255,10 +2839,18 @@ define <vscale x 4 x half> @intrinsic_vlseg4eff_mask_v_nxv4f16_nxv4f16( <vscale 
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vmv.v.v v11, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vlseg4eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_mask_v_nxv4f16_nxv4f16:
@@ -2274,10 +2866,18 @@ define <vscale x 4 x half> @intrinsic_vlseg4eff_mask_v_nxv4f16_nxv4f16( <vscale 
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vmv.v.v v11, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vlseg4eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, iXLen } @llvm.riscv.th.vlseg4eff.mask.nxv4f16.nxv4f16(
@@ -2304,6 +2904,10 @@ define <vscale x 4 x half> @intrinsic_vlseg5eff_v_nxv4f16_nxv4f16(<vscale x 4 x 
 ; RV32-NEXT:    th.vlseg5eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg5eff_v_nxv4f16_nxv4f16:
@@ -2312,6 +2916,10 @@ define <vscale x 4 x half> @intrinsic_vlseg5eff_v_nxv4f16_nxv4f16(<vscale x 4 x 
 ; RV64-NEXT:    th.vlseg5eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, iXLen } @llvm.riscv.th.vlseg5eff.nxv4f16.nxv4f16(
@@ -2346,10 +2954,18 @@ define <vscale x 4 x half> @intrinsic_vlseg5eff_mask_v_nxv4f16_nxv4f16( <vscale 
 ; RV32-NEXT:    th.vmv.v.v v11, v8
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vlseg5eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg5eff_mask_v_nxv4f16_nxv4f16:
@@ -2366,10 +2982,18 @@ define <vscale x 4 x half> @intrinsic_vlseg5eff_mask_v_nxv4f16_nxv4f16( <vscale 
 ; RV64-NEXT:    th.vmv.v.v v11, v8
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vlseg5eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, iXLen } @llvm.riscv.th.vlseg5eff.mask.nxv4f16.nxv4f16(
@@ -2396,6 +3020,10 @@ define <vscale x 4 x half> @intrinsic_vlseg6eff_v_nxv4f16_nxv4f16(<vscale x 4 x 
 ; RV32-NEXT:    th.vlseg6eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg6eff_v_nxv4f16_nxv4f16:
@@ -2404,6 +3032,10 @@ define <vscale x 4 x half> @intrinsic_vlseg6eff_v_nxv4f16_nxv4f16(<vscale x 4 x 
 ; RV64-NEXT:    th.vlseg6eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, iXLen } @llvm.riscv.th.vlseg6eff.nxv4f16.nxv4f16(
@@ -2439,10 +3071,18 @@ define <vscale x 4 x half> @intrinsic_vlseg6eff_mask_v_nxv4f16_nxv4f16( <vscale 
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vmv.v.v v13, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vlseg6eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg6eff_mask_v_nxv4f16_nxv4f16:
@@ -2460,10 +3100,18 @@ define <vscale x 4 x half> @intrinsic_vlseg6eff_mask_v_nxv4f16_nxv4f16( <vscale 
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vmv.v.v v13, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vlseg6eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, iXLen } @llvm.riscv.th.vlseg6eff.mask.nxv4f16.nxv4f16(
@@ -2490,6 +3138,10 @@ define <vscale x 4 x half> @intrinsic_vlseg7eff_v_nxv4f16_nxv4f16(<vscale x 4 x 
 ; RV32-NEXT:    th.vlseg7eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg7eff_v_nxv4f16_nxv4f16:
@@ -2498,6 +3150,10 @@ define <vscale x 4 x half> @intrinsic_vlseg7eff_v_nxv4f16_nxv4f16(<vscale x 4 x 
 ; RV64-NEXT:    th.vlseg7eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, iXLen } @llvm.riscv.th.vlseg7eff.nxv4f16.nxv4f16(
@@ -2534,10 +3190,18 @@ define <vscale x 4 x half> @intrinsic_vlseg7eff_mask_v_nxv4f16_nxv4f16( <vscale 
 ; RV32-NEXT:    th.vmv.v.v v13, v8
 ; RV32-NEXT:    th.vmv.v.v v14, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vlseg7eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg7eff_mask_v_nxv4f16_nxv4f16:
@@ -2556,10 +3220,18 @@ define <vscale x 4 x half> @intrinsic_vlseg7eff_mask_v_nxv4f16_nxv4f16( <vscale 
 ; RV64-NEXT:    th.vmv.v.v v13, v8
 ; RV64-NEXT:    th.vmv.v.v v14, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vlseg7eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, iXLen } @llvm.riscv.th.vlseg7eff.mask.nxv4f16.nxv4f16(
@@ -2586,6 +3258,10 @@ define <vscale x 4 x half> @intrinsic_vlseg8eff_v_nxv4f16_nxv4f16(<vscale x 4 x 
 ; RV32-NEXT:    th.vlseg8eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg8eff_v_nxv4f16_nxv4f16:
@@ -2594,6 +3270,10 @@ define <vscale x 4 x half> @intrinsic_vlseg8eff_v_nxv4f16_nxv4f16(<vscale x 4 x 
 ; RV64-NEXT:    th.vlseg8eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, iXLen } @llvm.riscv.th.vlseg8eff.nxv4f16.nxv4f16(
@@ -2631,10 +3311,18 @@ define <vscale x 4 x half> @intrinsic_vlseg8eff_mask_v_nxv4f16_nxv4f16( <vscale 
 ; RV32-NEXT:    th.vmv.v.v v14, v8
 ; RV32-NEXT:    th.vmv.v.v v15, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV32-NEXT:    th.vlseg8eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg8eff_mask_v_nxv4f16_nxv4f16:
@@ -2654,10 +3342,18 @@ define <vscale x 4 x half> @intrinsic_vlseg8eff_mask_v_nxv4f16_nxv4f16( <vscale 
 ; RV64-NEXT:    th.vmv.v.v v14, v8
 ; RV64-NEXT:    th.vmv.v.v v15, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m1, d1
 ; RV64-NEXT:    th.vlseg8eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, iXLen } @llvm.riscv.th.vlseg8eff.mask.nxv4f16.nxv4f16(
@@ -2684,6 +3380,10 @@ define <vscale x 8 x half> @intrinsic_vlseg2eff_v_nxv8f16_nxv8f16(<vscale x 8 x 
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv8f16_nxv8f16:
@@ -2692,6 +3392,10 @@ define <vscale x 8 x half> @intrinsic_vlseg2eff_v_nxv8f16_nxv8f16(<vscale x 8 x 
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x half>, <vscale x 8 x half>, iXLen } @llvm.riscv.th.vlseg2eff.nxv8f16.nxv8f16(
@@ -2724,10 +3428,18 @@ define <vscale x 8 x half> @intrinsic_vlseg2eff_mask_v_nxv8f16_nxv8f16( <vscale 
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vmv.v.v v11, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv8f16_nxv8f16:
@@ -2742,10 +3454,18 @@ define <vscale x 8 x half> @intrinsic_vlseg2eff_mask_v_nxv8f16_nxv8f16( <vscale 
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vmv.v.v v11, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x half>, <vscale x 8 x half>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv8f16.nxv8f16(
@@ -2772,6 +3492,10 @@ define <vscale x 8 x half> @intrinsic_vlseg3eff_v_nxv8f16_nxv8f16(<vscale x 8 x 
 ; RV32-NEXT:    th.vlseg3eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_v_nxv8f16_nxv8f16:
@@ -2780,6 +3504,10 @@ define <vscale x 8 x half> @intrinsic_vlseg3eff_v_nxv8f16_nxv8f16(<vscale x 8 x 
 ; RV64-NEXT:    th.vlseg3eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half>, iXLen } @llvm.riscv.th.vlseg3eff.nxv8f16.nxv8f16(
@@ -2814,10 +3542,18 @@ define <vscale x 8 x half> @intrinsic_vlseg3eff_mask_v_nxv8f16_nxv8f16( <vscale 
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vmv.v.v v13, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV32-NEXT:    th.vlseg3eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_mask_v_nxv8f16_nxv8f16:
@@ -2834,10 +3570,18 @@ define <vscale x 8 x half> @intrinsic_vlseg3eff_mask_v_nxv8f16_nxv8f16( <vscale 
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vmv.v.v v13, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV64-NEXT:    th.vlseg3eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half>, iXLen } @llvm.riscv.th.vlseg3eff.mask.nxv8f16.nxv8f16(
@@ -2864,6 +3608,10 @@ define <vscale x 8 x half> @intrinsic_vlseg4eff_v_nxv8f16_nxv8f16(<vscale x 8 x 
 ; RV32-NEXT:    th.vlseg4eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_v_nxv8f16_nxv8f16:
@@ -2872,6 +3620,10 @@ define <vscale x 8 x half> @intrinsic_vlseg4eff_v_nxv8f16_nxv8f16(<vscale x 8 x 
 ; RV64-NEXT:    th.vlseg4eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half>, iXLen } @llvm.riscv.th.vlseg4eff.nxv8f16.nxv8f16(
@@ -2908,10 +3660,18 @@ define <vscale x 8 x half> @intrinsic_vlseg4eff_mask_v_nxv8f16_nxv8f16( <vscale 
 ; RV32-NEXT:    th.vmv.v.v v14, v8
 ; RV32-NEXT:    th.vmv.v.v v15, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV32-NEXT:    th.vlseg4eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_mask_v_nxv8f16_nxv8f16:
@@ -2930,10 +3690,18 @@ define <vscale x 8 x half> @intrinsic_vlseg4eff_mask_v_nxv8f16_nxv8f16( <vscale 
 ; RV64-NEXT:    th.vmv.v.v v14, v8
 ; RV64-NEXT:    th.vmv.v.v v15, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m2, d1
 ; RV64-NEXT:    th.vlseg4eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half>, iXLen } @llvm.riscv.th.vlseg4eff.mask.nxv8f16.nxv8f16(
@@ -2960,6 +3728,10 @@ define <vscale x 16 x half> @intrinsic_vlseg2eff_v_nxv16f16_nxv16f16(<vscale x 1
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv16f16_nxv16f16:
@@ -2968,6 +3740,10 @@ define <vscale x 16 x half> @intrinsic_vlseg2eff_v_nxv16f16_nxv16f16(<vscale x 1
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x half>, <vscale x 16 x half>, iXLen } @llvm.riscv.th.vlseg2eff.nxv16f16.nxv16f16(
@@ -3002,10 +3778,18 @@ define <vscale x 16 x half> @intrinsic_vlseg2eff_mask_v_nxv16f16_nxv16f16( <vsca
 ; RV32-NEXT:    th.vmv.v.v v14, v10
 ; RV32-NEXT:    th.vmv.v.v v15, v11
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e16, m4, d1
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv16f16_nxv16f16:
@@ -3022,10 +3806,18 @@ define <vscale x 16 x half> @intrinsic_vlseg2eff_mask_v_nxv16f16_nxv16f16( <vsca
 ; RV64-NEXT:    th.vmv.v.v v14, v10
 ; RV64-NEXT:    th.vmv.v.v v15, v11
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e16, m4, d1
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x half>, <vscale x 16 x half>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv16f16.nxv16f16(
@@ -3052,6 +3844,10 @@ define <vscale x 2 x i32> @intrinsic_vlseg2eff_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; RV32-NEXT:    th.vlseg2eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv2i32_nxv2i32:
@@ -3060,6 +3856,10 @@ define <vscale x 2 x i32> @intrinsic_vlseg2eff_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; RV64-NEXT:    th.vlseg2eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vlseg2eff.nxv2i32.nxv2i32(
@@ -3091,10 +3891,18 @@ define <vscale x 2 x i32> @intrinsic_vlseg2eff_mask_v_nxv2i32_nxv2i32(<vscale x 
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vmv.v.v v7, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vlseg2eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv2i32_nxv2i32:
@@ -3108,10 +3916,18 @@ define <vscale x 2 x i32> @intrinsic_vlseg2eff_mask_v_nxv2i32_nxv2i32(<vscale x 
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vmv.v.v v7, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vlseg2eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv2i32.nxv2i32(
@@ -3138,6 +3954,10 @@ define <vscale x 2 x i32> @intrinsic_vlseg3eff_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; RV32-NEXT:    th.vlseg3eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_v_nxv2i32_nxv2i32:
@@ -3146,6 +3966,10 @@ define <vscale x 2 x i32> @intrinsic_vlseg3eff_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; RV64-NEXT:    th.vlseg3eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vlseg3eff.nxv2i32.nxv2i32(
@@ -3178,10 +4002,18 @@ define <vscale x 2 x i32> @intrinsic_vlseg3eff_mask_v_nxv2i32_nxv2i32(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v7, v8
 ; RV32-NEXT:    th.vmv.v.v v9, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vlseg3eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_mask_v_nxv2i32_nxv2i32:
@@ -3196,10 +4028,18 @@ define <vscale x 2 x i32> @intrinsic_vlseg3eff_mask_v_nxv2i32_nxv2i32(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v7, v8
 ; RV64-NEXT:    th.vmv.v.v v9, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vlseg3eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vlseg3eff.mask.nxv2i32.nxv2i32(
@@ -3226,6 +4066,10 @@ define <vscale x 2 x i32> @intrinsic_vlseg4eff_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; RV32-NEXT:    th.vlseg4eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_v_nxv2i32_nxv2i32:
@@ -3234,6 +4078,10 @@ define <vscale x 2 x i32> @intrinsic_vlseg4eff_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; RV64-NEXT:    th.vlseg4eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vlseg4eff.nxv2i32.nxv2i32(
@@ -3267,10 +4115,18 @@ define <vscale x 2 x i32> @intrinsic_vlseg4eff_mask_v_nxv2i32_nxv2i32(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v9, v8
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vlseg4eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_mask_v_nxv2i32_nxv2i32:
@@ -3286,10 +4142,18 @@ define <vscale x 2 x i32> @intrinsic_vlseg4eff_mask_v_nxv2i32_nxv2i32(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v9, v8
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vlseg4eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vlseg4eff.mask.nxv2i32.nxv2i32(
@@ -3316,6 +4180,10 @@ define <vscale x 2 x i32> @intrinsic_vlseg5eff_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; RV32-NEXT:    th.vlseg5eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg5eff_v_nxv2i32_nxv2i32:
@@ -3324,6 +4192,10 @@ define <vscale x 2 x i32> @intrinsic_vlseg5eff_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; RV64-NEXT:    th.vlseg5eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vlseg5eff.nxv2i32.nxv2i32(
@@ -3358,10 +4230,18 @@ define <vscale x 2 x i32> @intrinsic_vlseg5eff_mask_v_nxv2i32_nxv2i32(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vmv.v.v v11, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vlseg5eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg5eff_mask_v_nxv2i32_nxv2i32:
@@ -3378,10 +4258,18 @@ define <vscale x 2 x i32> @intrinsic_vlseg5eff_mask_v_nxv2i32_nxv2i32(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vmv.v.v v11, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vlseg5eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vlseg5eff.mask.nxv2i32.nxv2i32(
@@ -3408,6 +4296,10 @@ define <vscale x 2 x i32> @intrinsic_vlseg6eff_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; RV32-NEXT:    th.vlseg6eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg6eff_v_nxv2i32_nxv2i32:
@@ -3416,6 +4308,10 @@ define <vscale x 2 x i32> @intrinsic_vlseg6eff_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; RV64-NEXT:    th.vlseg6eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vlseg6eff.nxv2i32.nxv2i32(
@@ -3451,10 +4347,18 @@ define <vscale x 2 x i32> @intrinsic_vlseg6eff_mask_v_nxv2i32_nxv2i32(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v11, v8
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vlseg6eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg6eff_mask_v_nxv2i32_nxv2i32:
@@ -3472,10 +4376,18 @@ define <vscale x 2 x i32> @intrinsic_vlseg6eff_mask_v_nxv2i32_nxv2i32(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v11, v8
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vlseg6eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vlseg6eff.mask.nxv2i32.nxv2i32(
@@ -3502,6 +4414,10 @@ define <vscale x 2 x i32> @intrinsic_vlseg7eff_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; RV32-NEXT:    th.vlseg7eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg7eff_v_nxv2i32_nxv2i32:
@@ -3510,6 +4426,10 @@ define <vscale x 2 x i32> @intrinsic_vlseg7eff_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; RV64-NEXT:    th.vlseg7eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vlseg7eff.nxv2i32.nxv2i32(
@@ -3546,10 +4466,18 @@ define <vscale x 2 x i32> @intrinsic_vlseg7eff_mask_v_nxv2i32_nxv2i32(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vmv.v.v v13, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vlseg7eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg7eff_mask_v_nxv2i32_nxv2i32:
@@ -3568,10 +4496,18 @@ define <vscale x 2 x i32> @intrinsic_vlseg7eff_mask_v_nxv2i32_nxv2i32(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vmv.v.v v13, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vlseg7eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vlseg7eff.mask.nxv2i32.nxv2i32(
@@ -3598,6 +4534,10 @@ define <vscale x 2 x i32> @intrinsic_vlseg8eff_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; RV32-NEXT:    th.vlseg8eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg8eff_v_nxv2i32_nxv2i32:
@@ -3606,6 +4546,10 @@ define <vscale x 2 x i32> @intrinsic_vlseg8eff_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; RV64-NEXT:    th.vlseg8eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vlseg8eff.nxv2i32.nxv2i32(
@@ -3643,10 +4587,18 @@ define <vscale x 2 x i32> @intrinsic_vlseg8eff_mask_v_nxv2i32_nxv2i32(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v13, v8
 ; RV32-NEXT:    th.vmv.v.v v14, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vlseg8eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg8eff_mask_v_nxv2i32_nxv2i32:
@@ -3666,10 +4618,18 @@ define <vscale x 2 x i32> @intrinsic_vlseg8eff_mask_v_nxv2i32_nxv2i32(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v13, v8
 ; RV64-NEXT:    th.vmv.v.v v14, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vlseg8eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, iXLen } @llvm.riscv.th.vlseg8eff.mask.nxv2i32.nxv2i32(
@@ -3696,6 +4656,10 @@ define <vscale x 4 x i32> @intrinsic_vlseg2eff_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; RV32-NEXT:    th.vlseg2eff.v v6, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv4i32_nxv4i32:
@@ -3704,6 +4668,10 @@ define <vscale x 4 x i32> @intrinsic_vlseg2eff_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; RV64-NEXT:    th.vlseg2eff.v v6, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, iXLen } @llvm.riscv.th.vlseg2eff.nxv4i32.nxv4i32(
@@ -3736,10 +4704,18 @@ define <vscale x 4 x i32> @intrinsic_vlseg2eff_mask_v_nxv4i32_nxv4i32(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v6, v8
 ; RV32-NEXT:    th.vmv.v.v v7, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV32-NEXT:    th.vlseg2eff.v v6, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv4i32_nxv4i32:
@@ -3754,10 +4730,18 @@ define <vscale x 4 x i32> @intrinsic_vlseg2eff_mask_v_nxv4i32_nxv4i32(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v6, v8
 ; RV64-NEXT:    th.vmv.v.v v7, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV64-NEXT:    th.vlseg2eff.v v6, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv4i32.nxv4i32(
@@ -3784,6 +4768,10 @@ define <vscale x 4 x i32> @intrinsic_vlseg3eff_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; RV32-NEXT:    th.vlseg3eff.v v6, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_v_nxv4i32_nxv4i32:
@@ -3792,6 +4780,10 @@ define <vscale x 4 x i32> @intrinsic_vlseg3eff_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; RV64-NEXT:    th.vlseg3eff.v v6, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, iXLen } @llvm.riscv.th.vlseg3eff.nxv4i32.nxv4i32(
@@ -3826,10 +4818,18 @@ define <vscale x 4 x i32> @intrinsic_vlseg3eff_mask_v_nxv4i32_nxv4i32(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vmv.v.v v11, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV32-NEXT:    th.vlseg3eff.v v6, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_mask_v_nxv4i32_nxv4i32:
@@ -3846,10 +4846,18 @@ define <vscale x 4 x i32> @intrinsic_vlseg3eff_mask_v_nxv4i32_nxv4i32(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vmv.v.v v11, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV64-NEXT:    th.vlseg3eff.v v6, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, iXLen } @llvm.riscv.th.vlseg3eff.mask.nxv4i32.nxv4i32(
@@ -3876,6 +4884,10 @@ define <vscale x 4 x i32> @intrinsic_vlseg4eff_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; RV32-NEXT:    th.vlseg4eff.v v6, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_v_nxv4i32_nxv4i32:
@@ -3884,6 +4896,10 @@ define <vscale x 4 x i32> @intrinsic_vlseg4eff_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; RV64-NEXT:    th.vlseg4eff.v v6, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, iXLen } @llvm.riscv.th.vlseg4eff.nxv4i32.nxv4i32(
@@ -3920,10 +4936,18 @@ define <vscale x 4 x i32> @intrinsic_vlseg4eff_mask_v_nxv4i32_nxv4i32(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vmv.v.v v13, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV32-NEXT:    th.vlseg4eff.v v6, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_mask_v_nxv4i32_nxv4i32:
@@ -3942,10 +4966,18 @@ define <vscale x 4 x i32> @intrinsic_vlseg4eff_mask_v_nxv4i32_nxv4i32(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vmv.v.v v13, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV64-NEXT:    th.vlseg4eff.v v6, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, iXLen } @llvm.riscv.th.vlseg4eff.mask.nxv4i32.nxv4i32(
@@ -3972,6 +5004,10 @@ define <vscale x 8 x i32> @intrinsic_vlseg2eff_v_nxv8i32_nxv8i32(<vscale x 8 x i
 ; RV32-NEXT:    th.vlseg2eff.v v4, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv8i32_nxv8i32:
@@ -3980,6 +5016,10 @@ define <vscale x 8 x i32> @intrinsic_vlseg2eff_v_nxv8i32_nxv8i32(<vscale x 8 x i
 ; RV64-NEXT:    th.vlseg2eff.v v4, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32>, iXLen } @llvm.riscv.th.vlseg2eff.nxv8i32.nxv8i32(
@@ -4014,10 +5054,18 @@ define <vscale x 8 x i32> @intrinsic_vlseg2eff_mask_v_nxv8i32_nxv8i32(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v6, v10
 ; RV32-NEXT:    th.vmv.v.v v7, v11
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m4, d1
 ; RV32-NEXT:    th.vlseg2eff.v v4, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv8i32_nxv8i32:
@@ -4034,10 +5082,18 @@ define <vscale x 8 x i32> @intrinsic_vlseg2eff_mask_v_nxv8i32_nxv8i32(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v6, v10
 ; RV64-NEXT:    th.vmv.v.v v7, v11
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m4, d1
 ; RV64-NEXT:    th.vlseg2eff.v v4, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv8i32.nxv8i32(
@@ -4064,6 +5120,10 @@ define <vscale x 2 x float> @intrinsic_vlseg2eff_v_nxv2f32_nxv2f32(<vscale x 2 x
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv2f32_nxv2f32:
@@ -4072,6 +5132,10 @@ define <vscale x 2 x float> @intrinsic_vlseg2eff_v_nxv2f32_nxv2f32(<vscale x 2 x
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, iXLen } @llvm.riscv.th.vlseg2eff.nxv2f32.nxv2f32(
@@ -4103,10 +5167,18 @@ define <vscale x 2 x float> @intrinsic_vlseg2eff_mask_v_nxv2f32_nxv2f32( <vscale
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vmv.v.v v9, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv2f32_nxv2f32:
@@ -4120,10 +5192,18 @@ define <vscale x 2 x float> @intrinsic_vlseg2eff_mask_v_nxv2f32_nxv2f32( <vscale
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vmv.v.v v9, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv2f32.nxv2f32(
@@ -4150,6 +5230,10 @@ define <vscale x 2 x float> @intrinsic_vlseg3eff_v_nxv2f32_nxv2f32(<vscale x 2 x
 ; RV32-NEXT:    th.vlseg3eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_v_nxv2f32_nxv2f32:
@@ -4158,6 +5242,10 @@ define <vscale x 2 x float> @intrinsic_vlseg3eff_v_nxv2f32_nxv2f32(<vscale x 2 x
 ; RV64-NEXT:    th.vlseg3eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, iXLen } @llvm.riscv.th.vlseg3eff.nxv2f32.nxv2f32(
@@ -4190,10 +5278,18 @@ define <vscale x 2 x float> @intrinsic_vlseg3eff_mask_v_nxv2f32_nxv2f32( <vscale
 ; RV32-NEXT:    th.vmv.v.v v9, v8
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vlseg3eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_mask_v_nxv2f32_nxv2f32:
@@ -4208,10 +5304,18 @@ define <vscale x 2 x float> @intrinsic_vlseg3eff_mask_v_nxv2f32_nxv2f32( <vscale
 ; RV64-NEXT:    th.vmv.v.v v9, v8
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vlseg3eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, iXLen } @llvm.riscv.th.vlseg3eff.mask.nxv2f32.nxv2f32(
@@ -4238,6 +5342,10 @@ define <vscale x 2 x float> @intrinsic_vlseg4eff_v_nxv2f32_nxv2f32(<vscale x 2 x
 ; RV32-NEXT:    th.vlseg4eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_v_nxv2f32_nxv2f32:
@@ -4246,6 +5354,10 @@ define <vscale x 2 x float> @intrinsic_vlseg4eff_v_nxv2f32_nxv2f32(<vscale x 2 x
 ; RV64-NEXT:    th.vlseg4eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, iXLen } @llvm.riscv.th.vlseg4eff.nxv2f32.nxv2f32(
@@ -4279,10 +5391,18 @@ define <vscale x 2 x float> @intrinsic_vlseg4eff_mask_v_nxv2f32_nxv2f32( <vscale
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vmv.v.v v11, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vlseg4eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_mask_v_nxv2f32_nxv2f32:
@@ -4298,10 +5418,18 @@ define <vscale x 2 x float> @intrinsic_vlseg4eff_mask_v_nxv2f32_nxv2f32( <vscale
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vmv.v.v v11, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vlseg4eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, iXLen } @llvm.riscv.th.vlseg4eff.mask.nxv2f32.nxv2f32(
@@ -4328,6 +5456,10 @@ define <vscale x 2 x float> @intrinsic_vlseg5eff_v_nxv2f32_nxv2f32(<vscale x 2 x
 ; RV32-NEXT:    th.vlseg5eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg5eff_v_nxv2f32_nxv2f32:
@@ -4336,6 +5468,10 @@ define <vscale x 2 x float> @intrinsic_vlseg5eff_v_nxv2f32_nxv2f32(<vscale x 2 x
 ; RV64-NEXT:    th.vlseg5eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, iXLen } @llvm.riscv.th.vlseg5eff.nxv2f32.nxv2f32(
@@ -4370,10 +5506,18 @@ define <vscale x 2 x float> @intrinsic_vlseg5eff_mask_v_nxv2f32_nxv2f32( <vscale
 ; RV32-NEXT:    th.vmv.v.v v11, v8
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vlseg5eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg5eff_mask_v_nxv2f32_nxv2f32:
@@ -4390,10 +5534,18 @@ define <vscale x 2 x float> @intrinsic_vlseg5eff_mask_v_nxv2f32_nxv2f32( <vscale
 ; RV64-NEXT:    th.vmv.v.v v11, v8
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vlseg5eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, iXLen } @llvm.riscv.th.vlseg5eff.mask.nxv2f32.nxv2f32(
@@ -4420,6 +5572,10 @@ define <vscale x 2 x float> @intrinsic_vlseg6eff_v_nxv2f32_nxv2f32(<vscale x 2 x
 ; RV32-NEXT:    th.vlseg6eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg6eff_v_nxv2f32_nxv2f32:
@@ -4428,6 +5584,10 @@ define <vscale x 2 x float> @intrinsic_vlseg6eff_v_nxv2f32_nxv2f32(<vscale x 2 x
 ; RV64-NEXT:    th.vlseg6eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, iXLen } @llvm.riscv.th.vlseg6eff.nxv2f32.nxv2f32(
@@ -4463,10 +5623,18 @@ define <vscale x 2 x float> @intrinsic_vlseg6eff_mask_v_nxv2f32_nxv2f32( <vscale
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vmv.v.v v13, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vlseg6eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg6eff_mask_v_nxv2f32_nxv2f32:
@@ -4484,10 +5652,18 @@ define <vscale x 2 x float> @intrinsic_vlseg6eff_mask_v_nxv2f32_nxv2f32( <vscale
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vmv.v.v v13, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vlseg6eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, iXLen } @llvm.riscv.th.vlseg6eff.mask.nxv2f32.nxv2f32(
@@ -4514,6 +5690,10 @@ define <vscale x 2 x float> @intrinsic_vlseg7eff_v_nxv2f32_nxv2f32(<vscale x 2 x
 ; RV32-NEXT:    th.vlseg7eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg7eff_v_nxv2f32_nxv2f32:
@@ -4522,6 +5702,10 @@ define <vscale x 2 x float> @intrinsic_vlseg7eff_v_nxv2f32_nxv2f32(<vscale x 2 x
 ; RV64-NEXT:    th.vlseg7eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, iXLen } @llvm.riscv.th.vlseg7eff.nxv2f32.nxv2f32(
@@ -4558,10 +5742,18 @@ define <vscale x 2 x float> @intrinsic_vlseg7eff_mask_v_nxv2f32_nxv2f32( <vscale
 ; RV32-NEXT:    th.vmv.v.v v13, v8
 ; RV32-NEXT:    th.vmv.v.v v14, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vlseg7eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg7eff_mask_v_nxv2f32_nxv2f32:
@@ -4580,10 +5772,18 @@ define <vscale x 2 x float> @intrinsic_vlseg7eff_mask_v_nxv2f32_nxv2f32( <vscale
 ; RV64-NEXT:    th.vmv.v.v v13, v8
 ; RV64-NEXT:    th.vmv.v.v v14, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vlseg7eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, iXLen } @llvm.riscv.th.vlseg7eff.mask.nxv2f32.nxv2f32(
@@ -4610,6 +5810,10 @@ define <vscale x 2 x float> @intrinsic_vlseg8eff_v_nxv2f32_nxv2f32(<vscale x 2 x
 ; RV32-NEXT:    th.vlseg8eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg8eff_v_nxv2f32_nxv2f32:
@@ -4618,6 +5822,10 @@ define <vscale x 2 x float> @intrinsic_vlseg8eff_v_nxv2f32_nxv2f32(<vscale x 2 x
 ; RV64-NEXT:    th.vlseg8eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, iXLen } @llvm.riscv.th.vlseg8eff.nxv2f32.nxv2f32(
@@ -4655,10 +5863,18 @@ define <vscale x 2 x float> @intrinsic_vlseg8eff_mask_v_nxv2f32_nxv2f32( <vscale
 ; RV32-NEXT:    th.vmv.v.v v14, v8
 ; RV32-NEXT:    th.vmv.v.v v15, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV32-NEXT:    th.vlseg8eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg8eff_mask_v_nxv2f32_nxv2f32:
@@ -4678,10 +5894,18 @@ define <vscale x 2 x float> @intrinsic_vlseg8eff_mask_v_nxv2f32_nxv2f32( <vscale
 ; RV64-NEXT:    th.vmv.v.v v14, v8
 ; RV64-NEXT:    th.vmv.v.v v15, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m1, d1
 ; RV64-NEXT:    th.vlseg8eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, iXLen } @llvm.riscv.th.vlseg8eff.mask.nxv2f32.nxv2f32(
@@ -4708,6 +5932,10 @@ define <vscale x 4 x float> @intrinsic_vlseg2eff_v_nxv4f32_nxv4f32(<vscale x 4 x
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv4f32_nxv4f32:
@@ -4716,6 +5944,10 @@ define <vscale x 4 x float> @intrinsic_vlseg2eff_v_nxv4f32_nxv4f32(<vscale x 4 x
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x float>, <vscale x 4 x float>, iXLen } @llvm.riscv.th.vlseg2eff.nxv4f32.nxv4f32(
@@ -4748,10 +5980,18 @@ define <vscale x 4 x float> @intrinsic_vlseg2eff_mask_v_nxv4f32_nxv4f32( <vscale
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vmv.v.v v11, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv4f32_nxv4f32:
@@ -4766,10 +6006,18 @@ define <vscale x 4 x float> @intrinsic_vlseg2eff_mask_v_nxv4f32_nxv4f32( <vscale
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vmv.v.v v11, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x float>, <vscale x 4 x float>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv4f32.nxv4f32(
@@ -4796,6 +6044,10 @@ define <vscale x 4 x float> @intrinsic_vlseg3eff_v_nxv4f32_nxv4f32(<vscale x 4 x
 ; RV32-NEXT:    th.vlseg3eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_v_nxv4f32_nxv4f32:
@@ -4804,6 +6056,10 @@ define <vscale x 4 x float> @intrinsic_vlseg3eff_v_nxv4f32_nxv4f32(<vscale x 4 x
 ; RV64-NEXT:    th.vlseg3eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, iXLen } @llvm.riscv.th.vlseg3eff.nxv4f32.nxv4f32(
@@ -4838,10 +6094,18 @@ define <vscale x 4 x float> @intrinsic_vlseg3eff_mask_v_nxv4f32_nxv4f32( <vscale
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vmv.v.v v13, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV32-NEXT:    th.vlseg3eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_mask_v_nxv4f32_nxv4f32:
@@ -4858,10 +6122,18 @@ define <vscale x 4 x float> @intrinsic_vlseg3eff_mask_v_nxv4f32_nxv4f32( <vscale
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vmv.v.v v13, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV64-NEXT:    th.vlseg3eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, iXLen } @llvm.riscv.th.vlseg3eff.mask.nxv4f32.nxv4f32(
@@ -4888,6 +6160,10 @@ define <vscale x 4 x float> @intrinsic_vlseg4eff_v_nxv4f32_nxv4f32(<vscale x 4 x
 ; RV32-NEXT:    th.vlseg4eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_v_nxv4f32_nxv4f32:
@@ -4896,6 +6172,10 @@ define <vscale x 4 x float> @intrinsic_vlseg4eff_v_nxv4f32_nxv4f32(<vscale x 4 x
 ; RV64-NEXT:    th.vlseg4eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, iXLen } @llvm.riscv.th.vlseg4eff.nxv4f32.nxv4f32(
@@ -4932,10 +6212,18 @@ define <vscale x 4 x float> @intrinsic_vlseg4eff_mask_v_nxv4f32_nxv4f32( <vscale
 ; RV32-NEXT:    th.vmv.v.v v14, v8
 ; RV32-NEXT:    th.vmv.v.v v15, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV32-NEXT:    th.vlseg4eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_mask_v_nxv4f32_nxv4f32:
@@ -4954,10 +6242,18 @@ define <vscale x 4 x float> @intrinsic_vlseg4eff_mask_v_nxv4f32_nxv4f32( <vscale
 ; RV64-NEXT:    th.vmv.v.v v14, v8
 ; RV64-NEXT:    th.vmv.v.v v15, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m2, d1
 ; RV64-NEXT:    th.vlseg4eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, iXLen } @llvm.riscv.th.vlseg4eff.mask.nxv4f32.nxv4f32(
@@ -4984,6 +6280,10 @@ define <vscale x 8 x float> @intrinsic_vlseg2eff_v_nxv8f32_nxv8f32(<vscale x 8 x
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv8f32_nxv8f32:
@@ -4992,6 +6292,10 @@ define <vscale x 8 x float> @intrinsic_vlseg2eff_v_nxv8f32_nxv8f32(<vscale x 8 x
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x float>, <vscale x 8 x float>, iXLen } @llvm.riscv.th.vlseg2eff.nxv8f32.nxv8f32(
@@ -5026,10 +6330,18 @@ define <vscale x 8 x float> @intrinsic_vlseg2eff_mask_v_nxv8f32_nxv8f32( <vscale
 ; RV32-NEXT:    th.vmv.v.v v14, v10
 ; RV32-NEXT:    th.vmv.v.v v15, v11
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e32, m4, d1
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv8f32_nxv8f32:
@@ -5046,10 +6358,18 @@ define <vscale x 8 x float> @intrinsic_vlseg2eff_mask_v_nxv8f32_nxv8f32( <vscale
 ; RV64-NEXT:    th.vmv.v.v v14, v10
 ; RV64-NEXT:    th.vmv.v.v v15, v11
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e32, m4, d1
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x float>, <vscale x 8 x float>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv8f32.nxv8f32(
@@ -5076,6 +6396,10 @@ define <vscale x 1 x i64> @intrinsic_vlseg2eff_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; RV32-NEXT:    th.vlseg2eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv1i64_nxv1i64:
@@ -5084,6 +6408,10 @@ define <vscale x 1 x i64> @intrinsic_vlseg2eff_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; RV64-NEXT:    th.vlseg2eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vlseg2eff.nxv1i64.nxv1i64(
@@ -5115,10 +6443,18 @@ define <vscale x 1 x i64> @intrinsic_vlseg2eff_mask_v_nxv1i64_nxv1i64(<vscale x 
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vmv.v.v v7, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vlseg2eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv1i64_nxv1i64:
@@ -5132,10 +6468,18 @@ define <vscale x 1 x i64> @intrinsic_vlseg2eff_mask_v_nxv1i64_nxv1i64(<vscale x 
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vmv.v.v v7, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vlseg2eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv1i64.nxv1i64(
@@ -5162,6 +6506,10 @@ define <vscale x 1 x i64> @intrinsic_vlseg3eff_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; RV32-NEXT:    th.vlseg3eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_v_nxv1i64_nxv1i64:
@@ -5170,6 +6518,10 @@ define <vscale x 1 x i64> @intrinsic_vlseg3eff_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; RV64-NEXT:    th.vlseg3eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vlseg3eff.nxv1i64.nxv1i64(
@@ -5202,10 +6554,18 @@ define <vscale x 1 x i64> @intrinsic_vlseg3eff_mask_v_nxv1i64_nxv1i64(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v7, v8
 ; RV32-NEXT:    th.vmv.v.v v9, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vlseg3eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_mask_v_nxv1i64_nxv1i64:
@@ -5220,10 +6580,18 @@ define <vscale x 1 x i64> @intrinsic_vlseg3eff_mask_v_nxv1i64_nxv1i64(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v7, v8
 ; RV64-NEXT:    th.vmv.v.v v9, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vlseg3eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vlseg3eff.mask.nxv1i64.nxv1i64(
@@ -5250,6 +6618,10 @@ define <vscale x 1 x i64> @intrinsic_vlseg4eff_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; RV32-NEXT:    th.vlseg4eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_v_nxv1i64_nxv1i64:
@@ -5258,6 +6630,10 @@ define <vscale x 1 x i64> @intrinsic_vlseg4eff_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; RV64-NEXT:    th.vlseg4eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vlseg4eff.nxv1i64.nxv1i64(
@@ -5291,10 +6667,18 @@ define <vscale x 1 x i64> @intrinsic_vlseg4eff_mask_v_nxv1i64_nxv1i64(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v9, v8
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vlseg4eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_mask_v_nxv1i64_nxv1i64:
@@ -5310,10 +6694,18 @@ define <vscale x 1 x i64> @intrinsic_vlseg4eff_mask_v_nxv1i64_nxv1i64(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v9, v8
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vlseg4eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vlseg4eff.mask.nxv1i64.nxv1i64(
@@ -5340,6 +6732,10 @@ define <vscale x 1 x i64> @intrinsic_vlseg5eff_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; RV32-NEXT:    th.vlseg5eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg5eff_v_nxv1i64_nxv1i64:
@@ -5348,6 +6744,10 @@ define <vscale x 1 x i64> @intrinsic_vlseg5eff_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; RV64-NEXT:    th.vlseg5eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vlseg5eff.nxv1i64.nxv1i64(
@@ -5382,10 +6782,18 @@ define <vscale x 1 x i64> @intrinsic_vlseg5eff_mask_v_nxv1i64_nxv1i64(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vmv.v.v v11, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vlseg5eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg5eff_mask_v_nxv1i64_nxv1i64:
@@ -5402,10 +6810,18 @@ define <vscale x 1 x i64> @intrinsic_vlseg5eff_mask_v_nxv1i64_nxv1i64(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vmv.v.v v11, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vlseg5eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vlseg5eff.mask.nxv1i64.nxv1i64(
@@ -5432,6 +6848,10 @@ define <vscale x 1 x i64> @intrinsic_vlseg6eff_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; RV32-NEXT:    th.vlseg6eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg6eff_v_nxv1i64_nxv1i64:
@@ -5440,6 +6860,10 @@ define <vscale x 1 x i64> @intrinsic_vlseg6eff_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; RV64-NEXT:    th.vlseg6eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vlseg6eff.nxv1i64.nxv1i64(
@@ -5475,10 +6899,18 @@ define <vscale x 1 x i64> @intrinsic_vlseg6eff_mask_v_nxv1i64_nxv1i64(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v11, v8
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vlseg6eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg6eff_mask_v_nxv1i64_nxv1i64:
@@ -5496,10 +6928,18 @@ define <vscale x 1 x i64> @intrinsic_vlseg6eff_mask_v_nxv1i64_nxv1i64(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v11, v8
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vlseg6eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vlseg6eff.mask.nxv1i64.nxv1i64(
@@ -5526,6 +6966,10 @@ define <vscale x 1 x i64> @intrinsic_vlseg7eff_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; RV32-NEXT:    th.vlseg7eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg7eff_v_nxv1i64_nxv1i64:
@@ -5534,6 +6978,10 @@ define <vscale x 1 x i64> @intrinsic_vlseg7eff_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; RV64-NEXT:    th.vlseg7eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vlseg7eff.nxv1i64.nxv1i64(
@@ -5570,10 +7018,18 @@ define <vscale x 1 x i64> @intrinsic_vlseg7eff_mask_v_nxv1i64_nxv1i64(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vmv.v.v v13, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vlseg7eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg7eff_mask_v_nxv1i64_nxv1i64:
@@ -5592,10 +7048,18 @@ define <vscale x 1 x i64> @intrinsic_vlseg7eff_mask_v_nxv1i64_nxv1i64(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vmv.v.v v13, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vlseg7eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vlseg7eff.mask.nxv1i64.nxv1i64(
@@ -5622,6 +7086,10 @@ define <vscale x 1 x i64> @intrinsic_vlseg8eff_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; RV32-NEXT:    th.vlseg8eff.v v7, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg8eff_v_nxv1i64_nxv1i64:
@@ -5630,6 +7098,10 @@ define <vscale x 1 x i64> @intrinsic_vlseg8eff_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; RV64-NEXT:    th.vlseg8eff.v v7, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vlseg8eff.nxv1i64.nxv1i64(
@@ -5667,10 +7139,18 @@ define <vscale x 1 x i64> @intrinsic_vlseg8eff_mask_v_nxv1i64_nxv1i64(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v13, v8
 ; RV32-NEXT:    th.vmv.v.v v14, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vlseg8eff.v v7, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg8eff_mask_v_nxv1i64_nxv1i64:
@@ -5690,10 +7170,18 @@ define <vscale x 1 x i64> @intrinsic_vlseg8eff_mask_v_nxv1i64_nxv1i64(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v13, v8
 ; RV64-NEXT:    th.vmv.v.v v14, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vlseg8eff.v v7, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, iXLen } @llvm.riscv.th.vlseg8eff.mask.nxv1i64.nxv1i64(
@@ -5720,6 +7208,10 @@ define <vscale x 2 x i64> @intrinsic_vlseg2eff_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; RV32-NEXT:    th.vlseg2eff.v v6, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv2i64_nxv2i64:
@@ -5728,6 +7220,10 @@ define <vscale x 2 x i64> @intrinsic_vlseg2eff_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; RV64-NEXT:    th.vlseg2eff.v v6, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, iXLen } @llvm.riscv.th.vlseg2eff.nxv2i64.nxv2i64(
@@ -5760,10 +7256,18 @@ define <vscale x 2 x i64> @intrinsic_vlseg2eff_mask_v_nxv2i64_nxv2i64(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v6, v8
 ; RV32-NEXT:    th.vmv.v.v v7, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV32-NEXT:    th.vlseg2eff.v v6, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv2i64_nxv2i64:
@@ -5778,10 +7282,18 @@ define <vscale x 2 x i64> @intrinsic_vlseg2eff_mask_v_nxv2i64_nxv2i64(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v6, v8
 ; RV64-NEXT:    th.vmv.v.v v7, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV64-NEXT:    th.vlseg2eff.v v6, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv2i64.nxv2i64(
@@ -5808,6 +7320,10 @@ define <vscale x 2 x i64> @intrinsic_vlseg3eff_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; RV32-NEXT:    th.vlseg3eff.v v6, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_v_nxv2i64_nxv2i64:
@@ -5816,6 +7332,10 @@ define <vscale x 2 x i64> @intrinsic_vlseg3eff_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; RV64-NEXT:    th.vlseg3eff.v v6, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, iXLen } @llvm.riscv.th.vlseg3eff.nxv2i64.nxv2i64(
@@ -5850,10 +7370,18 @@ define <vscale x 2 x i64> @intrinsic_vlseg3eff_mask_v_nxv2i64_nxv2i64(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vmv.v.v v11, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV32-NEXT:    th.vlseg3eff.v v6, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_mask_v_nxv2i64_nxv2i64:
@@ -5870,10 +7398,18 @@ define <vscale x 2 x i64> @intrinsic_vlseg3eff_mask_v_nxv2i64_nxv2i64(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vmv.v.v v11, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV64-NEXT:    th.vlseg3eff.v v6, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, iXLen } @llvm.riscv.th.vlseg3eff.mask.nxv2i64.nxv2i64(
@@ -5900,6 +7436,10 @@ define <vscale x 2 x i64> @intrinsic_vlseg4eff_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; RV32-NEXT:    th.vlseg4eff.v v6, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_v_nxv2i64_nxv2i64:
@@ -5908,6 +7448,10 @@ define <vscale x 2 x i64> @intrinsic_vlseg4eff_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; RV64-NEXT:    th.vlseg4eff.v v6, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, iXLen } @llvm.riscv.th.vlseg4eff.nxv2i64.nxv2i64(
@@ -5944,10 +7488,18 @@ define <vscale x 2 x i64> @intrinsic_vlseg4eff_mask_v_nxv2i64_nxv2i64(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vmv.v.v v13, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV32-NEXT:    th.vlseg4eff.v v6, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_mask_v_nxv2i64_nxv2i64:
@@ -5966,10 +7518,18 @@ define <vscale x 2 x i64> @intrinsic_vlseg4eff_mask_v_nxv2i64_nxv2i64(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vmv.v.v v13, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV64-NEXT:    th.vlseg4eff.v v6, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, iXLen } @llvm.riscv.th.vlseg4eff.mask.nxv2i64.nxv2i64(
@@ -5996,6 +7556,10 @@ define <vscale x 4 x i64> @intrinsic_vlseg2eff_v_nxv4i64_nxv4i64(<vscale x 4 x i
 ; RV32-NEXT:    th.vlseg2eff.v v4, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv4i64_nxv4i64:
@@ -6004,6 +7568,10 @@ define <vscale x 4 x i64> @intrinsic_vlseg2eff_v_nxv4i64_nxv4i64(<vscale x 4 x i
 ; RV64-NEXT:    th.vlseg2eff.v v4, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64>, iXLen } @llvm.riscv.th.vlseg2eff.nxv4i64.nxv4i64(
@@ -6038,10 +7606,18 @@ define <vscale x 4 x i64> @intrinsic_vlseg2eff_mask_v_nxv4i64_nxv4i64(<vscale x 
 ; RV32-NEXT:    th.vmv.v.v v6, v10
 ; RV32-NEXT:    th.vmv.v.v v7, v11
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m4, d1
 ; RV32-NEXT:    th.vlseg2eff.v v4, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv4i64_nxv4i64:
@@ -6058,10 +7634,18 @@ define <vscale x 4 x i64> @intrinsic_vlseg2eff_mask_v_nxv4i64_nxv4i64(<vscale x 
 ; RV64-NEXT:    th.vmv.v.v v6, v10
 ; RV64-NEXT:    th.vmv.v.v v7, v11
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m4, d1
 ; RV64-NEXT:    th.vlseg2eff.v v4, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv4i64.nxv4i64(
@@ -6088,6 +7672,10 @@ define <vscale x 1 x double> @intrinsic_vlseg2eff_v_nxv1f64_nxv1f64(<vscale x 1 
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv1f64_nxv1f64:
@@ -6096,6 +7684,10 @@ define <vscale x 1 x double> @intrinsic_vlseg2eff_v_nxv1f64_nxv1f64(<vscale x 1 
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, iXLen } @llvm.riscv.th.vlseg2eff.nxv1f64.nxv1f64(
@@ -6127,10 +7719,18 @@ define <vscale x 1 x double> @intrinsic_vlseg2eff_mask_v_nxv1f64_nxv1f64( <vscal
 ; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV32-NEXT:    th.vmv.v.v v9, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv1f64_nxv1f64:
@@ -6144,10 +7744,18 @@ define <vscale x 1 x double> @intrinsic_vlseg2eff_mask_v_nxv1f64_nxv1f64( <vscal
 ; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
 ; RV64-NEXT:    th.vmv.v.v v9, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv1f64.nxv1f64(
@@ -6174,6 +7782,10 @@ define <vscale x 1 x double> @intrinsic_vlseg3eff_v_nxv1f64_nxv1f64(<vscale x 1 
 ; RV32-NEXT:    th.vlseg3eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_v_nxv1f64_nxv1f64:
@@ -6182,6 +7794,10 @@ define <vscale x 1 x double> @intrinsic_vlseg3eff_v_nxv1f64_nxv1f64(<vscale x 1 
 ; RV64-NEXT:    th.vlseg3eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, iXLen } @llvm.riscv.th.vlseg3eff.nxv1f64.nxv1f64(
@@ -6214,10 +7830,18 @@ define <vscale x 1 x double> @intrinsic_vlseg3eff_mask_v_nxv1f64_nxv1f64( <vscal
 ; RV32-NEXT:    th.vmv.v.v v9, v8
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vlseg3eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_mask_v_nxv1f64_nxv1f64:
@@ -6232,10 +7856,18 @@ define <vscale x 1 x double> @intrinsic_vlseg3eff_mask_v_nxv1f64_nxv1f64( <vscal
 ; RV64-NEXT:    th.vmv.v.v v9, v8
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vlseg3eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, iXLen } @llvm.riscv.th.vlseg3eff.mask.nxv1f64.nxv1f64(
@@ -6262,6 +7894,10 @@ define <vscale x 1 x double> @intrinsic_vlseg4eff_v_nxv1f64_nxv1f64(<vscale x 1 
 ; RV32-NEXT:    th.vlseg4eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_v_nxv1f64_nxv1f64:
@@ -6270,6 +7906,10 @@ define <vscale x 1 x double> @intrinsic_vlseg4eff_v_nxv1f64_nxv1f64(<vscale x 1 
 ; RV64-NEXT:    th.vlseg4eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, iXLen } @llvm.riscv.th.vlseg4eff.nxv1f64.nxv1f64(
@@ -6303,10 +7943,18 @@ define <vscale x 1 x double> @intrinsic_vlseg4eff_mask_v_nxv1f64_nxv1f64( <vscal
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vmv.v.v v11, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vlseg4eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_mask_v_nxv1f64_nxv1f64:
@@ -6322,10 +7970,18 @@ define <vscale x 1 x double> @intrinsic_vlseg4eff_mask_v_nxv1f64_nxv1f64( <vscal
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vmv.v.v v11, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vlseg4eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, iXLen } @llvm.riscv.th.vlseg4eff.mask.nxv1f64.nxv1f64(
@@ -6352,6 +8008,10 @@ define <vscale x 1 x double> @intrinsic_vlseg5eff_v_nxv1f64_nxv1f64(<vscale x 1 
 ; RV32-NEXT:    th.vlseg5eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg5eff_v_nxv1f64_nxv1f64:
@@ -6360,6 +8020,10 @@ define <vscale x 1 x double> @intrinsic_vlseg5eff_v_nxv1f64_nxv1f64(<vscale x 1 
 ; RV64-NEXT:    th.vlseg5eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, iXLen } @llvm.riscv.th.vlseg5eff.nxv1f64.nxv1f64(
@@ -6394,10 +8058,18 @@ define <vscale x 1 x double> @intrinsic_vlseg5eff_mask_v_nxv1f64_nxv1f64( <vscal
 ; RV32-NEXT:    th.vmv.v.v v11, v8
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vlseg5eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg5eff_mask_v_nxv1f64_nxv1f64:
@@ -6414,10 +8086,18 @@ define <vscale x 1 x double> @intrinsic_vlseg5eff_mask_v_nxv1f64_nxv1f64( <vscal
 ; RV64-NEXT:    th.vmv.v.v v11, v8
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vlseg5eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, iXLen } @llvm.riscv.th.vlseg5eff.mask.nxv1f64.nxv1f64(
@@ -6444,6 +8124,10 @@ define <vscale x 1 x double> @intrinsic_vlseg6eff_v_nxv1f64_nxv1f64(<vscale x 1 
 ; RV32-NEXT:    th.vlseg6eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg6eff_v_nxv1f64_nxv1f64:
@@ -6452,6 +8136,10 @@ define <vscale x 1 x double> @intrinsic_vlseg6eff_v_nxv1f64_nxv1f64(<vscale x 1 
 ; RV64-NEXT:    th.vlseg6eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, iXLen } @llvm.riscv.th.vlseg6eff.nxv1f64.nxv1f64(
@@ -6487,10 +8175,18 @@ define <vscale x 1 x double> @intrinsic_vlseg6eff_mask_v_nxv1f64_nxv1f64( <vscal
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vmv.v.v v13, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vlseg6eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg6eff_mask_v_nxv1f64_nxv1f64:
@@ -6508,10 +8204,18 @@ define <vscale x 1 x double> @intrinsic_vlseg6eff_mask_v_nxv1f64_nxv1f64( <vscal
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vmv.v.v v13, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vlseg6eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, iXLen } @llvm.riscv.th.vlseg6eff.mask.nxv1f64.nxv1f64(
@@ -6538,6 +8242,10 @@ define <vscale x 1 x double> @intrinsic_vlseg7eff_v_nxv1f64_nxv1f64(<vscale x 1 
 ; RV32-NEXT:    th.vlseg7eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg7eff_v_nxv1f64_nxv1f64:
@@ -6546,6 +8254,10 @@ define <vscale x 1 x double> @intrinsic_vlseg7eff_v_nxv1f64_nxv1f64(<vscale x 1 
 ; RV64-NEXT:    th.vlseg7eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, iXLen } @llvm.riscv.th.vlseg7eff.nxv1f64.nxv1f64(
@@ -6582,10 +8294,18 @@ define <vscale x 1 x double> @intrinsic_vlseg7eff_mask_v_nxv1f64_nxv1f64( <vscal
 ; RV32-NEXT:    th.vmv.v.v v13, v8
 ; RV32-NEXT:    th.vmv.v.v v14, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vlseg7eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg7eff_mask_v_nxv1f64_nxv1f64:
@@ -6604,10 +8324,18 @@ define <vscale x 1 x double> @intrinsic_vlseg7eff_mask_v_nxv1f64_nxv1f64( <vscal
 ; RV64-NEXT:    th.vmv.v.v v13, v8
 ; RV64-NEXT:    th.vmv.v.v v14, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vlseg7eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, iXLen } @llvm.riscv.th.vlseg7eff.mask.nxv1f64.nxv1f64(
@@ -6634,6 +8362,10 @@ define <vscale x 1 x double> @intrinsic_vlseg8eff_v_nxv1f64_nxv1f64(<vscale x 1 
 ; RV32-NEXT:    th.vlseg8eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg8eff_v_nxv1f64_nxv1f64:
@@ -6642,6 +8374,10 @@ define <vscale x 1 x double> @intrinsic_vlseg8eff_v_nxv1f64_nxv1f64(<vscale x 1 
 ; RV64-NEXT:    th.vlseg8eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, iXLen } @llvm.riscv.th.vlseg8eff.nxv1f64.nxv1f64(
@@ -6679,10 +8415,18 @@ define <vscale x 1 x double> @intrinsic_vlseg8eff_mask_v_nxv1f64_nxv1f64( <vscal
 ; RV32-NEXT:    th.vmv.v.v v14, v8
 ; RV32-NEXT:    th.vmv.v.v v15, v8
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV32-NEXT:    th.vlseg8eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg8eff_mask_v_nxv1f64_nxv1f64:
@@ -6702,10 +8446,18 @@ define <vscale x 1 x double> @intrinsic_vlseg8eff_mask_v_nxv1f64_nxv1f64( <vscal
 ; RV64-NEXT:    th.vmv.v.v v14, v8
 ; RV64-NEXT:    th.vmv.v.v v15, v8
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m1, d1
 ; RV64-NEXT:    th.vlseg8eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, iXLen } @llvm.riscv.th.vlseg8eff.mask.nxv1f64.nxv1f64(
@@ -6732,6 +8484,10 @@ define <vscale x 2 x double> @intrinsic_vlseg2eff_v_nxv2f64_nxv2f64(<vscale x 2 
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv2f64_nxv2f64:
@@ -6740,6 +8496,10 @@ define <vscale x 2 x double> @intrinsic_vlseg2eff_v_nxv2f64_nxv2f64(<vscale x 2 
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x double>, <vscale x 2 x double>, iXLen } @llvm.riscv.th.vlseg2eff.nxv2f64.nxv2f64(
@@ -6772,10 +8532,18 @@ define <vscale x 2 x double> @intrinsic_vlseg2eff_mask_v_nxv2f64_nxv2f64( <vscal
 ; RV32-NEXT:    th.vmv.v.v v10, v8
 ; RV32-NEXT:    th.vmv.v.v v11, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv2f64_nxv2f64:
@@ -6790,10 +8558,18 @@ define <vscale x 2 x double> @intrinsic_vlseg2eff_mask_v_nxv2f64_nxv2f64( <vscal
 ; RV64-NEXT:    th.vmv.v.v v10, v8
 ; RV64-NEXT:    th.vmv.v.v v11, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x double>, <vscale x 2 x double>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv2f64.nxv2f64(
@@ -6820,6 +8596,10 @@ define <vscale x 2 x double> @intrinsic_vlseg3eff_v_nxv2f64_nxv2f64(<vscale x 2 
 ; RV32-NEXT:    th.vlseg3eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_v_nxv2f64_nxv2f64:
@@ -6828,6 +8608,10 @@ define <vscale x 2 x double> @intrinsic_vlseg3eff_v_nxv2f64_nxv2f64(<vscale x 2 
 ; RV64-NEXT:    th.vlseg3eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double>, iXLen } @llvm.riscv.th.vlseg3eff.nxv2f64.nxv2f64(
@@ -6862,10 +8646,18 @@ define <vscale x 2 x double> @intrinsic_vlseg3eff_mask_v_nxv2f64_nxv2f64( <vscal
 ; RV32-NEXT:    th.vmv.v.v v12, v8
 ; RV32-NEXT:    th.vmv.v.v v13, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV32-NEXT:    th.vlseg3eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg3eff_mask_v_nxv2f64_nxv2f64:
@@ -6882,10 +8674,18 @@ define <vscale x 2 x double> @intrinsic_vlseg3eff_mask_v_nxv2f64_nxv2f64( <vscal
 ; RV64-NEXT:    th.vmv.v.v v12, v8
 ; RV64-NEXT:    th.vmv.v.v v13, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV64-NEXT:    th.vlseg3eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double>, iXLen } @llvm.riscv.th.vlseg3eff.mask.nxv2f64.nxv2f64(
@@ -6912,6 +8712,10 @@ define <vscale x 2 x double> @intrinsic_vlseg4eff_v_nxv2f64_nxv2f64(<vscale x 2 
 ; RV32-NEXT:    th.vlseg4eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_v_nxv2f64_nxv2f64:
@@ -6920,6 +8724,10 @@ define <vscale x 2 x double> @intrinsic_vlseg4eff_v_nxv2f64_nxv2f64(<vscale x 2 
 ; RV64-NEXT:    th.vlseg4eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double>, iXLen } @llvm.riscv.th.vlseg4eff.nxv2f64.nxv2f64(
@@ -6956,10 +8764,18 @@ define <vscale x 2 x double> @intrinsic_vlseg4eff_mask_v_nxv2f64_nxv2f64( <vscal
 ; RV32-NEXT:    th.vmv.v.v v14, v8
 ; RV32-NEXT:    th.vmv.v.v v15, v9
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV32-NEXT:    th.vlseg4eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg4eff_mask_v_nxv2f64_nxv2f64:
@@ -6978,10 +8794,18 @@ define <vscale x 2 x double> @intrinsic_vlseg4eff_mask_v_nxv2f64_nxv2f64( <vscal
 ; RV64-NEXT:    th.vmv.v.v v14, v8
 ; RV64-NEXT:    th.vmv.v.v v15, v9
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m2, d1
 ; RV64-NEXT:    th.vlseg4eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double>, iXLen } @llvm.riscv.th.vlseg4eff.mask.nxv2f64.nxv2f64(
@@ -7008,6 +8832,10 @@ define <vscale x 4 x double> @intrinsic_vlseg2eff_v_nxv4f64_nxv4f64(<vscale x 4 
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_v_nxv4f64_nxv4f64:
@@ -7016,6 +8844,10 @@ define <vscale x 4 x double> @intrinsic_vlseg2eff_v_nxv4f64_nxv4f64(<vscale x 4 
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0)
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x double>, <vscale x 4 x double>, iXLen } @llvm.riscv.th.vlseg2eff.nxv4f64.nxv4f64(
@@ -7050,10 +8882,18 @@ define <vscale x 4 x double> @intrinsic_vlseg2eff_mask_v_nxv4f64_nxv4f64( <vscal
 ; RV32-NEXT:    th.vmv.v.v v14, v10
 ; RV32-NEXT:    th.vmv.v.v v15, v11
 ; RV32-NEXT:    th.vsetvl zero, a3, a4
+; RV32-NEXT:    csrr a3, vl
+; RV32-NEXT:    csrr a4, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a3, a4
 ; RV32-NEXT:    th.vsetvli zero, a1, e64, m4, d1
 ; RV32-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV32-NEXT:    csrr a0, vl
 ; RV32-NEXT:    sw a0, 0(a2)
+; RV32-NEXT:    csrr a0, vl
+; RV32-NEXT:    csrr a1, vtype
+; RV32-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV32-NEXT:    th.vsetvl zero, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: intrinsic_vlseg2eff_mask_v_nxv4f64_nxv4f64:
@@ -7070,10 +8910,18 @@ define <vscale x 4 x double> @intrinsic_vlseg2eff_mask_v_nxv4f64_nxv4f64( <vscal
 ; RV64-NEXT:    th.vmv.v.v v14, v10
 ; RV64-NEXT:    th.vmv.v.v v15, v11
 ; RV64-NEXT:    th.vsetvl zero, a3, a4
+; RV64-NEXT:    csrr a3, vl
+; RV64-NEXT:    csrr a4, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a3, a4
 ; RV64-NEXT:    th.vsetvli zero, a1, e64, m4, d1
 ; RV64-NEXT:    th.vlseg2eff.v v8, (a0), v0.t
 ; RV64-NEXT:    csrr a0, vl
 ; RV64-NEXT:    sd a0, 0(a2)
+; RV64-NEXT:    csrr a0, vl
+; RV64-NEXT:    csrr a1, vtype
+; RV64-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; RV64-NEXT:    th.vsetvl zero, a0, a1
 ; RV64-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x double>, <vscale x 4 x double>, iXLen } @llvm.riscv.th.vlseg2eff.mask.nxv4f64.nxv4f64(

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vlssegb.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vlssegb.ll
@@ -15,6 +15,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg2b_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg2b.nxv8i8.nxv8i8(
@@ -34,19 +38,36 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg2b.mask.nx
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg2b_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg2b_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2b_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg2b.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -63,6 +84,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg2bu_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg2bu.nxv8i8.nxv8i8(
@@ -82,19 +107,36 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg2bu.mask.n
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg2bu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg2bu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2bu_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg2bu.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -111,6 +153,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg3b_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg3b.nxv8i8.nxv8i8(
@@ -130,19 +176,37 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg3b_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg3b_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3b_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg3b.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -159,6 +223,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg3bu_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg3bu.nxv8i8.nxv8i8(
@@ -178,19 +246,37 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg3bu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg3bu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3bu_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg3bu.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -207,6 +293,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg4b_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg4b.nxv8i8.nxv8i8(
@@ -226,19 +316,38 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg4b_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg4b_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4b_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg4b.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -255,6 +364,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg4bu_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg4bu.nxv8i8.nxv8i8(
@@ -274,19 +387,38 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg4bu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg4bu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4bu_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg4bu.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -303,6 +435,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg5b_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg5b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg5b.nxv8i8.nxv8i8(
@@ -322,19 +458,39 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg5b_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg5b_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5b_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg5b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg5b.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -351,6 +507,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg5bu_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg5bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg5bu.nxv8i8.nxv8i8(
@@ -370,19 +530,39 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg5bu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg5bu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5bu_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg5bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg5bu.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -399,6 +579,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg6b_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg6b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg6b.nxv8i8.nxv8i8(
@@ -418,19 +602,40 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg6b_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg6b_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6b_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg6b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg6b.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -447,6 +652,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg6bu_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg6bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg6bu.nxv8i8.nxv8i8(
@@ -466,19 +675,40 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg6bu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg6bu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6bu_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg6bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg6bu.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -495,6 +725,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg7b_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg7b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg7b.nxv8i8.nxv8i8(
@@ -514,19 +748,41 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg7b_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg7b_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7b_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg7b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg7b.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -543,6 +799,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg7bu_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg7bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg7bu.nxv8i8.nxv8i8(
@@ -562,19 +822,41 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg7bu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg7bu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7bu_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg7bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg7bu.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -591,6 +873,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg8b_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg8b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg8b.nxv8i8.nxv8i8(
@@ -610,19 +896,42 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg8b_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg8b_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8b_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg8b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg8b.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -639,6 +948,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg8bu_v_nxv8i8_nxv8i8(<vscale x 8 x i8>*
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg8bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg8bu.nxv8i8.nxv8i8(
@@ -658,19 +971,42 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg8bu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg8bu_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8bu_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg8bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg8bu.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -687,6 +1023,10 @@ define <vscale x 16 x i8> @intrinsic_vlsseg2b_v_nxv16i8_nxv16i8(<vscale x 16 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg2b.nxv16i8.nxv16i8(
@@ -706,19 +1046,37 @@ declare { <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg2b.mask.
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i8> @intrinsic_vlsseg2b_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x i8> @intrinsic_vlsseg2b_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2b_mask_v_nxv16i8_nxv16i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg2b.mask.nxv16i8.nxv16i8(
-    <vscale x 16 x i8> undef, <vscale x 16 x i8> undef,
-    <vscale x 16 x i8>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x i8> %0, <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x i8>, <vscale x 16 x i8> } %a, 1
   ret <vscale x 16 x i8> %b
@@ -735,6 +1093,10 @@ define <vscale x 16 x i8> @intrinsic_vlsseg2bu_v_nxv16i8_nxv16i8(<vscale x 16 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg2bu.nxv16i8.nxv16i8(
@@ -754,19 +1116,37 @@ declare { <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg2bu.mask
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i8> @intrinsic_vlsseg2bu_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x i8> @intrinsic_vlsseg2bu_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2bu_mask_v_nxv16i8_nxv16i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg2bu.mask.nxv16i8.nxv16i8(
-    <vscale x 16 x i8> undef, <vscale x 16 x i8> undef,
-    <vscale x 16 x i8>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x i8> %0, <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x i8>, <vscale x 16 x i8> } %a, 1
   ret <vscale x 16 x i8> %b
@@ -783,6 +1163,10 @@ define <vscale x 16 x i8> @intrinsic_vlsseg3b_v_nxv16i8_nxv16i8(<vscale x 16 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg3b.nxv16i8.nxv16i8(
@@ -802,19 +1186,39 @@ declare { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.ris
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i8> @intrinsic_vlsseg3b_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x i8> @intrinsic_vlsseg3b_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3b_mask_v_nxv16i8_nxv16i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg3b.mask.nxv16i8.nxv16i8(
-    <vscale x 16 x i8> undef, <vscale x 16 x i8> undef, <vscale x 16 x i8> undef,
-    <vscale x 16 x i8>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x i8> %0, <vscale x 16 x i8> %0, <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } %a, 1
   ret <vscale x 16 x i8> %b
@@ -831,6 +1235,10 @@ define <vscale x 16 x i8> @intrinsic_vlsseg3bu_v_nxv16i8_nxv16i8(<vscale x 16 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg3bu.nxv16i8.nxv16i8(
@@ -850,19 +1258,39 @@ declare { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.ris
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i8> @intrinsic_vlsseg3bu_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x i8> @intrinsic_vlsseg3bu_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3bu_mask_v_nxv16i8_nxv16i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg3bu.mask.nxv16i8.nxv16i8(
-    <vscale x 16 x i8> undef, <vscale x 16 x i8> undef, <vscale x 16 x i8> undef,
-    <vscale x 16 x i8>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x i8> %0, <vscale x 16 x i8> %0, <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } %a, 1
   ret <vscale x 16 x i8> %b
@@ -879,6 +1307,10 @@ define <vscale x 16 x i8> @intrinsic_vlsseg4b_v_nxv16i8_nxv16i8(<vscale x 16 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg4b.nxv16i8.nxv16i8(
@@ -898,19 +1330,41 @@ declare { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i8> @intrinsic_vlsseg4b_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x i8> @intrinsic_vlsseg4b_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4b_mask_v_nxv16i8_nxv16i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg4b.mask.nxv16i8.nxv16i8(
-    <vscale x 16 x i8> undef, <vscale x 16 x i8> undef, <vscale x 16 x i8> undef, <vscale x 16 x i8> undef,
-    <vscale x 16 x i8>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x i8> %0, <vscale x 16 x i8> %0, <vscale x 16 x i8> %0, <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } %a, 1
   ret <vscale x 16 x i8> %b
@@ -927,6 +1381,10 @@ define <vscale x 16 x i8> @intrinsic_vlsseg4bu_v_nxv16i8_nxv16i8(<vscale x 16 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg4bu.nxv16i8.nxv16i8(
@@ -946,19 +1404,41 @@ declare { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i8> @intrinsic_vlsseg4bu_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x i8> @intrinsic_vlsseg4bu_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4bu_mask_v_nxv16i8_nxv16i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg4bu.mask.nxv16i8.nxv16i8(
-    <vscale x 16 x i8> undef, <vscale x 16 x i8> undef, <vscale x 16 x i8> undef, <vscale x 16 x i8> undef,
-    <vscale x 16 x i8>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x i8> %0, <vscale x 16 x i8> %0, <vscale x 16 x i8> %0, <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } %a, 1
   ret <vscale x 16 x i8> %b
@@ -975,6 +1455,10 @@ define <vscale x 32 x i8> @intrinsic_vlsseg2b_v_nxv32i8_nxv32i8(<vscale x 32 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m4, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 32 x i8>, <vscale x 32 x i8> } @llvm.riscv.th.vlsseg2b.nxv32i8.nxv32i8(
@@ -994,19 +1478,39 @@ declare { <vscale x 32 x i8>, <vscale x 32 x i8> } @llvm.riscv.th.vlsseg2b.mask.
   <vscale x 32 x i1>,
   iXLen);
 
-define <vscale x 32 x i8> @intrinsic_vlsseg2b_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, <vscale x 32 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 32 x i8> @intrinsic_vlsseg2b_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, <vscale x 32 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2b_mask_v_nxv32i8_nxv32i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m4, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 32 x i8>, <vscale x 32 x i8> } @llvm.riscv.th.vlsseg2b.mask.nxv32i8.nxv32i8(
-    <vscale x 32 x i8> undef, <vscale x 32 x i8> undef,
-    <vscale x 32 x i8>* %0,
-    iXLen %2,
-    <vscale x 32 x i1> %1,
-    iXLen %3)
+    <vscale x 32 x i8> %0, <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    iXLen %3,
+    <vscale x 32 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 32 x i8>, <vscale x 32 x i8> } %a, 1
   ret <vscale x 32 x i8> %b
@@ -1023,6 +1527,10 @@ define <vscale x 32 x i8> @intrinsic_vlsseg2bu_v_nxv32i8_nxv32i8(<vscale x 32 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m4, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 32 x i8>, <vscale x 32 x i8> } @llvm.riscv.th.vlsseg2bu.nxv32i8.nxv32i8(
@@ -1042,19 +1550,39 @@ declare { <vscale x 32 x i8>, <vscale x 32 x i8> } @llvm.riscv.th.vlsseg2bu.mask
   <vscale x 32 x i1>,
   iXLen);
 
-define <vscale x 32 x i8> @intrinsic_vlsseg2bu_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, <vscale x 32 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 32 x i8> @intrinsic_vlsseg2bu_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, <vscale x 32 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2bu_mask_v_nxv32i8_nxv32i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m4, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 32 x i8>, <vscale x 32 x i8> } @llvm.riscv.th.vlsseg2bu.mask.nxv32i8.nxv32i8(
-    <vscale x 32 x i8> undef, <vscale x 32 x i8> undef,
-    <vscale x 32 x i8>* %0,
-    iXLen %2,
-    <vscale x 32 x i1> %1,
-    iXLen %3)
+    <vscale x 32 x i8> %0, <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    iXLen %3,
+    <vscale x 32 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 32 x i8>, <vscale x 32 x i8> } %a, 1
   ret <vscale x 32 x i8> %b
@@ -1071,6 +1599,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg2b_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2b.nxv4i16.nxv4i16(
@@ -1090,19 +1622,36 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2b.mask.
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg2b_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg2b_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2b_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2b.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -1119,6 +1668,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg2bu_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2bu.nxv4i16.nxv4i16(
@@ -1138,19 +1691,36 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2bu.mask
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg2bu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg2bu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2bu_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2bu.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -1167,6 +1737,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg3b_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg3b.nxv4i16.nxv4i16(
@@ -1186,19 +1760,37 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.ris
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg3b_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg3b_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3b_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg3b.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -1215,6 +1807,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg3bu_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg3bu.nxv4i16.nxv4i16(
@@ -1234,19 +1830,37 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.ris
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg3bu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg3bu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3bu_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg3bu.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -1263,6 +1877,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg4b_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg4b.nxv4i16.nxv4i16(
@@ -1282,19 +1900,38 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg4b_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg4b_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4b_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg4b.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -1311,6 +1948,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg4bu_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg4bu.nxv4i16.nxv4i16(
@@ -1330,19 +1971,38 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg4bu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg4bu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4bu_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg4bu.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -1359,6 +2019,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg5b_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg5b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg5b.nxv4i16.nxv4i16(
@@ -1378,19 +2042,39 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg5b_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg5b_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5b_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg5b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg5b.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -1407,6 +2091,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg5bu_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg5bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg5bu.nxv4i16.nxv4i16(
@@ -1426,19 +2114,39 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg5bu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg5bu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5bu_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg5bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg5bu.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -1455,6 +2163,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg6b_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg6b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg6b.nxv4i16.nxv4i16(
@@ -1474,19 +2186,40 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg6b_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg6b_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6b_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg6b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg6b.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -1503,6 +2236,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg6bu_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg6bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg6bu.nxv4i16.nxv4i16(
@@ -1522,19 +2259,40 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg6bu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg6bu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6bu_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg6bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg6bu.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -1551,6 +2309,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg7b_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg7b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg7b.nxv4i16.nxv4i16(
@@ -1570,19 +2332,41 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg7b_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg7b_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7b_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg7b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg7b.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -1599,6 +2383,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg7bu_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg7bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg7bu.nxv4i16.nxv4i16(
@@ -1618,19 +2406,41 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg7bu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg7bu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7bu_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg7bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg7bu.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -1647,6 +2457,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg8b_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg8b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg8b.nxv4i16.nxv4i16(
@@ -1666,19 +2480,42 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg8b_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg8b_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8b_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg8b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg8b.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -1695,6 +2532,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg8bu_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg8bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg8bu.nxv4i16.nxv4i16(
@@ -1714,19 +2555,42 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg8bu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg8bu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8bu_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg8bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg8bu.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -1743,6 +2607,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg2b_v_nxv8i16_nxv8i16(<vscale x 8 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2b.nxv8i16.nxv8i16(
@@ -1762,19 +2630,37 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2b.mask.
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg2b_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg2b_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2b_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2b.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -1791,6 +2677,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg2bu_v_nxv8i16_nxv8i16(<vscale x 8 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2bu.nxv8i16.nxv8i16(
@@ -1810,19 +2700,37 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2bu.mask
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg2bu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg2bu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2bu_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2bu.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -1839,6 +2747,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg3b_v_nxv8i16_nxv8i16(<vscale x 8 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg3b.nxv8i16.nxv8i16(
@@ -1858,19 +2770,39 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.ris
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg3b_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg3b_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3b_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg3b.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -1887,6 +2819,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg3bu_v_nxv8i16_nxv8i16(<vscale x 8 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg3bu.nxv8i16.nxv8i16(
@@ -1906,19 +2842,39 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.ris
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg3bu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg3bu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3bu_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg3bu.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -1935,6 +2891,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg4b_v_nxv8i16_nxv8i16(<vscale x 8 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg4b.nxv8i16.nxv8i16(
@@ -1954,19 +2914,41 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg4b_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg4b_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4b_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg4b.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -1983,6 +2965,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg4bu_v_nxv8i16_nxv8i16(<vscale x 8 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg4bu.nxv8i16.nxv8i16(
@@ -2002,19 +2988,41 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg4bu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg4bu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4bu_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg4bu.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -2031,6 +3039,10 @@ define <vscale x 16 x i16> @intrinsic_vlsseg2b_v_nxv16i16_nxv16i16(<vscale x 16 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m4, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2b.nxv16i16.nxv16i16(
@@ -2050,19 +3062,39 @@ declare { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2b.mas
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i16> @intrinsic_vlsseg2b_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x i16> @intrinsic_vlsseg2b_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2b_mask_v_nxv16i16_nxv16i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m4, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2b.mask.nxv16i16.nxv16i16(
-    <vscale x 16 x i16> undef, <vscale x 16 x i16> undef,
-    <vscale x 16 x i16>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x i16> %0, <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x i16>, <vscale x 16 x i16> } %a, 1
   ret <vscale x 16 x i16> %b
@@ -2079,6 +3111,10 @@ define <vscale x 16 x i16> @intrinsic_vlsseg2bu_v_nxv16i16_nxv16i16(<vscale x 16
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m4, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2bu.nxv16i16.nxv16i16(
@@ -2098,19 +3134,39 @@ declare { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2bu.ma
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i16> @intrinsic_vlsseg2bu_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x i16> @intrinsic_vlsseg2bu_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2bu_mask_v_nxv16i16_nxv16i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m4, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2bu.mask.nxv16i16.nxv16i16(
-    <vscale x 16 x i16> undef, <vscale x 16 x i16> undef,
-    <vscale x 16 x i16>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x i16> %0, <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x i16>, <vscale x 16 x i16> } %a, 1
   ret <vscale x 16 x i16> %b
@@ -2127,6 +3183,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg2b_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2b.nxv2i32.nxv2i32(
@@ -2146,19 +3206,36 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2b.mask.
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg2b_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg2b_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2b_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2b.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -2175,6 +3252,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg2bu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2bu.nxv2i32.nxv2i32(
@@ -2194,19 +3275,36 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2bu.mask
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg2bu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg2bu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2bu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2bu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -2223,6 +3321,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg3b_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg3b.nxv2i32.nxv2i32(
@@ -2242,19 +3344,37 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.ris
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg3b_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg3b_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3b_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg3b.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -2271,6 +3391,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg3bu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg3bu.nxv2i32.nxv2i32(
@@ -2290,19 +3414,37 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.ris
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg3bu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg3bu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3bu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg3bu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -2319,6 +3461,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg4b_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg4b.nxv2i32.nxv2i32(
@@ -2338,19 +3484,38 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg4b_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg4b_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4b_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg4b.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -2367,6 +3532,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg4bu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg4bu.nxv2i32.nxv2i32(
@@ -2386,19 +3555,38 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg4bu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg4bu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4bu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg4bu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -2415,6 +3603,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg5b_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg5b.nxv2i32.nxv2i32(
@@ -2434,19 +3626,39 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg5b_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg5b_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5b_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg5b.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -2463,6 +3675,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg5bu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg5bu.nxv2i32.nxv2i32(
@@ -2482,19 +3698,39 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg5bu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg5bu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5bu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg5bu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -2511,6 +3747,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg6b_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg6b.nxv2i32.nxv2i32(
@@ -2530,19 +3770,40 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg6b_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg6b_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6b_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg6b.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -2559,6 +3820,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg6bu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg6bu.nxv2i32.nxv2i32(
@@ -2578,19 +3843,40 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg6bu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg6bu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6bu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg6bu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -2607,6 +3893,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg7b_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg7b.nxv2i32.nxv2i32(
@@ -2626,19 +3916,41 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg7b_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg7b_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7b_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg7b.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -2655,6 +3967,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg7bu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg7bu.nxv2i32.nxv2i32(
@@ -2674,19 +3990,41 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg7bu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg7bu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7bu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg7bu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -2703,6 +4041,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg8b_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg8b.nxv2i32.nxv2i32(
@@ -2722,19 +4064,42 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg8b_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg8b_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8b_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg8b.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -2751,6 +4116,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg8bu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg8bu.nxv2i32.nxv2i32(
@@ -2770,19 +4139,42 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg8bu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg8bu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8bu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg8bu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -2799,6 +4191,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg2b_v_nxv4i32_nxv4i32(<vscale x 4 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2b.nxv4i32.nxv4i32(
@@ -2818,19 +4214,37 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2b.mask.
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg2b_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg2b_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2b_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2b.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -2847,6 +4261,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg2bu_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2bu.nxv4i32.nxv4i32(
@@ -2866,19 +4284,37 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2bu.mask
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg2bu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg2bu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2bu_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2bu.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -2895,6 +4331,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg3b_v_nxv4i32_nxv4i32(<vscale x 4 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg3b.nxv4i32.nxv4i32(
@@ -2914,19 +4354,39 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.ris
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg3b_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg3b_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3b_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg3b.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -2943,6 +4403,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg3bu_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg3bu.nxv4i32.nxv4i32(
@@ -2962,19 +4426,39 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.ris
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg3bu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg3bu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3bu_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg3bu.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -2991,6 +4475,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg4b_v_nxv4i32_nxv4i32(<vscale x 4 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg4b.nxv4i32.nxv4i32(
@@ -3010,19 +4498,41 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg4b_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg4b_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4b_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg4b.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -3039,6 +4549,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg4bu_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg4bu.nxv4i32.nxv4i32(
@@ -3058,19 +4572,41 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg4bu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg4bu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4bu_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg4bu.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -3087,6 +4623,10 @@ define <vscale x 8 x i32> @intrinsic_vlsseg2b_v_nxv8i32_nxv8i32(<vscale x 8 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2b.nxv8i32.nxv8i32(
@@ -3106,19 +4646,39 @@ declare { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2b.mask.
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i32> @intrinsic_vlsseg2b_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i32> @intrinsic_vlsseg2b_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2b_mask_v_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2b.mask.nxv8i32.nxv8i32(
-    <vscale x 8 x i32> undef, <vscale x 8 x i32> undef,
-    <vscale x 8 x i32>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i32> %0, <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i32>, <vscale x 8 x i32> } %a, 1
   ret <vscale x 8 x i32> %b
@@ -3135,6 +4695,10 @@ define <vscale x 8 x i32> @intrinsic_vlsseg2bu_v_nxv8i32_nxv8i32(<vscale x 8 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2bu.nxv8i32.nxv8i32(
@@ -3154,19 +4718,39 @@ declare { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2bu.mask
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i32> @intrinsic_vlsseg2bu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i32> @intrinsic_vlsseg2bu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2bu_mask_v_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2bu.mask.nxv8i32.nxv8i32(
-    <vscale x 8 x i32> undef, <vscale x 8 x i32> undef,
-    <vscale x 8 x i32>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i32> %0, <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i32>, <vscale x 8 x i32> } %a, 1
   ret <vscale x 8 x i32> %b
@@ -3183,6 +4767,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg2b_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2b.nxv1i64.nxv1i64(
@@ -3202,19 +4790,36 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2b.mask.
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg2b_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg2b_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2b_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2b.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -3231,6 +4836,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg2bu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2bu.nxv1i64.nxv1i64(
@@ -3250,19 +4859,36 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2bu.mask
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg2bu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg2bu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2bu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2bu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -3279,6 +4905,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg3b_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg3b.nxv1i64.nxv1i64(
@@ -3298,19 +4928,37 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.ris
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg3b_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg3b_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3b_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg3b.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -3327,6 +4975,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg3bu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg3bu.nxv1i64.nxv1i64(
@@ -3346,19 +4998,37 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.ris
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg3bu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg3bu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3bu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg3bu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -3375,6 +5045,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg4b_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg4b.nxv1i64.nxv1i64(
@@ -3394,19 +5068,38 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg4b_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg4b_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4b_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg4b.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -3423,6 +5116,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg4bu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg4bu.nxv1i64.nxv1i64(
@@ -3442,19 +5139,38 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg4bu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg4bu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4bu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg4bu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -3471,6 +5187,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg5b_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg5b.nxv1i64.nxv1i64(
@@ -3490,19 +5210,39 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg5b_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg5b_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5b_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg5b.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -3519,6 +5259,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg5bu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg5bu.nxv1i64.nxv1i64(
@@ -3538,19 +5282,39 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg5bu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg5bu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5bu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg5bu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -3567,6 +5331,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg6b_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg6b.nxv1i64.nxv1i64(
@@ -3586,19 +5354,40 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg6b_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg6b_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6b_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg6b.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -3615,6 +5404,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg6bu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg6bu.nxv1i64.nxv1i64(
@@ -3634,19 +5427,40 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg6bu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg6bu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6bu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg6bu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -3663,6 +5477,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg7b_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg7b.nxv1i64.nxv1i64(
@@ -3682,19 +5500,41 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg7b_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg7b_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7b_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg7b.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -3711,6 +5551,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg7bu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg7bu.nxv1i64.nxv1i64(
@@ -3730,19 +5574,41 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg7bu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg7bu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7bu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg7bu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -3759,6 +5625,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg8b_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8b.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg8b.nxv1i64.nxv1i64(
@@ -3778,19 +5648,42 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg8b_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg8b_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8b_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8b.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg8b.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -3807,6 +5700,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg8bu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8bu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg8bu.nxv1i64.nxv1i64(
@@ -3826,19 +5723,42 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg8bu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg8bu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8bu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8bu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg8bu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -3855,6 +5775,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg2b_v_nxv2i64_nxv2i64(<vscale x 2 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2b.nxv2i64.nxv2i64(
@@ -3874,19 +5798,37 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2b.mask.
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg2b_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg2b_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2b_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2b.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -3903,6 +5845,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg2bu_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2bu.nxv2i64.nxv2i64(
@@ -3922,19 +5868,37 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2bu.mask
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg2bu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg2bu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2bu_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2bu.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -3951,6 +5915,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg3b_v_nxv2i64_nxv2i64(<vscale x 2 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg3b.nxv2i64.nxv2i64(
@@ -3970,19 +5938,39 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.ris
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg3b_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg3b_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3b_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3b.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg3b.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -3999,6 +5987,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg3bu_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg3bu.nxv2i64.nxv2i64(
@@ -4018,19 +6010,39 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.ris
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg3bu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg3bu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3bu_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3bu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg3bu.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -4047,6 +6059,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg4b_v_nxv2i64_nxv2i64(<vscale x 2 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg4b.nxv2i64.nxv2i64(
@@ -4066,19 +6082,41 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg4b_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg4b_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4b_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4b.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg4b.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -4095,6 +6133,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg4bu_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg4bu.nxv2i64.nxv2i64(
@@ -4114,19 +6156,41 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg4bu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg4bu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4bu_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4bu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg4bu.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -4143,6 +6207,10 @@ define <vscale x 4 x i64> @intrinsic_vlsseg2b_v_nxv4i64_nxv4i64(<vscale x 4 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2b.nxv4i64.nxv4i64(
@@ -4162,19 +6230,39 @@ declare { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2b.mask.
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i64> @intrinsic_vlsseg2b_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i64> @intrinsic_vlsseg2b_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2b_mask_v_nxv4i64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2b.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2b.mask.nxv4i64.nxv4i64(
-    <vscale x 4 x i64> undef, <vscale x 4 x i64> undef,
-    <vscale x 4 x i64>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i64> %0, <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i64>, <vscale x 4 x i64> } %a, 1
   ret <vscale x 4 x i64> %b
@@ -4191,6 +6279,10 @@ define <vscale x 4 x i64> @intrinsic_vlsseg2bu_v_nxv4i64_nxv4i64(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2bu.nxv4i64.nxv4i64(
@@ -4210,19 +6302,39 @@ declare { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2bu.mask
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i64> @intrinsic_vlsseg2bu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i64> @intrinsic_vlsseg2bu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2bu_mask_v_nxv4i64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2bu.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2bu.mask.nxv4i64.nxv4i64(
-    <vscale x 4 x i64> undef, <vscale x 4 x i64> undef,
-    <vscale x 4 x i64>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i64> %0, <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i64>, <vscale x 4 x i64> } %a, 1
   ret <vscale x 4 x i64> %b

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vlssege.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vlssege.ll
@@ -15,6 +15,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg2e_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg2e.nxv8i8.nxv8i8(
@@ -34,19 +38,36 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg2e.mask.nx
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg2e_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg2e_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg2e.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -63,6 +84,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg3e_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg3e.nxv8i8.nxv8i8(
@@ -82,19 +107,37 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg3e_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg3e_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3e_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg3e.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -111,6 +154,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg4e_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg4e.nxv8i8.nxv8i8(
@@ -130,19 +177,38 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg4e_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg4e_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4e_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg4e.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -159,6 +225,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg5e_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg5e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg5e.nxv8i8.nxv8i8(
@@ -178,19 +248,39 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg5e_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg5e_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5e_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg5e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg5e.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -207,6 +297,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg6e_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg6e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg6e.nxv8i8.nxv8i8(
@@ -226,19 +320,40 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg6e_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg6e_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6e_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg6e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg6e.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -255,6 +370,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg7e_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg7e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg7e.nxv8i8.nxv8i8(
@@ -274,19 +393,41 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg7e_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg7e_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7e_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg7e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg7e.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -303,6 +444,10 @@ define <vscale x 8 x i8> @intrinsic_vlsseg8e_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg8e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg8e.nxv8i8.nxv8i8(
@@ -322,19 +467,42 @@ declare { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i8> @intrinsic_vlsseg8e_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i8> @intrinsic_vlsseg8e_mask_v_nxv8i8_nxv8i8(<vscale x 8 x i8> %0, <vscale x 8 x i8>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8e_mask_v_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m1, d1
 ; CHECK-NEXT:    th.vlsseg8e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } @llvm.riscv.th.vlsseg8e.mask.nxv8i8.nxv8i8(
-    <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef, <vscale x 8 x i8> undef,
-    <vscale x 8 x i8>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0, <vscale x 8 x i8> %0,
+    <vscale x 8 x i8>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8>, <vscale x 8 x i8> } %a, 1
   ret <vscale x 8 x i8> %b
@@ -351,6 +519,10 @@ define <vscale x 16 x i8> @intrinsic_vlsseg2e_v_nxv16i8_nxv16i8(<vscale x 16 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg2e.nxv16i8.nxv16i8(
@@ -370,19 +542,37 @@ declare { <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg2e.mask.
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i8> @intrinsic_vlsseg2e_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x i8> @intrinsic_vlsseg2e_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv16i8_nxv16i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg2e.mask.nxv16i8.nxv16i8(
-    <vscale x 16 x i8> undef, <vscale x 16 x i8> undef,
-    <vscale x 16 x i8>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x i8> %0, <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x i8>, <vscale x 16 x i8> } %a, 1
   ret <vscale x 16 x i8> %b
@@ -399,6 +589,10 @@ define <vscale x 16 x i8> @intrinsic_vlsseg3e_v_nxv16i8_nxv16i8(<vscale x 16 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg3e.nxv16i8.nxv16i8(
@@ -418,19 +612,39 @@ declare { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.ris
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i8> @intrinsic_vlsseg3e_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x i8> @intrinsic_vlsseg3e_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3e_mask_v_nxv16i8_nxv16i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg3e.mask.nxv16i8.nxv16i8(
-    <vscale x 16 x i8> undef, <vscale x 16 x i8> undef, <vscale x 16 x i8> undef,
-    <vscale x 16 x i8>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x i8> %0, <vscale x 16 x i8> %0, <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } %a, 1
   ret <vscale x 16 x i8> %b
@@ -447,6 +661,10 @@ define <vscale x 16 x i8> @intrinsic_vlsseg4e_v_nxv16i8_nxv16i8(<vscale x 16 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg4e.nxv16i8.nxv16i8(
@@ -466,19 +684,41 @@ declare { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i8> @intrinsic_vlsseg4e_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x i8> @intrinsic_vlsseg4e_mask_v_nxv16i8_nxv16i8(<vscale x 16 x i8> %0, <vscale x 16 x i8>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4e_mask_v_nxv16i8_nxv16i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m2, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } @llvm.riscv.th.vlsseg4e.mask.nxv16i8.nxv16i8(
-    <vscale x 16 x i8> undef, <vscale x 16 x i8> undef, <vscale x 16 x i8> undef, <vscale x 16 x i8> undef,
-    <vscale x 16 x i8>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x i8> %0, <vscale x 16 x i8> %0, <vscale x 16 x i8> %0, <vscale x 16 x i8> %0,
+    <vscale x 16 x i8>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8>, <vscale x 16 x i8> } %a, 1
   ret <vscale x 16 x i8> %b
@@ -495,6 +735,10 @@ define <vscale x 32 x i8> @intrinsic_vlsseg2e_v_nxv32i8_nxv32i8(<vscale x 32 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m4, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 32 x i8>, <vscale x 32 x i8> } @llvm.riscv.th.vlsseg2e.nxv32i8.nxv32i8(
@@ -514,19 +758,39 @@ declare { <vscale x 32 x i8>, <vscale x 32 x i8> } @llvm.riscv.th.vlsseg2e.mask.
   <vscale x 32 x i1>,
   iXLen);
 
-define <vscale x 32 x i8> @intrinsic_vlsseg2e_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8>* %0, <vscale x 32 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 32 x i8> @intrinsic_vlsseg2e_mask_v_nxv32i8_nxv32i8(<vscale x 32 x i8> %0, <vscale x 32 x i8>* %1, <vscale x 32 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv32i8_nxv32i8:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e8, m4, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 32 x i8>, <vscale x 32 x i8> } @llvm.riscv.th.vlsseg2e.mask.nxv32i8.nxv32i8(
-    <vscale x 32 x i8> undef, <vscale x 32 x i8> undef,
-    <vscale x 32 x i8>* %0,
-    iXLen %2,
-    <vscale x 32 x i1> %1,
-    iXLen %3)
+    <vscale x 32 x i8> %0, <vscale x 32 x i8> %0,
+    <vscale x 32 x i8>* %1,
+    iXLen %3,
+    <vscale x 32 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 32 x i8>, <vscale x 32 x i8> } %a, 1
   ret <vscale x 32 x i8> %b
@@ -543,6 +807,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg2e_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2e.nxv4i16.nxv4i16(
@@ -562,19 +830,36 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2e.mask.
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg2e_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg2e_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2e.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -591,6 +876,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg3e_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg3e.nxv4i16.nxv4i16(
@@ -610,19 +899,37 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.ris
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg3e_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg3e_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3e_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg3e.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -639,6 +946,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg4e_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg4e.nxv4i16.nxv4i16(
@@ -658,19 +969,38 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg4e_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg4e_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4e_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg4e.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -687,6 +1017,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg5e_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg5e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg5e.nxv4i16.nxv4i16(
@@ -706,19 +1040,39 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg5e_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg5e_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5e_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg5e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg5e.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -735,6 +1089,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg6e_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg6e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg6e.nxv4i16.nxv4i16(
@@ -754,19 +1112,40 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg6e_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg6e_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6e_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg6e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg6e.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -783,6 +1162,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg7e_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg7e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg7e.nxv4i16.nxv4i16(
@@ -802,19 +1185,41 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg7e_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg7e_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7e_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg7e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg7e.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -831,6 +1236,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg8e_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg8e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg8e.nxv4i16.nxv4i16(
@@ -850,19 +1259,42 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg8e_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg8e_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8e_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg8e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg8e.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -879,6 +1311,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg2e_v_nxv8i16_nxv8i16(<vscale x 8 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2e.nxv8i16.nxv8i16(
@@ -898,19 +1334,37 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2e.mask.
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg2e_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg2e_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2e.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -927,6 +1381,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg3e_v_nxv8i16_nxv8i16(<vscale x 8 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg3e.nxv8i16.nxv8i16(
@@ -946,19 +1404,39 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.ris
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg3e_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg3e_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3e_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg3e.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -975,6 +1453,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg4e_v_nxv8i16_nxv8i16(<vscale x 8 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg4e.nxv8i16.nxv8i16(
@@ -994,19 +1476,41 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg4e_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg4e_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4e_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg4e.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -1023,6 +1527,10 @@ define <vscale x 16 x i16> @intrinsic_vlsseg2e_v_nxv16i16_nxv16i16(<vscale x 16 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m4, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2e.nxv16i16.nxv16i16(
@@ -1042,19 +1550,39 @@ declare { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2e.mas
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i16> @intrinsic_vlsseg2e_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x i16> @intrinsic_vlsseg2e_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv16i16_nxv16i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m4, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2e.mask.nxv16i16.nxv16i16(
-    <vscale x 16 x i16> undef, <vscale x 16 x i16> undef,
-    <vscale x 16 x i16>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x i16> %0, <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x i16>, <vscale x 16 x i16> } %a, 1
   ret <vscale x 16 x i16> %b
@@ -1071,6 +1599,10 @@ define <vscale x 4 x half> @intrinsic_vlsseg2e_v_nxv4f16_nxv4f16(<vscale x 4 x h
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg2e.nxv4f16.nxv4f16(
@@ -1090,19 +1622,36 @@ declare { <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg2e.mas
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x half> @intrinsic_vlsseg2e_mask_v_nxv4f16_nxv4f16( <vscale x 4 x half>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x half> @intrinsic_vlsseg2e_mask_v_nxv4f16_nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x half>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv4f16_nxv4f16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg2e.mask.nxv4f16.nxv4f16(
-    <vscale x 4 x half> undef, <vscale x 4 x half> undef,
-    <vscale x 4 x half>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x half> %0, <vscale x 4 x half> %0,
+    <vscale x 4 x half>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x half>, <vscale x 4 x half> } %a, 1
   ret <vscale x 4 x half> %b
@@ -1119,6 +1668,10 @@ define <vscale x 4 x half> @intrinsic_vlsseg3e_v_nxv4f16_nxv4f16(<vscale x 4 x h
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg3e.nxv4f16.nxv4f16(
@@ -1138,19 +1691,37 @@ declare { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } @llvm.
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x half> @intrinsic_vlsseg3e_mask_v_nxv4f16_nxv4f16( <vscale x 4 x half>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x half> @intrinsic_vlsseg3e_mask_v_nxv4f16_nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x half>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3e_mask_v_nxv4f16_nxv4f16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg3e.mask.nxv4f16.nxv4f16(
-    <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef,
-    <vscale x 4 x half>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0,
+    <vscale x 4 x half>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } %a, 1
   ret <vscale x 4 x half> %b
@@ -1167,6 +1738,10 @@ define <vscale x 4 x half> @intrinsic_vlsseg4e_v_nxv4f16_nxv4f16(<vscale x 4 x h
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg4e.nxv4f16.nxv4f16(
@@ -1186,19 +1761,38 @@ declare { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x half> @intrinsic_vlsseg4e_mask_v_nxv4f16_nxv4f16( <vscale x 4 x half>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x half> @intrinsic_vlsseg4e_mask_v_nxv4f16_nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x half>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4e_mask_v_nxv4f16_nxv4f16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg4e.mask.nxv4f16.nxv4f16(
-    <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef,
-    <vscale x 4 x half>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0,
+    <vscale x 4 x half>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } %a, 1
   ret <vscale x 4 x half> %b
@@ -1215,6 +1809,10 @@ define <vscale x 4 x half> @intrinsic_vlsseg5e_v_nxv4f16_nxv4f16(<vscale x 4 x h
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg5e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg5e.nxv4f16.nxv4f16(
@@ -1234,19 +1832,39 @@ declare { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x half> @intrinsic_vlsseg5e_mask_v_nxv4f16_nxv4f16( <vscale x 4 x half>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x half> @intrinsic_vlsseg5e_mask_v_nxv4f16_nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x half>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5e_mask_v_nxv4f16_nxv4f16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg5e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg5e.mask.nxv4f16.nxv4f16(
-    <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef,
-    <vscale x 4 x half>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0,
+    <vscale x 4 x half>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } %a, 1
   ret <vscale x 4 x half> %b
@@ -1263,6 +1881,10 @@ define <vscale x 4 x half> @intrinsic_vlsseg6e_v_nxv4f16_nxv4f16(<vscale x 4 x h
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg6e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg6e.nxv4f16.nxv4f16(
@@ -1282,19 +1904,40 @@ declare { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x half> @intrinsic_vlsseg6e_mask_v_nxv4f16_nxv4f16( <vscale x 4 x half>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x half> @intrinsic_vlsseg6e_mask_v_nxv4f16_nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x half>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6e_mask_v_nxv4f16_nxv4f16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg6e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg6e.mask.nxv4f16.nxv4f16(
-    <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef,
-    <vscale x 4 x half>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0,
+    <vscale x 4 x half>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } %a, 1
   ret <vscale x 4 x half> %b
@@ -1311,6 +1954,10 @@ define <vscale x 4 x half> @intrinsic_vlsseg7e_v_nxv4f16_nxv4f16(<vscale x 4 x h
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg7e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg7e.nxv4f16.nxv4f16(
@@ -1330,19 +1977,41 @@ declare { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x half> @intrinsic_vlsseg7e_mask_v_nxv4f16_nxv4f16( <vscale x 4 x half>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x half> @intrinsic_vlsseg7e_mask_v_nxv4f16_nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x half>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7e_mask_v_nxv4f16_nxv4f16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg7e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg7e.mask.nxv4f16.nxv4f16(
-    <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef,
-    <vscale x 4 x half>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0,
+    <vscale x 4 x half>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } %a, 1
   ret <vscale x 4 x half> %b
@@ -1359,6 +2028,10 @@ define <vscale x 4 x half> @intrinsic_vlsseg8e_v_nxv4f16_nxv4f16(<vscale x 4 x h
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg8e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg8e.nxv4f16.nxv4f16(
@@ -1378,19 +2051,42 @@ declare { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x half> @intrinsic_vlsseg8e_mask_v_nxv4f16_nxv4f16( <vscale x 4 x half>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x half> @intrinsic_vlsseg8e_mask_v_nxv4f16_nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x half>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8e_mask_v_nxv4f16_nxv4f16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg8e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } @llvm.riscv.th.vlsseg8e.mask.nxv4f16.nxv4f16(
-    <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef, <vscale x 4 x half> undef,
-    <vscale x 4 x half>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0, <vscale x 4 x half> %0,
+    <vscale x 4 x half>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half>, <vscale x 4 x half> } %a, 1
   ret <vscale x 4 x half> %b
@@ -1407,6 +2103,10 @@ define <vscale x 8 x half> @intrinsic_vlsseg2e_v_nxv8f16_nxv8f16(<vscale x 8 x h
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x half>, <vscale x 8 x half> } @llvm.riscv.th.vlsseg2e.nxv8f16.nxv8f16(
@@ -1426,19 +2126,37 @@ declare { <vscale x 8 x half>, <vscale x 8 x half> } @llvm.riscv.th.vlsseg2e.mas
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x half> @intrinsic_vlsseg2e_mask_v_nxv8f16_nxv8f16( <vscale x 8 x half>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x half> @intrinsic_vlsseg2e_mask_v_nxv8f16_nxv8f16(<vscale x 8 x half> %0, <vscale x 8 x half>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv8f16_nxv8f16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x half>, <vscale x 8 x half> } @llvm.riscv.th.vlsseg2e.mask.nxv8f16.nxv8f16(
-    <vscale x 8 x half> undef, <vscale x 8 x half> undef,
-    <vscale x 8 x half>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x half> %0, <vscale x 8 x half> %0,
+    <vscale x 8 x half>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x half>, <vscale x 8 x half> } %a, 1
   ret <vscale x 8 x half> %b
@@ -1455,6 +2173,10 @@ define <vscale x 8 x half> @intrinsic_vlsseg3e_v_nxv8f16_nxv8f16(<vscale x 8 x h
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half> } @llvm.riscv.th.vlsseg3e.nxv8f16.nxv8f16(
@@ -1474,19 +2196,39 @@ declare { <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half> } @llvm.
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x half> @intrinsic_vlsseg3e_mask_v_nxv8f16_nxv8f16( <vscale x 8 x half>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x half> @intrinsic_vlsseg3e_mask_v_nxv8f16_nxv8f16(<vscale x 8 x half> %0, <vscale x 8 x half>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3e_mask_v_nxv8f16_nxv8f16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half> } @llvm.riscv.th.vlsseg3e.mask.nxv8f16.nxv8f16(
-    <vscale x 8 x half> undef, <vscale x 8 x half> undef, <vscale x 8 x half> undef,
-    <vscale x 8 x half>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x half> %0, <vscale x 8 x half> %0, <vscale x 8 x half> %0,
+    <vscale x 8 x half>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half> } %a, 1
   ret <vscale x 8 x half> %b
@@ -1503,6 +2245,10 @@ define <vscale x 8 x half> @intrinsic_vlsseg4e_v_nxv8f16_nxv8f16(<vscale x 8 x h
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half> } @llvm.riscv.th.vlsseg4e.nxv8f16.nxv8f16(
@@ -1522,19 +2268,41 @@ declare { <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half>, <vscale
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x half> @intrinsic_vlsseg4e_mask_v_nxv8f16_nxv8f16( <vscale x 8 x half>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x half> @intrinsic_vlsseg4e_mask_v_nxv8f16_nxv8f16(<vscale x 8 x half> %0, <vscale x 8 x half>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4e_mask_v_nxv8f16_nxv8f16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half> } @llvm.riscv.th.vlsseg4e.mask.nxv8f16.nxv8f16(
-    <vscale x 8 x half> undef, <vscale x 8 x half> undef, <vscale x 8 x half> undef, <vscale x 8 x half> undef,
-    <vscale x 8 x half>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x half> %0, <vscale x 8 x half> %0, <vscale x 8 x half> %0, <vscale x 8 x half> %0,
+    <vscale x 8 x half>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half>, <vscale x 8 x half> } %a, 1
   ret <vscale x 8 x half> %b
@@ -1551,6 +2319,10 @@ define <vscale x 16 x half> @intrinsic_vlsseg2e_v_nxv16f16_nxv16f16(<vscale x 16
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m4, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x half>, <vscale x 16 x half> } @llvm.riscv.th.vlsseg2e.nxv16f16.nxv16f16(
@@ -1570,19 +2342,39 @@ declare { <vscale x 16 x half>, <vscale x 16 x half> } @llvm.riscv.th.vlsseg2e.m
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x half> @intrinsic_vlsseg2e_mask_v_nxv16f16_nxv16f16( <vscale x 16 x half>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x half> @intrinsic_vlsseg2e_mask_v_nxv16f16_nxv16f16(<vscale x 16 x half> %0, <vscale x 16 x half>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv16f16_nxv16f16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m4, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x half>, <vscale x 16 x half> } @llvm.riscv.th.vlsseg2e.mask.nxv16f16.nxv16f16(
-    <vscale x 16 x half> undef, <vscale x 16 x half> undef,
-    <vscale x 16 x half>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x half> %0, <vscale x 16 x half> %0,
+    <vscale x 16 x half>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x half>, <vscale x 16 x half> } %a, 1
   ret <vscale x 16 x half> %b
@@ -1599,6 +2391,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg2e_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2e.nxv2i32.nxv2i32(
@@ -1618,19 +2414,36 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2e.mask.
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg2e_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg2e_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2e.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1647,6 +2460,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg3e_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg3e.nxv2i32.nxv2i32(
@@ -1666,19 +2483,37 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.ris
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg3e_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg3e_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3e_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg3e.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1695,6 +2530,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg4e_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg4e.nxv2i32.nxv2i32(
@@ -1714,19 +2553,38 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg4e_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg4e_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4e_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg4e.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1743,6 +2601,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg5e_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg5e.nxv2i32.nxv2i32(
@@ -1762,19 +2624,39 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg5e_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg5e_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5e_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg5e.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1791,6 +2673,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg6e_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg6e.nxv2i32.nxv2i32(
@@ -1810,19 +2696,40 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg6e_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg6e_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6e_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg6e.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1839,6 +2746,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg7e_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg7e.nxv2i32.nxv2i32(
@@ -1858,19 +2769,41 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg7e_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg7e_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7e_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg7e.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1887,6 +2820,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg8e_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg8e.nxv2i32.nxv2i32(
@@ -1906,19 +2843,42 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg8e_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg8e_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8e_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg8e.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1935,6 +2895,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg2e_v_nxv4i32_nxv4i32(<vscale x 4 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2e.nxv4i32.nxv4i32(
@@ -1954,19 +2918,37 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2e.mask.
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg2e_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg2e_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2e.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -1983,6 +2965,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg3e_v_nxv4i32_nxv4i32(<vscale x 4 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg3e.nxv4i32.nxv4i32(
@@ -2002,19 +2988,39 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.ris
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg3e_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg3e_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3e_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg3e.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -2031,6 +3037,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg4e_v_nxv4i32_nxv4i32(<vscale x 4 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg4e.nxv4i32.nxv4i32(
@@ -2050,19 +3060,41 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg4e_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg4e_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4e_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg4e.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -2079,6 +3111,10 @@ define <vscale x 8 x i32> @intrinsic_vlsseg2e_v_nxv8i32_nxv8i32(<vscale x 8 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2e.nxv8i32.nxv8i32(
@@ -2098,19 +3134,39 @@ declare { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2e.mask.
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i32> @intrinsic_vlsseg2e_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i32> @intrinsic_vlsseg2e_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2e.mask.nxv8i32.nxv8i32(
-    <vscale x 8 x i32> undef, <vscale x 8 x i32> undef,
-    <vscale x 8 x i32>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i32> %0, <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i32>, <vscale x 8 x i32> } %a, 1
   ret <vscale x 8 x i32> %b
@@ -2127,6 +3183,10 @@ define <vscale x 2 x float> @intrinsic_vlsseg2e_v_nxv2f32_nxv2f32(<vscale x 2 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg2e.nxv2f32.nxv2f32(
@@ -2146,19 +3206,36 @@ declare { <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg2e.m
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x float> @intrinsic_vlsseg2e_mask_v_nxv2f32_nxv2f32( <vscale x 2 x float>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x float> @intrinsic_vlsseg2e_mask_v_nxv2f32_nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x float>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv2f32_nxv2f32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg2e.mask.nxv2f32.nxv2f32(
-    <vscale x 2 x float> undef, <vscale x 2 x float> undef,
-    <vscale x 2 x float>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x float> %0, <vscale x 2 x float> %0,
+    <vscale x 2 x float>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x float>, <vscale x 2 x float> } %a, 1
   ret <vscale x 2 x float> %b
@@ -2175,6 +3252,10 @@ define <vscale x 2 x float> @intrinsic_vlsseg3e_v_nxv2f32_nxv2f32(<vscale x 2 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg3e.nxv2f32.nxv2f32(
@@ -2194,19 +3275,37 @@ declare { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } @ll
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x float> @intrinsic_vlsseg3e_mask_v_nxv2f32_nxv2f32( <vscale x 2 x float>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x float> @intrinsic_vlsseg3e_mask_v_nxv2f32_nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x float>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3e_mask_v_nxv2f32_nxv2f32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg3e.mask.nxv2f32.nxv2f32(
-    <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef,
-    <vscale x 2 x float>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0,
+    <vscale x 2 x float>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } %a, 1
   ret <vscale x 2 x float> %b
@@ -2223,6 +3322,10 @@ define <vscale x 2 x float> @intrinsic_vlsseg4e_v_nxv2f32_nxv2f32(<vscale x 2 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg4e.nxv2f32.nxv2f32(
@@ -2242,19 +3345,38 @@ declare { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vsc
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x float> @intrinsic_vlsseg4e_mask_v_nxv2f32_nxv2f32( <vscale x 2 x float>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x float> @intrinsic_vlsseg4e_mask_v_nxv2f32_nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x float>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4e_mask_v_nxv2f32_nxv2f32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg4e.mask.nxv2f32.nxv2f32(
-    <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef,
-    <vscale x 2 x float>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0,
+    <vscale x 2 x float>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } %a, 1
   ret <vscale x 2 x float> %b
@@ -2271,6 +3393,10 @@ define <vscale x 2 x float> @intrinsic_vlsseg5e_v_nxv2f32_nxv2f32(<vscale x 2 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg5e.nxv2f32.nxv2f32(
@@ -2290,19 +3416,39 @@ declare { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vsc
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x float> @intrinsic_vlsseg5e_mask_v_nxv2f32_nxv2f32( <vscale x 2 x float>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x float> @intrinsic_vlsseg5e_mask_v_nxv2f32_nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x float>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5e_mask_v_nxv2f32_nxv2f32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg5e.mask.nxv2f32.nxv2f32(
-    <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef,
-    <vscale x 2 x float>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0,
+    <vscale x 2 x float>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } %a, 1
   ret <vscale x 2 x float> %b
@@ -2319,6 +3465,10 @@ define <vscale x 2 x float> @intrinsic_vlsseg6e_v_nxv2f32_nxv2f32(<vscale x 2 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg6e.nxv2f32.nxv2f32(
@@ -2338,19 +3488,40 @@ declare { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vsc
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x float> @intrinsic_vlsseg6e_mask_v_nxv2f32_nxv2f32( <vscale x 2 x float>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x float> @intrinsic_vlsseg6e_mask_v_nxv2f32_nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x float>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6e_mask_v_nxv2f32_nxv2f32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg6e.mask.nxv2f32.nxv2f32(
-    <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef,
-    <vscale x 2 x float>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0,
+    <vscale x 2 x float>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } %a, 1
   ret <vscale x 2 x float> %b
@@ -2367,6 +3538,10 @@ define <vscale x 2 x float> @intrinsic_vlsseg7e_v_nxv2f32_nxv2f32(<vscale x 2 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg7e.nxv2f32.nxv2f32(
@@ -2386,19 +3561,41 @@ declare { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vsc
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x float> @intrinsic_vlsseg7e_mask_v_nxv2f32_nxv2f32( <vscale x 2 x float>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x float> @intrinsic_vlsseg7e_mask_v_nxv2f32_nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x float>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7e_mask_v_nxv2f32_nxv2f32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg7e.mask.nxv2f32.nxv2f32(
-    <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef,
-    <vscale x 2 x float>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0,
+    <vscale x 2 x float>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } %a, 1
   ret <vscale x 2 x float> %b
@@ -2415,6 +3612,10 @@ define <vscale x 2 x float> @intrinsic_vlsseg8e_v_nxv2f32_nxv2f32(<vscale x 2 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg8e.nxv2f32.nxv2f32(
@@ -2434,19 +3635,42 @@ declare { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vsc
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x float> @intrinsic_vlsseg8e_mask_v_nxv2f32_nxv2f32( <vscale x 2 x float>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x float> @intrinsic_vlsseg8e_mask_v_nxv2f32_nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x float>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8e_mask_v_nxv2f32_nxv2f32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } @llvm.riscv.th.vlsseg8e.mask.nxv2f32.nxv2f32(
-    <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef, <vscale x 2 x float> undef,
-    <vscale x 2 x float>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0, <vscale x 2 x float> %0,
+    <vscale x 2 x float>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float>, <vscale x 2 x float> } %a, 1
   ret <vscale x 2 x float> %b
@@ -2463,6 +3687,10 @@ define <vscale x 4 x float> @intrinsic_vlsseg2e_v_nxv4f32_nxv4f32(<vscale x 4 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x float>, <vscale x 4 x float> } @llvm.riscv.th.vlsseg2e.nxv4f32.nxv4f32(
@@ -2482,19 +3710,37 @@ declare { <vscale x 4 x float>, <vscale x 4 x float> } @llvm.riscv.th.vlsseg2e.m
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x float> @intrinsic_vlsseg2e_mask_v_nxv4f32_nxv4f32( <vscale x 4 x float>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x float> @intrinsic_vlsseg2e_mask_v_nxv4f32_nxv4f32(<vscale x 4 x float> %0, <vscale x 4 x float>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv4f32_nxv4f32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x float>, <vscale x 4 x float> } @llvm.riscv.th.vlsseg2e.mask.nxv4f32.nxv4f32(
-    <vscale x 4 x float> undef, <vscale x 4 x float> undef,
-    <vscale x 4 x float>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x float> %0, <vscale x 4 x float> %0,
+    <vscale x 4 x float>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x float>, <vscale x 4 x float> } %a, 1
   ret <vscale x 4 x float> %b
@@ -2511,6 +3757,10 @@ define <vscale x 4 x float> @intrinsic_vlsseg3e_v_nxv4f32_nxv4f32(<vscale x 4 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } @llvm.riscv.th.vlsseg3e.nxv4f32.nxv4f32(
@@ -2530,19 +3780,39 @@ declare { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } @ll
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x float> @intrinsic_vlsseg3e_mask_v_nxv4f32_nxv4f32( <vscale x 4 x float>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x float> @intrinsic_vlsseg3e_mask_v_nxv4f32_nxv4f32(<vscale x 4 x float> %0, <vscale x 4 x float>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3e_mask_v_nxv4f32_nxv4f32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } @llvm.riscv.th.vlsseg3e.mask.nxv4f32.nxv4f32(
-    <vscale x 4 x float> undef, <vscale x 4 x float> undef, <vscale x 4 x float> undef,
-    <vscale x 4 x float>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x float> %0, <vscale x 4 x float> %0, <vscale x 4 x float> %0,
+    <vscale x 4 x float>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } %a, 1
   ret <vscale x 4 x float> %b
@@ -2559,6 +3829,10 @@ define <vscale x 4 x float> @intrinsic_vlsseg4e_v_nxv4f32_nxv4f32(<vscale x 4 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } @llvm.riscv.th.vlsseg4e.nxv4f32.nxv4f32(
@@ -2578,19 +3852,41 @@ declare { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vsc
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x float> @intrinsic_vlsseg4e_mask_v_nxv4f32_nxv4f32( <vscale x 4 x float>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x float> @intrinsic_vlsseg4e_mask_v_nxv4f32_nxv4f32(<vscale x 4 x float> %0, <vscale x 4 x float>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4e_mask_v_nxv4f32_nxv4f32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } @llvm.riscv.th.vlsseg4e.mask.nxv4f32.nxv4f32(
-    <vscale x 4 x float> undef, <vscale x 4 x float> undef, <vscale x 4 x float> undef, <vscale x 4 x float> undef,
-    <vscale x 4 x float>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x float> %0, <vscale x 4 x float> %0, <vscale x 4 x float> %0, <vscale x 4 x float> %0,
+    <vscale x 4 x float>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } %a, 1
   ret <vscale x 4 x float> %b
@@ -2607,6 +3903,10 @@ define <vscale x 8 x float> @intrinsic_vlsseg2e_v_nxv8f32_nxv8f32(<vscale x 8 x 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x float>, <vscale x 8 x float> } @llvm.riscv.th.vlsseg2e.nxv8f32.nxv8f32(
@@ -2626,19 +3926,39 @@ declare { <vscale x 8 x float>, <vscale x 8 x float> } @llvm.riscv.th.vlsseg2e.m
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x float> @intrinsic_vlsseg2e_mask_v_nxv8f32_nxv8f32( <vscale x 8 x float>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x float> @intrinsic_vlsseg2e_mask_v_nxv8f32_nxv8f32(<vscale x 8 x float> %0, <vscale x 8 x float>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv8f32_nxv8f32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x float>, <vscale x 8 x float> } @llvm.riscv.th.vlsseg2e.mask.nxv8f32.nxv8f32(
-    <vscale x 8 x float> undef, <vscale x 8 x float> undef,
-    <vscale x 8 x float>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x float> %0, <vscale x 8 x float> %0,
+    <vscale x 8 x float>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x float>, <vscale x 8 x float> } %a, 1
   ret <vscale x 8 x float> %b
@@ -2655,6 +3975,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg2e_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2e.nxv1i64.nxv1i64(
@@ -2674,19 +3998,36 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2e.mask.
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg2e_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg2e_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2e.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2703,6 +4044,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg3e_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg3e.nxv1i64.nxv1i64(
@@ -2722,19 +4067,37 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.ris
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg3e_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg3e_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3e_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg3e.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2751,6 +4114,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg4e_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg4e.nxv1i64.nxv1i64(
@@ -2770,19 +4137,38 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg4e_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg4e_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4e_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg4e.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2799,6 +4185,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg5e_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg5e.nxv1i64.nxv1i64(
@@ -2818,19 +4208,39 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg5e_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg5e_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5e_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg5e.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2847,6 +4257,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg6e_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg6e.nxv1i64.nxv1i64(
@@ -2866,19 +4280,40 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg6e_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg6e_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6e_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg6e.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2895,6 +4330,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg7e_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg7e.nxv1i64.nxv1i64(
@@ -2914,19 +4353,41 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg7e_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg7e_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7e_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg7e.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2943,6 +4404,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg8e_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg8e.nxv1i64.nxv1i64(
@@ -2962,19 +4427,42 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg8e_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg8e_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8e_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg8e.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2991,6 +4479,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg2e_v_nxv2i64_nxv2i64(<vscale x 2 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2e.nxv2i64.nxv2i64(
@@ -3010,19 +4502,37 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2e.mask.
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg2e_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg2e_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2e.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -3039,6 +4549,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg3e_v_nxv2i64_nxv2i64(<vscale x 2 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg3e.nxv2i64.nxv2i64(
@@ -3058,19 +4572,39 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.ris
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg3e_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg3e_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3e_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg3e.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -3087,6 +4621,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg4e_v_nxv2i64_nxv2i64(<vscale x 2 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg4e.nxv2i64.nxv2i64(
@@ -3106,19 +4644,41 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg4e_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg4e_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4e_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg4e.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -3135,6 +4695,10 @@ define <vscale x 4 x i64> @intrinsic_vlsseg2e_v_nxv4i64_nxv4i64(<vscale x 4 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2e.nxv4i64.nxv4i64(
@@ -3154,19 +4718,39 @@ declare { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2e.mask.
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i64> @intrinsic_vlsseg2e_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i64> @intrinsic_vlsseg2e_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv4i64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2e.mask.nxv4i64.nxv4i64(
-    <vscale x 4 x i64> undef, <vscale x 4 x i64> undef,
-    <vscale x 4 x i64>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i64> %0, <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i64>, <vscale x 4 x i64> } %a, 1
   ret <vscale x 4 x i64> %b
@@ -3183,6 +4767,10 @@ define <vscale x 1 x double> @intrinsic_vlsseg2e_v_nxv1f64_nxv1f64(<vscale x 1 x
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg2e.nxv1f64.nxv1f64(
@@ -3202,19 +4790,36 @@ declare { <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg2e
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x double> @intrinsic_vlsseg2e_mask_v_nxv1f64_nxv1f64( <vscale x 1 x double>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x double> @intrinsic_vlsseg2e_mask_v_nxv1f64_nxv1f64(<vscale x 1 x double> %0, <vscale x 1 x double>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv1f64_nxv1f64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg2e.mask.nxv1f64.nxv1f64(
-    <vscale x 1 x double> undef, <vscale x 1 x double> undef,
-    <vscale x 1 x double>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x double> %0, <vscale x 1 x double> %0,
+    <vscale x 1 x double>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x double>, <vscale x 1 x double> } %a, 1
   ret <vscale x 1 x double> %b
@@ -3231,6 +4836,10 @@ define <vscale x 1 x double> @intrinsic_vlsseg3e_v_nxv1f64_nxv1f64(<vscale x 1 x
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg3e.nxv1f64.nxv1f64(
@@ -3250,19 +4859,37 @@ declare { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x double> @intrinsic_vlsseg3e_mask_v_nxv1f64_nxv1f64( <vscale x 1 x double>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x double> @intrinsic_vlsseg3e_mask_v_nxv1f64_nxv1f64(<vscale x 1 x double> %0, <vscale x 1 x double>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3e_mask_v_nxv1f64_nxv1f64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg3e.mask.nxv1f64.nxv1f64(
-    <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef,
-    <vscale x 1 x double>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0,
+    <vscale x 1 x double>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } %a, 1
   ret <vscale x 1 x double> %b
@@ -3279,6 +4906,10 @@ define <vscale x 1 x double> @intrinsic_vlsseg4e_v_nxv1f64_nxv1f64(<vscale x 1 x
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg4e.nxv1f64.nxv1f64(
@@ -3298,19 +4929,38 @@ declare { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x double> @intrinsic_vlsseg4e_mask_v_nxv1f64_nxv1f64( <vscale x 1 x double>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x double> @intrinsic_vlsseg4e_mask_v_nxv1f64_nxv1f64(<vscale x 1 x double> %0, <vscale x 1 x double>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4e_mask_v_nxv1f64_nxv1f64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg4e.mask.nxv1f64.nxv1f64(
-    <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef,
-    <vscale x 1 x double>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0,
+    <vscale x 1 x double>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } %a, 1
   ret <vscale x 1 x double> %b
@@ -3327,6 +4977,10 @@ define <vscale x 1 x double> @intrinsic_vlsseg5e_v_nxv1f64_nxv1f64(<vscale x 1 x
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg5e.nxv1f64.nxv1f64(
@@ -3346,19 +5000,39 @@ declare { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x double> @intrinsic_vlsseg5e_mask_v_nxv1f64_nxv1f64( <vscale x 1 x double>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x double> @intrinsic_vlsseg5e_mask_v_nxv1f64_nxv1f64(<vscale x 1 x double> %0, <vscale x 1 x double>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5e_mask_v_nxv1f64_nxv1f64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg5e.mask.nxv1f64.nxv1f64(
-    <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef,
-    <vscale x 1 x double>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0,
+    <vscale x 1 x double>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } %a, 1
   ret <vscale x 1 x double> %b
@@ -3375,6 +5049,10 @@ define <vscale x 1 x double> @intrinsic_vlsseg6e_v_nxv1f64_nxv1f64(<vscale x 1 x
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg6e.nxv1f64.nxv1f64(
@@ -3394,19 +5072,40 @@ declare { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x double> @intrinsic_vlsseg6e_mask_v_nxv1f64_nxv1f64( <vscale x 1 x double>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x double> @intrinsic_vlsseg6e_mask_v_nxv1f64_nxv1f64(<vscale x 1 x double> %0, <vscale x 1 x double>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6e_mask_v_nxv1f64_nxv1f64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg6e.mask.nxv1f64.nxv1f64(
-    <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef,
-    <vscale x 1 x double>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0,
+    <vscale x 1 x double>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } %a, 1
   ret <vscale x 1 x double> %b
@@ -3423,6 +5122,10 @@ define <vscale x 1 x double> @intrinsic_vlsseg7e_v_nxv1f64_nxv1f64(<vscale x 1 x
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg7e.nxv1f64.nxv1f64(
@@ -3442,19 +5145,41 @@ declare { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x double> @intrinsic_vlsseg7e_mask_v_nxv1f64_nxv1f64( <vscale x 1 x double>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x double> @intrinsic_vlsseg7e_mask_v_nxv1f64_nxv1f64(<vscale x 1 x double> %0, <vscale x 1 x double>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7e_mask_v_nxv1f64_nxv1f64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg7e.mask.nxv1f64.nxv1f64(
-    <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef,
-    <vscale x 1 x double>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0,
+    <vscale x 1 x double>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } %a, 1
   ret <vscale x 1 x double> %b
@@ -3471,6 +5196,10 @@ define <vscale x 1 x double> @intrinsic_vlsseg8e_v_nxv1f64_nxv1f64(<vscale x 1 x
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8e.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg8e.nxv1f64.nxv1f64(
@@ -3490,19 +5219,42 @@ declare { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x double> @intrinsic_vlsseg8e_mask_v_nxv1f64_nxv1f64( <vscale x 1 x double>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x double> @intrinsic_vlsseg8e_mask_v_nxv1f64_nxv1f64(<vscale x 1 x double> %0, <vscale x 1 x double>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8e_mask_v_nxv1f64_nxv1f64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8e.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } @llvm.riscv.th.vlsseg8e.mask.nxv1f64.nxv1f64(
-    <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef, <vscale x 1 x double> undef,
-    <vscale x 1 x double>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0, <vscale x 1 x double> %0,
+    <vscale x 1 x double>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double>, <vscale x 1 x double> } %a, 1
   ret <vscale x 1 x double> %b
@@ -3519,6 +5271,10 @@ define <vscale x 2 x double> @intrinsic_vlsseg2e_v_nxv2f64_nxv2f64(<vscale x 2 x
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x double>, <vscale x 2 x double> } @llvm.riscv.th.vlsseg2e.nxv2f64.nxv2f64(
@@ -3538,19 +5294,37 @@ declare { <vscale x 2 x double>, <vscale x 2 x double> } @llvm.riscv.th.vlsseg2e
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x double> @intrinsic_vlsseg2e_mask_v_nxv2f64_nxv2f64( <vscale x 2 x double>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x double> @intrinsic_vlsseg2e_mask_v_nxv2f64_nxv2f64(<vscale x 2 x double> %0, <vscale x 2 x double>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv2f64_nxv2f64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x double>, <vscale x 2 x double> } @llvm.riscv.th.vlsseg2e.mask.nxv2f64.nxv2f64(
-    <vscale x 2 x double> undef, <vscale x 2 x double> undef,
-    <vscale x 2 x double>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x double> %0, <vscale x 2 x double> %0,
+    <vscale x 2 x double>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x double>, <vscale x 2 x double> } %a, 1
   ret <vscale x 2 x double> %b
@@ -3567,6 +5341,10 @@ define <vscale x 2 x double> @intrinsic_vlsseg3e_v_nxv2f64_nxv2f64(<vscale x 2 x
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double> } @llvm.riscv.th.vlsseg3e.nxv2f64.nxv2f64(
@@ -3586,19 +5364,39 @@ declare { <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double> } 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x double> @intrinsic_vlsseg3e_mask_v_nxv2f64_nxv2f64( <vscale x 2 x double>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x double> @intrinsic_vlsseg3e_mask_v_nxv2f64_nxv2f64(<vscale x 2 x double> %0, <vscale x 2 x double>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3e_mask_v_nxv2f64_nxv2f64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double> } @llvm.riscv.th.vlsseg3e.mask.nxv2f64.nxv2f64(
-    <vscale x 2 x double> undef, <vscale x 2 x double> undef, <vscale x 2 x double> undef,
-    <vscale x 2 x double>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x double> %0, <vscale x 2 x double> %0, <vscale x 2 x double> %0,
+    <vscale x 2 x double>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double> } %a, 1
   ret <vscale x 2 x double> %b
@@ -3615,6 +5413,10 @@ define <vscale x 2 x double> @intrinsic_vlsseg4e_v_nxv2f64_nxv2f64(<vscale x 2 x
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double> } @llvm.riscv.th.vlsseg4e.nxv2f64.nxv2f64(
@@ -3634,19 +5436,41 @@ declare { <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double>, <
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x double> @intrinsic_vlsseg4e_mask_v_nxv2f64_nxv2f64( <vscale x 2 x double>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x double> @intrinsic_vlsseg4e_mask_v_nxv2f64_nxv2f64(<vscale x 2 x double> %0, <vscale x 2 x double>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4e_mask_v_nxv2f64_nxv2f64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4e.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double> } @llvm.riscv.th.vlsseg4e.mask.nxv2f64.nxv2f64(
-    <vscale x 2 x double> undef, <vscale x 2 x double> undef, <vscale x 2 x double> undef, <vscale x 2 x double> undef,
-    <vscale x 2 x double>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x double> %0, <vscale x 2 x double> %0, <vscale x 2 x double> %0, <vscale x 2 x double> %0,
+    <vscale x 2 x double>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double>, <vscale x 2 x double> } %a, 1
   ret <vscale x 2 x double> %b
@@ -3663,6 +5487,10 @@ define <vscale x 4 x double> @intrinsic_vlsseg2e_v_nxv4f64_nxv4f64(<vscale x 4 x
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x double>, <vscale x 4 x double> } @llvm.riscv.th.vlsseg2e.nxv4f64.nxv4f64(
@@ -3682,19 +5510,39 @@ declare { <vscale x 4 x double>, <vscale x 4 x double> } @llvm.riscv.th.vlsseg2e
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x double> @intrinsic_vlsseg2e_mask_v_nxv4f64_nxv4f64( <vscale x 4 x double>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x double> @intrinsic_vlsseg2e_mask_v_nxv4f64_nxv4f64(<vscale x 4 x double> %0, <vscale x 4 x double>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2e_mask_v_nxv4f64_nxv4f64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2e.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x double>, <vscale x 4 x double> } @llvm.riscv.th.vlsseg2e.mask.nxv4f64.nxv4f64(
-    <vscale x 4 x double> undef, <vscale x 4 x double> undef,
-    <vscale x 4 x double>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x double> %0, <vscale x 4 x double> %0,
+    <vscale x 4 x double>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x double>, <vscale x 4 x double> } %a, 1
   ret <vscale x 4 x double> %b

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vlssegh.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vlssegh.ll
@@ -15,6 +15,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg2h_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2h.nxv4i16.nxv4i16(
@@ -34,19 +38,36 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2h.mask.
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg2h_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg2h_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2h_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2h.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -63,6 +84,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg2hu_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2hu.nxv4i16.nxv4i16(
@@ -82,19 +107,36 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2hu.mask
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg2hu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg2hu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2hu_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg2hu.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -111,6 +153,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg3h_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg3h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg3h.nxv4i16.nxv4i16(
@@ -130,19 +176,37 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.ris
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg3h_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg3h_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3h_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg3h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg3h.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -159,6 +223,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg3hu_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg3hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg3hu.nxv4i16.nxv4i16(
@@ -178,19 +246,37 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.ris
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg3hu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg3hu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3hu_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg3hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg3hu.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -207,6 +293,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg4h_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg4h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg4h.nxv4i16.nxv4i16(
@@ -226,19 +316,38 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg4h_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg4h_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4h_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg4h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg4h.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -255,6 +364,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg4hu_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg4hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg4hu.nxv4i16.nxv4i16(
@@ -274,19 +387,38 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg4hu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg4hu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4hu_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg4hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg4hu.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -303,6 +435,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg5h_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg5h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg5h.nxv4i16.nxv4i16(
@@ -322,19 +458,39 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg5h_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg5h_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5h_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg5h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg5h.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -351,6 +507,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg5hu_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg5hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg5hu.nxv4i16.nxv4i16(
@@ -370,19 +530,39 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg5hu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg5hu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5hu_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg5hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg5hu.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -399,6 +579,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg6h_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg6h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg6h.nxv4i16.nxv4i16(
@@ -418,19 +602,40 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg6h_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg6h_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6h_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg6h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg6h.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -447,6 +652,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg6hu_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg6hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg6hu.nxv4i16.nxv4i16(
@@ -466,19 +675,40 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg6hu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg6hu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6hu_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg6hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg6hu.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -495,6 +725,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg7h_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg7h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg7h.nxv4i16.nxv4i16(
@@ -514,19 +748,41 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg7h_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg7h_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7h_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg7h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg7h.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -543,6 +799,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg7hu_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg7hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg7hu.nxv4i16.nxv4i16(
@@ -562,19 +822,41 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg7hu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg7hu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7hu_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg7hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg7hu.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -591,6 +873,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg8h_v_nxv4i16_nxv4i16(<vscale x 4 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg8h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg8h.nxv4i16.nxv4i16(
@@ -610,19 +896,42 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg8h_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg8h_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8h_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg8h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg8h.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -639,6 +948,10 @@ define <vscale x 4 x i16> @intrinsic_vlsseg8hu_v_nxv4i16_nxv4i16(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg8hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg8hu.nxv4i16.nxv4i16(
@@ -658,19 +971,42 @@ declare { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i16> @intrinsic_vlsseg8hu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i16> @intrinsic_vlsseg8hu_mask_v_nxv4i16_nxv4i16(<vscale x 4 x i16> %0, <vscale x 4 x i16>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8hu_mask_v_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m1, d1
 ; CHECK-NEXT:    th.vlsseg8hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } @llvm.riscv.th.vlsseg8hu.mask.nxv4i16.nxv4i16(
-    <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef, <vscale x 4 x i16> undef,
-    <vscale x 4 x i16>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0, <vscale x 4 x i16> %0,
+    <vscale x 4 x i16>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16>, <vscale x 4 x i16> } %a, 1
   ret <vscale x 4 x i16> %b
@@ -687,6 +1023,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg2h_v_nxv8i16_nxv8i16(<vscale x 8 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2h.nxv8i16.nxv8i16(
@@ -706,19 +1046,37 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2h.mask.
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg2h_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg2h_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2h_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2h.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -735,6 +1093,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg2hu_v_nxv8i16_nxv8i16(<vscale x 8 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2hu.nxv8i16.nxv8i16(
@@ -754,19 +1116,37 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2hu.mask
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg2hu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg2hu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2hu_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg2hu.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -783,6 +1163,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg3h_v_nxv8i16_nxv8i16(<vscale x 8 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg3h.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg3h.nxv8i16.nxv8i16(
@@ -802,19 +1186,39 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.ris
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg3h_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg3h_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3h_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg3h.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg3h.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -831,6 +1235,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg3hu_v_nxv8i16_nxv8i16(<vscale x 8 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg3hu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg3hu.nxv8i16.nxv8i16(
@@ -850,19 +1258,39 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.ris
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg3hu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg3hu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3hu_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg3hu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg3hu.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -879,6 +1307,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg4h_v_nxv8i16_nxv8i16(<vscale x 8 x i1
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg4h.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg4h.nxv8i16.nxv8i16(
@@ -898,19 +1330,41 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg4h_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg4h_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4h_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg4h.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg4h.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -927,6 +1381,10 @@ define <vscale x 8 x i16> @intrinsic_vlsseg4hu_v_nxv8i16_nxv8i16(<vscale x 8 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg4hu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg4hu.nxv8i16.nxv8i16(
@@ -946,19 +1404,41 @@ declare { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i16> @intrinsic_vlsseg4hu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i16> @intrinsic_vlsseg4hu_mask_v_nxv8i16_nxv8i16(<vscale x 8 x i16> %0, <vscale x 8 x i16>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4hu_mask_v_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m2, d1
 ; CHECK-NEXT:    th.vlsseg4hu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } @llvm.riscv.th.vlsseg4hu.mask.nxv8i16.nxv8i16(
-    <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef, <vscale x 8 x i16> undef,
-    <vscale x 8 x i16>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0, <vscale x 8 x i16> %0,
+    <vscale x 8 x i16>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16>, <vscale x 8 x i16> } %a, 1
   ret <vscale x 8 x i16> %b
@@ -975,6 +1455,10 @@ define <vscale x 16 x i16> @intrinsic_vlsseg2h_v_nxv16i16_nxv16i16(<vscale x 16 
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m4, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2h.nxv16i16.nxv16i16(
@@ -994,19 +1478,39 @@ declare { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2h.mas
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i16> @intrinsic_vlsseg2h_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x i16> @intrinsic_vlsseg2h_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2h_mask_v_nxv16i16_nxv16i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m4, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2h.mask.nxv16i16.nxv16i16(
-    <vscale x 16 x i16> undef, <vscale x 16 x i16> undef,
-    <vscale x 16 x i16>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x i16> %0, <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x i16>, <vscale x 16 x i16> } %a, 1
   ret <vscale x 16 x i16> %b
@@ -1023,6 +1527,10 @@ define <vscale x 16 x i16> @intrinsic_vlsseg2hu_v_nxv16i16_nxv16i16(<vscale x 16
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m4, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2hu.nxv16i16.nxv16i16(
@@ -1042,19 +1550,39 @@ declare { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2hu.ma
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i16> @intrinsic_vlsseg2hu_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16>* %0, <vscale x 16 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 16 x i16> @intrinsic_vlsseg2hu_mask_v_nxv16i16_nxv16i16(<vscale x 16 x i16> %0, <vscale x 16 x i16>* %1, <vscale x 16 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2hu_mask_v_nxv16i16_nxv16i16:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e16, m4, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 16 x i16>, <vscale x 16 x i16> } @llvm.riscv.th.vlsseg2hu.mask.nxv16i16.nxv16i16(
-    <vscale x 16 x i16> undef, <vscale x 16 x i16> undef,
-    <vscale x 16 x i16>* %0,
-    iXLen %2,
-    <vscale x 16 x i1> %1,
-    iXLen %3)
+    <vscale x 16 x i16> %0, <vscale x 16 x i16> %0,
+    <vscale x 16 x i16>* %1,
+    iXLen %3,
+    <vscale x 16 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 16 x i16>, <vscale x 16 x i16> } %a, 1
   ret <vscale x 16 x i16> %b
@@ -1071,6 +1599,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg2h_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2h.nxv2i32.nxv2i32(
@@ -1090,19 +1622,36 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2h.mask.
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg2h_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg2h_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2h_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2h.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1119,6 +1668,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg2hu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2hu.nxv2i32.nxv2i32(
@@ -1138,19 +1691,36 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2hu.mask
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg2hu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg2hu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2hu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2hu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1167,6 +1737,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg3h_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg3h.nxv2i32.nxv2i32(
@@ -1186,19 +1760,37 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.ris
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg3h_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg3h_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3h_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg3h.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1215,6 +1807,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg3hu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg3hu.nxv2i32.nxv2i32(
@@ -1234,19 +1830,37 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.ris
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg3hu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg3hu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3hu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg3hu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1263,6 +1877,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg4h_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg4h.nxv2i32.nxv2i32(
@@ -1282,19 +1900,38 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg4h_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg4h_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4h_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg4h.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1311,6 +1948,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg4hu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg4hu.nxv2i32.nxv2i32(
@@ -1330,19 +1971,38 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg4hu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg4hu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4hu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg4hu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1359,6 +2019,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg5h_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg5h.nxv2i32.nxv2i32(
@@ -1378,19 +2042,39 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg5h_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg5h_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5h_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg5h.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1407,6 +2091,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg5hu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg5hu.nxv2i32.nxv2i32(
@@ -1426,19 +2114,39 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg5hu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg5hu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5hu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg5hu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1455,6 +2163,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg6h_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg6h.nxv2i32.nxv2i32(
@@ -1474,19 +2186,40 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg6h_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg6h_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6h_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg6h.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1503,6 +2236,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg6hu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg6hu.nxv2i32.nxv2i32(
@@ -1522,19 +2259,40 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg6hu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg6hu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6hu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg6hu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1551,6 +2309,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg7h_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg7h.nxv2i32.nxv2i32(
@@ -1570,19 +2332,41 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg7h_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg7h_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7h_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg7h.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1599,6 +2383,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg7hu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg7hu.nxv2i32.nxv2i32(
@@ -1618,19 +2406,41 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg7hu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg7hu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7hu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg7hu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1647,6 +2457,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg8h_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg8h.nxv2i32.nxv2i32(
@@ -1666,19 +2480,42 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg8h_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg8h_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8h_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg8h.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1695,6 +2532,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg8hu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg8hu.nxv2i32.nxv2i32(
@@ -1714,19 +2555,42 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg8hu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg8hu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8hu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg8hu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -1743,6 +2607,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg2h_v_nxv4i32_nxv4i32(<vscale x 4 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2h.nxv4i32.nxv4i32(
@@ -1762,19 +2630,37 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2h.mask.
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg2h_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg2h_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2h_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2h.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -1791,6 +2677,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg2hu_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2hu.nxv4i32.nxv4i32(
@@ -1810,19 +2700,37 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2hu.mask
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg2hu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg2hu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2hu_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2hu.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -1839,6 +2747,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg3h_v_nxv4i32_nxv4i32(<vscale x 4 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3h.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg3h.nxv4i32.nxv4i32(
@@ -1858,19 +2770,39 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.ris
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg3h_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg3h_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3h_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3h.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg3h.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -1887,6 +2819,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg3hu_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3hu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg3hu.nxv4i32.nxv4i32(
@@ -1906,19 +2842,39 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.ris
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg3hu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg3hu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3hu_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3hu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg3hu.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -1935,6 +2891,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg4h_v_nxv4i32_nxv4i32(<vscale x 4 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4h.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg4h.nxv4i32.nxv4i32(
@@ -1954,19 +2914,41 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg4h_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg4h_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4h_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4h.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg4h.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -1983,6 +2965,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg4hu_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4hu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg4hu.nxv4i32.nxv4i32(
@@ -2002,19 +2988,41 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg4hu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg4hu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4hu_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4hu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg4hu.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -2031,6 +3039,10 @@ define <vscale x 8 x i32> @intrinsic_vlsseg2h_v_nxv8i32_nxv8i32(<vscale x 8 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2h.nxv8i32.nxv8i32(
@@ -2050,19 +3062,39 @@ declare { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2h.mask.
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i32> @intrinsic_vlsseg2h_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i32> @intrinsic_vlsseg2h_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2h_mask_v_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2h.mask.nxv8i32.nxv8i32(
-    <vscale x 8 x i32> undef, <vscale x 8 x i32> undef,
-    <vscale x 8 x i32>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i32> %0, <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i32>, <vscale x 8 x i32> } %a, 1
   ret <vscale x 8 x i32> %b
@@ -2079,6 +3111,10 @@ define <vscale x 8 x i32> @intrinsic_vlsseg2hu_v_nxv8i32_nxv8i32(<vscale x 8 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2hu.nxv8i32.nxv8i32(
@@ -2098,19 +3134,39 @@ declare { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2hu.mask
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i32> @intrinsic_vlsseg2hu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i32> @intrinsic_vlsseg2hu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2hu_mask_v_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2hu.mask.nxv8i32.nxv8i32(
-    <vscale x 8 x i32> undef, <vscale x 8 x i32> undef,
-    <vscale x 8 x i32>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i32> %0, <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i32>, <vscale x 8 x i32> } %a, 1
   ret <vscale x 8 x i32> %b
@@ -2127,6 +3183,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg2h_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2h.nxv1i64.nxv1i64(
@@ -2146,19 +3206,36 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2h.mask.
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg2h_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg2h_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2h_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2h.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2175,6 +3252,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg2hu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2hu.nxv1i64.nxv1i64(
@@ -2194,19 +3275,36 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2hu.mask
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg2hu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg2hu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2hu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2hu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2223,6 +3321,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg3h_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg3h.nxv1i64.nxv1i64(
@@ -2242,19 +3344,37 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.ris
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg3h_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg3h_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3h_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg3h.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2271,6 +3391,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg3hu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg3hu.nxv1i64.nxv1i64(
@@ -2290,19 +3414,37 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.ris
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg3hu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg3hu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3hu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg3hu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2319,6 +3461,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg4h_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg4h.nxv1i64.nxv1i64(
@@ -2338,19 +3484,38 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg4h_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg4h_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4h_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg4h.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2367,6 +3532,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg4hu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg4hu.nxv1i64.nxv1i64(
@@ -2386,19 +3555,38 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg4hu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg4hu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4hu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg4hu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2415,6 +3603,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg5h_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg5h.nxv1i64.nxv1i64(
@@ -2434,19 +3626,39 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg5h_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg5h_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5h_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg5h.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2463,6 +3675,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg5hu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg5hu.nxv1i64.nxv1i64(
@@ -2482,19 +3698,39 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg5hu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg5hu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5hu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg5hu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2511,6 +3747,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg6h_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg6h.nxv1i64.nxv1i64(
@@ -2530,19 +3770,40 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg6h_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg6h_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6h_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg6h.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2559,6 +3820,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg6hu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg6hu.nxv1i64.nxv1i64(
@@ -2578,19 +3843,40 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg6hu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg6hu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6hu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg6hu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2607,6 +3893,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg7h_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg7h.nxv1i64.nxv1i64(
@@ -2626,19 +3916,41 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg7h_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg7h_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7h_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg7h.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2655,6 +3967,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg7hu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg7hu.nxv1i64.nxv1i64(
@@ -2674,19 +3990,41 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg7hu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg7hu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7hu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg7hu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2703,6 +4041,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg8h_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8h.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg8h.nxv1i64.nxv1i64(
@@ -2722,19 +4064,42 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg8h_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg8h_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8h_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8h.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg8h.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2751,6 +4116,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg8hu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8hu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg8hu.nxv1i64.nxv1i64(
@@ -2770,19 +4139,42 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg8hu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg8hu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8hu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8hu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg8hu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -2799,6 +4191,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg2h_v_nxv2i64_nxv2i64(<vscale x 2 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2h.nxv2i64.nxv2i64(
@@ -2818,19 +4214,37 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2h.mask.
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg2h_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg2h_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2h_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2h.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -2847,6 +4261,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg2hu_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2hu.nxv2i64.nxv2i64(
@@ -2866,19 +4284,37 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2hu.mask
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg2hu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg2hu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2hu_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2hu.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -2895,6 +4331,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg3h_v_nxv2i64_nxv2i64(<vscale x 2 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3h.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg3h.nxv2i64.nxv2i64(
@@ -2914,19 +4354,39 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.ris
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg3h_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg3h_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3h_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3h.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg3h.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -2943,6 +4403,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg3hu_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3hu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg3hu.nxv2i64.nxv2i64(
@@ -2962,19 +4426,39 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.ris
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg3hu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg3hu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3hu_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3hu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg3hu.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -2991,6 +4475,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg4h_v_nxv2i64_nxv2i64(<vscale x 2 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4h.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg4h.nxv2i64.nxv2i64(
@@ -3010,19 +4498,41 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg4h_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg4h_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4h_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4h.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg4h.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -3039,6 +4549,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg4hu_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4hu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg4hu.nxv2i64.nxv2i64(
@@ -3058,19 +4572,41 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg4hu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg4hu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4hu_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4hu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg4hu.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -3087,6 +4623,10 @@ define <vscale x 4 x i64> @intrinsic_vlsseg2h_v_nxv4i64_nxv4i64(<vscale x 4 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2h.nxv4i64.nxv4i64(
@@ -3106,19 +4646,39 @@ declare { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2h.mask.
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i64> @intrinsic_vlsseg2h_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i64> @intrinsic_vlsseg2h_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2h_mask_v_nxv4i64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2h.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2h.mask.nxv4i64.nxv4i64(
-    <vscale x 4 x i64> undef, <vscale x 4 x i64> undef,
-    <vscale x 4 x i64>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i64> %0, <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i64>, <vscale x 4 x i64> } %a, 1
   ret <vscale x 4 x i64> %b
@@ -3135,6 +4695,10 @@ define <vscale x 4 x i64> @intrinsic_vlsseg2hu_v_nxv4i64_nxv4i64(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2hu.nxv4i64.nxv4i64(
@@ -3154,19 +4718,39 @@ declare { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2hu.mask
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i64> @intrinsic_vlsseg2hu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i64> @intrinsic_vlsseg2hu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2hu_mask_v_nxv4i64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2hu.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2hu.mask.nxv4i64.nxv4i64(
-    <vscale x 4 x i64> undef, <vscale x 4 x i64> undef,
-    <vscale x 4 x i64>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i64> %0, <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i64>, <vscale x 4 x i64> } %a, 1
   ret <vscale x 4 x i64> %b

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vlssegw.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vlssegw.ll
@@ -15,6 +15,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg2w_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2w.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2w.nxv2i32.nxv2i32(
@@ -34,19 +38,36 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2w.mask.
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg2w_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg2w_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2w_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2w.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2w.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -63,6 +84,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg2wu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2wu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2wu.nxv2i32.nxv2i32(
@@ -82,19 +107,36 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2wu.mask
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg2wu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg2wu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2wu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg2wu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg2wu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -111,6 +153,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg3w_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3w.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg3w.nxv2i32.nxv2i32(
@@ -130,19 +176,37 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.ris
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg3w_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg3w_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3w_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3w.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg3w.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -159,6 +223,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg3wu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3wu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg3wu.nxv2i32.nxv2i32(
@@ -178,19 +246,37 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.ris
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg3wu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg3wu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3wu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg3wu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg3wu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -207,6 +293,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg4w_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4w.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg4w.nxv2i32.nxv2i32(
@@ -226,19 +316,38 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg4w_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg4w_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4w_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4w.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg4w.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -255,6 +364,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg4wu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4wu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg4wu.nxv2i32.nxv2i32(
@@ -274,19 +387,38 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg4wu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg4wu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4wu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg4wu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg4wu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -303,6 +435,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg5w_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5w.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg5w.nxv2i32.nxv2i32(
@@ -322,19 +458,39 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg5w_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg5w_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5w_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5w.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg5w.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -351,6 +507,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg5wu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5wu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg5wu.nxv2i32.nxv2i32(
@@ -370,19 +530,39 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg5wu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg5wu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5wu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg5wu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg5wu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -399,6 +579,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg6w_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6w.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg6w.nxv2i32.nxv2i32(
@@ -418,19 +602,40 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg6w_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg6w_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6w_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6w.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg6w.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -447,6 +652,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg6wu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6wu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg6wu.nxv2i32.nxv2i32(
@@ -466,19 +675,40 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg6wu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg6wu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6wu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg6wu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg6wu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -495,6 +725,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg7w_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7w.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg7w.nxv2i32.nxv2i32(
@@ -514,19 +748,41 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg7w_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg7w_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7w_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7w.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg7w.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -543,6 +799,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg7wu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7wu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg7wu.nxv2i32.nxv2i32(
@@ -562,19 +822,41 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg7wu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg7wu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7wu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg7wu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg7wu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -591,6 +873,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg8w_v_nxv2i32_nxv2i32(<vscale x 2 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8w.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg8w.nxv2i32.nxv2i32(
@@ -610,19 +896,42 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg8w_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg8w_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8w_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8w.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg8w.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -639,6 +948,10 @@ define <vscale x 2 x i32> @intrinsic_vlsseg8wu_v_nxv2i32_nxv2i32(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8wu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg8wu.nxv2i32.nxv2i32(
@@ -658,19 +971,42 @@ declare { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i32> @intrinsic_vlsseg8wu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i32> @intrinsic_vlsseg8wu_mask_v_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8wu_mask_v_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m1, d1
 ; CHECK-NEXT:    th.vlsseg8wu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.riscv.th.vlsseg8wu.mask.nxv2i32.nxv2i32(
-    <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef, <vscale x 2 x i32> undef,
-    <vscale x 2 x i32>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0, <vscale x 2 x i32> %0,
+    <vscale x 2 x i32>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %a, 1
   ret <vscale x 2 x i32> %b
@@ -687,6 +1023,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg2w_v_nxv4i32_nxv4i32(<vscale x 4 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2w.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2w.nxv4i32.nxv4i32(
@@ -706,19 +1046,37 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2w.mask.
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg2w_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg2w_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2w_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2w.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2w.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -735,6 +1093,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg2wu_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2wu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2wu.nxv4i32.nxv4i32(
@@ -754,19 +1116,37 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2wu.mask
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg2wu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg2wu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2wu_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg2wu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg2wu.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -783,6 +1163,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg3w_v_nxv4i32_nxv4i32(<vscale x 4 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3w.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg3w.nxv4i32.nxv4i32(
@@ -802,19 +1186,39 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.ris
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg3w_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg3w_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3w_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3w.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg3w.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -831,6 +1235,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg3wu_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3wu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg3wu.nxv4i32.nxv4i32(
@@ -850,19 +1258,39 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.ris
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg3wu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg3wu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3wu_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg3wu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg3wu.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -879,6 +1307,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg4w_v_nxv4i32_nxv4i32(<vscale x 4 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4w.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg4w.nxv4i32.nxv4i32(
@@ -898,19 +1330,41 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg4w_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg4w_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4w_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4w.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg4w.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -927,6 +1381,10 @@ define <vscale x 4 x i32> @intrinsic_vlsseg4wu_v_nxv4i32_nxv4i32(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4wu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg4wu.nxv4i32.nxv4i32(
@@ -946,19 +1404,41 @@ declare { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i32> @intrinsic_vlsseg4wu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i32> @intrinsic_vlsseg4wu_mask_v_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4wu_mask_v_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m2, d1
 ; CHECK-NEXT:    th.vlsseg4wu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.riscv.th.vlsseg4wu.mask.nxv4i32.nxv4i32(
-    <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef, <vscale x 4 x i32> undef,
-    <vscale x 4 x i32>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0, <vscale x 4 x i32> %0,
+    <vscale x 4 x i32>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32>, <vscale x 4 x i32> } %a, 1
   ret <vscale x 4 x i32> %b
@@ -975,6 +1455,10 @@ define <vscale x 8 x i32> @intrinsic_vlsseg2w_v_nxv8i32_nxv8i32(<vscale x 8 x i3
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2w.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2w.nxv8i32.nxv8i32(
@@ -994,19 +1478,39 @@ declare { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2w.mask.
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i32> @intrinsic_vlsseg2w_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i32> @intrinsic_vlsseg2w_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2w_mask_v_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2w.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2w.mask.nxv8i32.nxv8i32(
-    <vscale x 8 x i32> undef, <vscale x 8 x i32> undef,
-    <vscale x 8 x i32>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i32> %0, <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i32>, <vscale x 8 x i32> } %a, 1
   ret <vscale x 8 x i32> %b
@@ -1023,6 +1527,10 @@ define <vscale x 8 x i32> @intrinsic_vlsseg2wu_v_nxv8i32_nxv8i32(<vscale x 8 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2wu.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2wu.nxv8i32.nxv8i32(
@@ -1042,19 +1550,39 @@ declare { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2wu.mask
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i32> @intrinsic_vlsseg2wu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32>* %0, <vscale x 8 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 8 x i32> @intrinsic_vlsseg2wu_mask_v_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32>* %1, <vscale x 8 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2wu_mask_v_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e32, m4, d1
 ; CHECK-NEXT:    th.vlsseg2wu.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 8 x i32>, <vscale x 8 x i32> } @llvm.riscv.th.vlsseg2wu.mask.nxv8i32.nxv8i32(
-    <vscale x 8 x i32> undef, <vscale x 8 x i32> undef,
-    <vscale x 8 x i32>* %0,
-    iXLen %2,
-    <vscale x 8 x i1> %1,
-    iXLen %3)
+    <vscale x 8 x i32> %0, <vscale x 8 x i32> %0,
+    <vscale x 8 x i32>* %1,
+    iXLen %3,
+    <vscale x 8 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 8 x i32>, <vscale x 8 x i32> } %a, 1
   ret <vscale x 8 x i32> %b
@@ -1071,6 +1599,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg2w_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2w.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2w.nxv1i64.nxv1i64(
@@ -1090,19 +1622,36 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2w.mask.
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg2w_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg2w_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2w_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2w.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2w.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -1119,6 +1668,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg2wu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2wu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2wu.nxv1i64.nxv1i64(
@@ -1138,19 +1691,36 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2wu.mask
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg2wu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg2wu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2wu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg2wu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg2wu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -1167,6 +1737,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg3w_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3w.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg3w.nxv1i64.nxv1i64(
@@ -1186,19 +1760,37 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.ris
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg3w_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg3w_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3w_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3w.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg3w.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -1215,6 +1807,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg3wu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3wu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg3wu.nxv1i64.nxv1i64(
@@ -1234,19 +1830,37 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.ris
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg3wu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg3wu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3wu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg3wu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg3wu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -1263,6 +1877,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg4w_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4w.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg4w.nxv1i64.nxv1i64(
@@ -1282,19 +1900,38 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg4w_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg4w_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4w_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4w.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg4w.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -1311,6 +1948,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg4wu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4wu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg4wu.nxv1i64.nxv1i64(
@@ -1330,19 +1971,38 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg4wu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg4wu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4wu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg4wu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg4wu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -1359,6 +2019,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg5w_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5w.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg5w.nxv1i64.nxv1i64(
@@ -1378,19 +2042,39 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg5w_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg5w_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5w_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5w.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg5w.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -1407,6 +2091,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg5wu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5wu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg5wu.nxv1i64.nxv1i64(
@@ -1426,19 +2114,39 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg5wu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg5wu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg5wu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg5wu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg5wu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -1455,6 +2163,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg6w_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6w.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg6w.nxv1i64.nxv1i64(
@@ -1474,19 +2186,40 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg6w_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg6w_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6w_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6w.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg6w.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -1503,6 +2236,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg6wu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6wu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg6wu.nxv1i64.nxv1i64(
@@ -1522,19 +2259,40 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg6wu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg6wu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg6wu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg6wu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg6wu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -1551,6 +2309,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg7w_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7w.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg7w.nxv1i64.nxv1i64(
@@ -1570,19 +2332,41 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg7w_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg7w_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7w_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7w.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg7w.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -1599,6 +2383,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg7wu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7wu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg7wu.nxv1i64.nxv1i64(
@@ -1618,19 +2406,41 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg7wu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg7wu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg7wu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg7wu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg7wu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -1647,6 +2457,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg8w_v_nxv1i64_nxv1i64(<vscale x 1 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8w.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg8w.nxv1i64.nxv1i64(
@@ -1666,19 +2480,42 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg8w_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg8w_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8w_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8w.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg8w.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -1695,6 +2532,10 @@ define <vscale x 1 x i64> @intrinsic_vlsseg8wu_v_nxv1i64_nxv1i64(<vscale x 1 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8wu.v v7, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg8wu.nxv1i64.nxv1i64(
@@ -1714,19 +2555,42 @@ declare { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 
   <vscale x 1 x i1>,
   iXLen);
 
-define <vscale x 1 x i64> @intrinsic_vlsseg8wu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64>* %0, <vscale x 1 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 1 x i64> @intrinsic_vlsseg8wu_mask_v_nxv1i64_nxv1i64(<vscale x 1 x i64> %0, <vscale x 1 x i64>* %1, <vscale x 1 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg8wu_mask_v_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v7, v8
+; CHECK-NEXT:    th.vmv.v.v v9, v8
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v8
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v8
+; CHECK-NEXT:    th.vmv.v.v v14, v8
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m1, d1
 ; CHECK-NEXT:    th.vlsseg8wu.v v7, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } @llvm.riscv.th.vlsseg8wu.mask.nxv1i64.nxv1i64(
-    <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef, <vscale x 1 x i64> undef,
-    <vscale x 1 x i64>* %0,
-    iXLen %2,
-    <vscale x 1 x i1> %1,
-    iXLen %3)
+    <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0, <vscale x 1 x i64> %0,
+    <vscale x 1 x i64>* %1,
+    iXLen %3,
+    <vscale x 1 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64>, <vscale x 1 x i64> } %a, 1
   ret <vscale x 1 x i64> %b
@@ -1743,6 +2607,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg2w_v_nxv2i64_nxv2i64(<vscale x 2 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2w.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2w.nxv2i64.nxv2i64(
@@ -1762,19 +2630,37 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2w.mask.
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg2w_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg2w_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2w_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2w.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2w.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -1791,6 +2677,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg2wu_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2wu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2wu.nxv2i64.nxv2i64(
@@ -1810,19 +2700,37 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2wu.mask
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg2wu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg2wu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2wu_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg2wu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg2wu.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -1839,6 +2747,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg3w_v_nxv2i64_nxv2i64(<vscale x 2 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3w.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg3w.nxv2i64.nxv2i64(
@@ -1858,19 +2770,39 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.ris
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg3w_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg3w_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3w_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3w.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg3w.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -1887,6 +2819,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg3wu_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3wu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg3wu.nxv2i64.nxv2i64(
@@ -1906,19 +2842,39 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.ris
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg3wu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg3wu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg3wu_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg3wu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg3wu.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -1935,6 +2891,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg4w_v_nxv2i64_nxv2i64(<vscale x 2 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4w.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg4w.nxv2i64.nxv2i64(
@@ -1954,19 +2914,41 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg4w_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg4w_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4w_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4w.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg4w.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -1983,6 +2965,10 @@ define <vscale x 2 x i64> @intrinsic_vlsseg4wu_v_nxv2i64_nxv2i64(<vscale x 2 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4wu.v v6, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg4wu.nxv2i64.nxv2i64(
@@ -2002,19 +2988,41 @@ declare { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 
   <vscale x 2 x i1>,
   iXLen);
 
-define <vscale x 2 x i64> @intrinsic_vlsseg4wu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64>* %0, <vscale x 2 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 2 x i64> @intrinsic_vlsseg4wu_mask_v_nxv2i64_nxv2i64(<vscale x 2 x i64> %0, <vscale x 2 x i64>* %1, <vscale x 2 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg4wu_mask_v_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v6, v8
+; CHECK-NEXT:    th.vmv.v.v v7, v9
+; CHECK-NEXT:    th.vmv.v.v v10, v8
+; CHECK-NEXT:    th.vmv.v.v v11, v9
+; CHECK-NEXT:    th.vmv.v.v v12, v8
+; CHECK-NEXT:    th.vmv.v.v v13, v9
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m2, d1
 ; CHECK-NEXT:    th.vlsseg4wu.v v6, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } @llvm.riscv.th.vlsseg4wu.mask.nxv2i64.nxv2i64(
-    <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef, <vscale x 2 x i64> undef,
-    <vscale x 2 x i64>* %0,
-    iXLen %2,
-    <vscale x 2 x i1> %1,
-    iXLen %3)
+    <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0, <vscale x 2 x i64> %0,
+    <vscale x 2 x i64>* %1,
+    iXLen %3,
+    <vscale x 2 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64> } %a, 1
   ret <vscale x 2 x i64> %b
@@ -2031,6 +3039,10 @@ define <vscale x 4 x i64> @intrinsic_vlsseg2w_v_nxv4i64_nxv4i64(<vscale x 4 x i6
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2w.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2w.nxv4i64.nxv4i64(
@@ -2050,19 +3062,39 @@ declare { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2w.mask.
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i64> @intrinsic_vlsseg2w_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i64> @intrinsic_vlsseg2w_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2w_mask_v_nxv4i64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2w.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2w.mask.nxv4i64.nxv4i64(
-    <vscale x 4 x i64> undef, <vscale x 4 x i64> undef,
-    <vscale x 4 x i64>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i64> %0, <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i64>, <vscale x 4 x i64> } %a, 1
   ret <vscale x 4 x i64> %b
@@ -2079,6 +3111,10 @@ define <vscale x 4 x i64> @intrinsic_vlsseg2wu_v_nxv4i64_nxv4i64(<vscale x 4 x i
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2wu.v v4, (a0), a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2wu.nxv4i64.nxv4i64(
@@ -2098,19 +3134,39 @@ declare { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2wu.mask
   <vscale x 4 x i1>,
   iXLen);
 
-define <vscale x 4 x i64> @intrinsic_vlsseg2wu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64>* %0, <vscale x 4 x i1> %1, iXLen %2, iXLen %3) nounwind {
+define <vscale x 4 x i64> @intrinsic_vlsseg2wu_mask_v_nxv4i64_nxv4i64(<vscale x 4 x i64> %0, <vscale x 4 x i64>* %1, <vscale x 4 x i1> %2, iXLen %3, iXLen %4) nounwind {
 ; CHECK-LABEL: intrinsic_vlsseg2wu_mask_v_nxv4i64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v4, v8
+; CHECK-NEXT:    th.vmv.v.v v5, v9
+; CHECK-NEXT:    th.vmv.v.v v6, v10
+; CHECK-NEXT:    th.vmv.v.v v7, v11
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
+; CHECK-NEXT:    csrr a3, vl
+; CHECK-NEXT:    csrr a4, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a3, a4
 ; CHECK-NEXT:    th.vsetvli zero, a2, e64, m4, d1
 ; CHECK-NEXT:    th.vlsseg2wu.v v4, (a0), a1, v0.t
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
 ; CHECK-NEXT:    ret
 entry:
   %a = call { <vscale x 4 x i64>, <vscale x 4 x i64> } @llvm.riscv.th.vlsseg2wu.mask.nxv4i64.nxv4i64(
-    <vscale x 4 x i64> undef, <vscale x 4 x i64> undef,
-    <vscale x 4 x i64>* %0,
-    iXLen %2,
-    <vscale x 4 x i1> %1,
-    iXLen %3)
+    <vscale x 4 x i64> %0, <vscale x 4 x i64> %0,
+    <vscale x 4 x i64>* %1,
+    iXLen %3,
+    <vscale x 4 x i1> %2,
+    iXLen %4)
 
   %b = extractvalue { <vscale x 4 x i64>, <vscale x 4 x i64> } %a, 1
   ret <vscale x 4 x i64> %b


### PR DESCRIPTION
Found a bug during writing intrinsic for `vlxseg`. Originally the `needVSETVLIForCOPY` method only checks COPY nodes with physical register sources. However for those nodes that have virtual register source and physical register destination and are to be converted to `PseudoTH_VMV_V_V` , this approach misses to generate `csrrs` + `vsetvli` for them.

This PR fixes the problem and updates tests. This introduces even more redundant instructions, but the behavior of the program is correct.