### PR TITLE
[LLVM][XTHeadVector] support `nvx1i1/nvx2i1/nvx4i1` operands for vector mask operations

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -146,18 +146,24 @@ bool RISCVExpandPseudo::expandMI(MachineBasicBlock &MBB,
   case RISCV::PseudoVMSET_M_B64:
     // vmset.m vd => vmxnor.mm vd, vd, vd
     return expandVMSET_VMCLR(MBB, MBBI, RISCV::VMXNOR_MM);
+  case RISCV::PseudoTH_VMCLR_M_B1:
+  case RISCV::PseudoTH_VMCLR_M_B2:
+  case RISCV::PseudoTH_VMCLR_M_B4:
   case RISCV::PseudoTH_VMCLR_M_B8:
   case RISCV::PseudoTH_VMCLR_M_B16:
   case RISCV::PseudoTH_VMCLR_M_B32:
   case RISCV::PseudoTH_VMCLR_M_B64:
-      // th.vmclr.m vd => th.vmxor.mm vd, vd, vd
-      return expandVMSET_VMCLR(MBB, MBBI, RISCV::TH_VMXOR_MM);
+    // th.vmclr.m vd => th.vmxor.mm vd, vd, vd
+    return expandVMSET_VMCLR(MBB, MBBI, RISCV::TH_VMXOR_MM);
+  case RISCV::PseudoTH_VMSET_M_B1:
+  case RISCV::PseudoTH_VMSET_M_B2:
+  case RISCV::PseudoTH_VMSET_M_B4:
   case RISCV::PseudoTH_VMSET_M_B8:
   case RISCV::PseudoTH_VMSET_M_B16:
   case RISCV::PseudoTH_VMSET_M_B32:
   case RISCV::PseudoTH_VMSET_M_B64:
-      // th.vmset.m vd => th.vmxnor.mm vd, vd, vd
-      return expandVMSET_VMCLR(MBB, MBBI, RISCV::TH_VMXNOR_MM);
+    // th.vmset.m vd => th.vmxnor.mm vd, vd, vd
+    return expandVMSET_VMCLR(MBB, MBBI, RISCV::TH_VMXNOR_MM);
   }
 
   return false;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXTHeadVPseudos.td
@@ -145,15 +145,32 @@ defset list<VTypeInfoToWide> AllWidenableIntToFloatXVectors = {
   def : VTypeInfoToWide<VI32M4, VF64M8>;
 }
 
+class XMTypeInfo<ValueType Mas, int Sew, int Log2Sew, LMULInfo M, string Bx> {
+  ValueType Mask = Mas;
+  // {SEW, VLMul} values set a valid VType to deal with this mask type.
+  int SEW = Sew;
+  int Log2SEW = Log2Sew;
+  LMULInfo LMul = M;
+  string BX = Bx; // Appendix of mask operations.
+  // The pattern fragment which produces the AVL operand, representing the
+  // "natural" vector length for this mask type. For scalable masks this is
+  // VLMax.
+  OutPatFrag AVL = VLMax;
+}
+
 // Redefine `AllMasks` from RISCVInstrInfoVPseudos.td to remove fractionally-grouped register groups.
-// TODO: riscv-v-intrinsics.pdf declares there are functions accepting vbool<16,32,64>_t, but they need
-//  to be connected to MF2, MF4, MF8, which are not supported by the 'V' extension 0.7.1.
-defset list<MTypeInfo> AllXMasks = {
+defset list<XMTypeInfo> AllXMasks = {
   // vbool<n>_t, <n> = SEW/LMUL, we assume SEW=8 and corresponding LMUL.
-  def : MTypeInfo<vbool8_t, V_M1, "B8">;
-  def : MTypeInfo<vbool4_t, V_M2, "B16">;
-  def : MTypeInfo<vbool2_t, V_M4, "B32">;
-  def : MTypeInfo<vbool1_t, V_M8, "B64">;
+  def : XMTypeInfo<vbool8_t, 8, 3, V_M1, "B8">;
+  def : XMTypeInfo<vbool4_t, 8, 3, V_M2, "B16">;
+  def : XMTypeInfo<vbool2_t, 8, 3, V_M4, "B32">;
+  def : XMTypeInfo<vbool1_t, 8, 3, V_M8, "B64">;
+
+  // Cannot assume SEW=8, as <n> = SEW/LMUL, so LMUL = MF2/MF4/MF8, which is not supported.
+  // Instead, we assume LMUL=1, so SEW = <n> * LMUL.
+  def : XMTypeInfo<vbool64_t, 64, 6, V_M1, "B1">;
+  def : XMTypeInfo<vbool32_t, 32, 5, V_M1, "B2">;
+  def : XMTypeInfo<vbool16_t, 16, 4, V_M1, "B4">;
 }
 
 class GetXVTypePredicates<VTypeInfo vti> {
@@ -3981,7 +3998,7 @@ multiclass XVPatUnaryS_M<string intrinsic_name,
 
 class XVPatMaskUnaryNoMask<string intrinsic_name,
                           string inst,
-                          MTypeInfo mti> :
+                          XMTypeInfo mti> :
   Pat<(mti.Mask (!cast<Intrinsic>(intrinsic_name)
                 (mti.Mask VR:$rs2),
                 VLOpFrag)),
@@ -3992,7 +4009,7 @@ class XVPatMaskUnaryNoMask<string intrinsic_name,
 
 class XVPatMaskUnaryMask<string intrinsic_name,
                         string inst,
-                        MTypeInfo mti> :
+                        XMTypeInfo mti> :
   Pat<(mti.Mask (!cast<Intrinsic>(intrinsic_name#"_mask")
                 (mti.Mask VR:$merge),
                 (mti.Mask VR:$rs2),

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmand.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmand.ll
@@ -4,6 +4,66 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare <vscale x 1 x i1> @llvm.riscv.th.vmand.nxv1i1(
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmand_mm_nxv1i1(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmand_mm_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmand.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmand.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmand.nxv2i1(
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmand_mm_nxv2i1(<vscale x 2 x i1> %0, <vscale x 2 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmand_mm_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmand.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmand.nxv2i1(
+    <vscale x 2 x i1> %0,
+    <vscale x 2 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmand.nxv4i1(
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmand_mm_nxv4i1(<vscale x 4 x i1> %0, <vscale x 4 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmand_mm_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmand.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmand.nxv4i1(
+    <vscale x 4 x i1> %0,
+    <vscale x 4 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i1> %a
+}
+
 declare <vscale x 8 x i1> @llvm.riscv.th.vmand.nxv8i1(
   <vscale x 8 x i1>,
   <vscale x 8 x i1>,

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmandn.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmandn.ll
@@ -4,13 +4,73 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare <vscale x 1 x i1> @llvm.riscv.th.vmandnot.nxv1i1(
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmandnot_mm_nxv1i1(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmandnot_mm_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmandnot.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmandnot.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmandnot.nxv2i1(
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmandnot_mm_nxv2i1(<vscale x 2 x i1> %0, <vscale x 2 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmandnot_mm_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmandnot.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmandnot.nxv2i1(
+    <vscale x 2 x i1> %0,
+    <vscale x 2 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmandnot.nxv4i1(
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmandnot_mm_nxv4i1(<vscale x 4 x i1> %0, <vscale x 4 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmandnot_mm_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmandnot.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmandnot.nxv4i1(
+    <vscale x 4 x i1> %0,
+    <vscale x 4 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i1> %a
+}
+
 declare <vscale x 8 x i1> @llvm.riscv.th.vmandnot.nxv8i1(
   <vscale x 8 x i1>,
   <vscale x 8 x i1>,
   iXLen);
 
-define <vscale x 8 x i1> @intrinsic_vmandn_mm_nxv8i1(<vscale x 8 x i1> %0, <vscale x 8 x i1> %1, iXLen %2) nounwind {
-; CHECK-LABEL: intrinsic_vmandn_mm_nxv8i1:
+define <vscale x 8 x i1> @intrinsic_vmandnot_mm_nxv8i1(<vscale x 8 x i1> %0, <vscale x 8 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmandnot_mm_nxv8i1:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a0, e8, m1, d1
 ; CHECK-NEXT:    th.vmandnot.mm v0, v0, v8
@@ -29,8 +89,8 @@ declare <vscale x 16 x i1> @llvm.riscv.th.vmandnot.nxv16i1(
   <vscale x 16 x i1>,
   iXLen);
 
-define <vscale x 16 x i1> @intrinsic_vmandn_mm_nxv16i1(<vscale x 16 x i1> %0, <vscale x 16 x i1> %1, iXLen %2) nounwind {
-; CHECK-LABEL: intrinsic_vmandn_mm_nxv16i1:
+define <vscale x 16 x i1> @intrinsic_vmandnot_mm_nxv16i1(<vscale x 16 x i1> %0, <vscale x 16 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmandnot_mm_nxv16i1:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a0, e8, m2, d1
 ; CHECK-NEXT:    th.vmandnot.mm v0, v0, v8
@@ -49,8 +109,8 @@ declare <vscale x 32 x i1> @llvm.riscv.th.vmandnot.nxv32i1(
   <vscale x 32 x i1>,
   iXLen);
 
-define <vscale x 32 x i1> @intrinsic_vmandn_mm_nxv32i1(<vscale x 32 x i1> %0, <vscale x 32 x i1> %1, iXLen %2) nounwind {
-; CHECK-LABEL: intrinsic_vmandn_mm_nxv32i1:
+define <vscale x 32 x i1> @intrinsic_vmandnot_mm_nxv32i1(<vscale x 32 x i1> %0, <vscale x 32 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmandnot_mm_nxv32i1:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a0, e8, m4, d1
 ; CHECK-NEXT:    th.vmandnot.mm v0, v0, v8
@@ -69,8 +129,8 @@ declare <vscale x 64 x i1> @llvm.riscv.th.vmandnot.nxv64i1(
   <vscale x 64 x i1>,
   iXLen);
 
-define <vscale x 64 x i1> @intrinsic_vmandn_mm_nxv64i1(<vscale x 64 x i1> %0, <vscale x 64 x i1> %1, iXLen %2) nounwind {
-; CHECK-LABEL: intrinsic_vmandn_mm_nxv64i1:
+define <vscale x 64 x i1> @intrinsic_vmandnot_mm_nxv64i1(<vscale x 64 x i1> %0, <vscale x 64 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmandnot_mm_nxv64i1:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    th.vsetvli zero, a0, e8, m8, d1
 ; CHECK-NEXT:    th.vmandnot.mm v0, v0, v8

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmclr.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmclr.ll
@@ -4,6 +4,54 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare <vscale x 1 x i1> @llvm.riscv.th.vmclr.nxv1i1(
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmclr_m_pseudo_nxv1i1(iXLen %0) nounwind {
+; CHECK-LABEL: intrinsic_vmclr_m_pseudo_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmclr.m v0
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmclr.nxv1i1(
+    iXLen %0)
+
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmclr.nxv2i1(
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmclr_m_pseudo_nxv2i1(iXLen %0) nounwind {
+; CHECK-LABEL: intrinsic_vmclr_m_pseudo_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmclr.m v0
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmclr.nxv2i1(
+    iXLen %0)
+
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmclr.nxv4i1(
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmclr_m_pseudo_nxv4i1(iXLen %0) nounwind {
+; CHECK-LABEL: intrinsic_vmclr_m_pseudo_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmclr.m v0
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmclr.nxv4i1(
+    iXLen %0)
+
+  ret <vscale x 4 x i1> %a
+}
+
 declare <vscale x 8 x i1> @llvm.riscv.th.vmclr.nxv8i1(
   iXLen);
 

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmfirst.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmfirst.ll
@@ -4,6 +4,177 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare iXLen @llvm.riscv.th.vmfirst.iXLen.nxv1i1(
+  <vscale x 1 x i1>,
+  iXLen);
+
+define iXLen @intrinsic_vmfirst_m_nxv1i1(<vscale x 1 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmfirst_m_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmfirst.m a0, v0
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmfirst.iXLen.nxv1i1(
+    <vscale x 1 x i1> %0,
+    iXLen %1)
+
+  ret iXLen %a
+}
+
+; define iXLen @intrinsic_vmfirst_m_nxv1i1_zero(<vscale x 1 x i1> %0) nounwind {
+; ; CHECK-LABEL: intrinsic_vmfirst_m_nxv1i1_zero:
+; ; CHECK:       # %bb.0: # %entry
+; ; CHECK-NEXT:    li a0, -1
+; ; CHECK-NEXT:    ret
+; entry:
+;   %a = call iXLen @llvm.riscv.th.vmfirst.iXLen.nxv1i1(
+;     <vscale x 1 x i1> %0,
+;     iXLen 0)
+;
+;   ret iXLen %a
+; }
+
+declare iXLen @llvm.riscv.th.vmfirst.mask.iXLen.nxv1i1(
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define iXLen @intrinsic_vmfirst_mask_m_nxv1i1(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmfirst_mask_m_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v9, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmfirst.m a0, v9, v0.t
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmfirst.mask.iXLen.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    iXLen %2)
+
+  ret iXLen %a
+}
+
+; define iXLen @intrinsic_vmfirst_mask_m_nxv1i1_zero(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1) nounwind {
+; ; CHECK-LABEL: intrinsic_vmfirst_mask_m_nxv1i1_zero:
+; ; CHECK:       # %bb.0: # %entry
+; ; CHECK-NEXT:    li a0, -1
+; ; CHECK-NEXT:    ret
+; entry:
+;   %a = call iXLen @llvm.riscv.th.vmfirst.mask.iXLen.nxv1i1(
+;     <vscale x 1 x i1> %0,
+;     <vscale x 1 x i1> %1,
+;     iXLen 0)
+;
+;   ret iXLen %a
+; }
+
+declare iXLen @llvm.riscv.th.vmfirst.iXLen.nxv2i1(
+  <vscale x 2 x i1>,
+  iXLen);
+
+define iXLen @intrinsic_vmfirst_m_nxv2i1(<vscale x 2 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmfirst_m_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmfirst.m a0, v0
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmfirst.iXLen.nxv2i1(
+    <vscale x 2 x i1> %0,
+    iXLen %1)
+
+  ret iXLen %a
+}
+
+declare iXLen @llvm.riscv.th.vmfirst.mask.iXLen.nxv2i1(
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define iXLen @intrinsic_vmfirst_mask_m_nxv2i1(<vscale x 2 x i1> %0, <vscale x 2 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmfirst_mask_m_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v9, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmfirst.m a0, v9, v0.t
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmfirst.mask.iXLen.nxv2i1(
+    <vscale x 2 x i1> %0,
+    <vscale x 2 x i1> %1,
+    iXLen %2)
+
+  ret iXLen %a
+}
+
+declare iXLen @llvm.riscv.th.vmfirst.iXLen.nxv4i1(
+  <vscale x 4 x i1>,
+  iXLen);
+
+define iXLen @intrinsic_vmfirst_m_nxv4i1(<vscale x 4 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmfirst_m_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmfirst.m a0, v0
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmfirst.iXLen.nxv4i1(
+    <vscale x 4 x i1> %0,
+    iXLen %1)
+
+  ret iXLen %a
+}
+
+declare iXLen @llvm.riscv.th.vmfirst.mask.iXLen.nxv4i1(
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define iXLen @intrinsic_vmfirst_mask_m_nxv4i1(<vscale x 4 x i1> %0, <vscale x 4 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmfirst_mask_m_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v9, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmfirst.m a0, v9, v0.t
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmfirst.mask.iXLen.nxv4i1(
+    <vscale x 4 x i1> %0,
+    <vscale x 4 x i1> %1,
+    iXLen %2)
+
+  ret iXLen %a
+}
+
 declare iXLen @llvm.riscv.th.vmfirst.iXLen.nxv8i1(
   <vscale x 8 x i1>,
   iXLen);

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmfirst.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmfirst.ll
@@ -22,19 +22,6 @@ entry:
   ret iXLen %a
 }
 
-; define iXLen @intrinsic_vmfirst_m_nxv1i1_zero(<vscale x 1 x i1> %0) nounwind {
-; ; CHECK-LABEL: intrinsic_vmfirst_m_nxv1i1_zero:
-; ; CHECK:       # %bb.0: # %entry
-; ; CHECK-NEXT:    li a0, -1
-; ; CHECK-NEXT:    ret
-; entry:
-;   %a = call iXLen @llvm.riscv.th.vmfirst.iXLen.nxv1i1(
-;     <vscale x 1 x i1> %0,
-;     iXLen 0)
-;
-;   ret iXLen %a
-; }
-
 declare iXLen @llvm.riscv.th.vmfirst.mask.iXLen.nxv1i1(
   <vscale x 1 x i1>,
   <vscale x 1 x i1>,
@@ -64,20 +51,6 @@ entry:
 
   ret iXLen %a
 }
-
-; define iXLen @intrinsic_vmfirst_mask_m_nxv1i1_zero(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1) nounwind {
-; ; CHECK-LABEL: intrinsic_vmfirst_mask_m_nxv1i1_zero:
-; ; CHECK:       # %bb.0: # %entry
-; ; CHECK-NEXT:    li a0, -1
-; ; CHECK-NEXT:    ret
-; entry:
-;   %a = call iXLen @llvm.riscv.th.vmfirst.mask.iXLen.nxv1i1(
-;     <vscale x 1 x i1> %0,
-;     <vscale x 1 x i1> %1,
-;     iXLen 0)
-;
-;   ret iXLen %a
-; }
 
 declare iXLen @llvm.riscv.th.vmfirst.iXLen.nxv2i1(
   <vscale x 2 x i1>,

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmnand.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmnand.ll
@@ -4,6 +4,66 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare <vscale x 1 x i1> @llvm.riscv.th.vmnand.nxv1i1(
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmnand_mm_nxv1i1(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmnand_mm_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmnand.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmnand.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmnand.nxv2i1(
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmnand_mm_nxv2i1(<vscale x 2 x i1> %0, <vscale x 2 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmnand_mm_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmnand.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmnand.nxv2i1(
+    <vscale x 2 x i1> %0,
+    <vscale x 2 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmnand.nxv4i1(
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmnand_mm_nxv4i1(<vscale x 4 x i1> %0, <vscale x 4 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmnand_mm_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmnand.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmnand.nxv4i1(
+    <vscale x 4 x i1> %0,
+    <vscale x 4 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i1> %a
+}
+
 declare <vscale x 8 x i1> @llvm.riscv.th.vmnand.nxv8i1(
   <vscale x 8 x i1>,
   <vscale x 8 x i1>,

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmnor.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmnor.ll
@@ -4,6 +4,66 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare <vscale x 1 x i1> @llvm.riscv.th.vmnor.nxv1i1(
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmnor_mm_nxv1i1(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmnor_mm_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmnor.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmnor.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmnor.nxv2i1(
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmnor_mm_nxv2i1(<vscale x 2 x i1> %0, <vscale x 2 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmnor_mm_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmnor.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmnor.nxv2i1(
+    <vscale x 2 x i1> %0,
+    <vscale x 2 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmnor.nxv4i1(
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmnor_mm_nxv4i1(<vscale x 4 x i1> %0, <vscale x 4 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmnor_mm_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmnor.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmnor.nxv4i1(
+    <vscale x 4 x i1> %0,
+    <vscale x 4 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i1> %a
+}
+
 declare <vscale x 8 x i1> @llvm.riscv.th.vmnor.nxv8i1(
   <vscale x 8 x i1>,
   <vscale x 8 x i1>,

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmor.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmor.ll
@@ -4,6 +4,66 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare <vscale x 1 x i1> @llvm.riscv.th.vmor.nxv1i1(
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmor_mm_nxv1i1(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmor_mm_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmor.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmor.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmor.nxv2i1(
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmor_mm_nxv2i1(<vscale x 2 x i1> %0, <vscale x 2 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmor_mm_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmor.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmor.nxv2i1(
+    <vscale x 2 x i1> %0,
+    <vscale x 2 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmor.nxv4i1(
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmor_mm_nxv4i1(<vscale x 4 x i1> %0, <vscale x 4 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmor_mm_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmor.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmor.nxv4i1(
+    <vscale x 4 x i1> %0,
+    <vscale x 4 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i1> %a
+}
+
 declare <vscale x 8 x i1> @llvm.riscv.th.vmor.nxv8i1(
   <vscale x 8 x i1>,
   <vscale x 8 x i1>,

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmorn.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmorn.ll
@@ -4,6 +4,66 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare <vscale x 1 x i1> @llvm.riscv.th.vmornot.nxv1i1(
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmornot_mm_nxv1i1(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmornot_mm_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmornot.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmornot.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmornot.nxv2i1(
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmornot_mm_nxv2i1(<vscale x 2 x i1> %0, <vscale x 2 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmornot_mm_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmornot.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmornot.nxv2i1(
+    <vscale x 2 x i1> %0,
+    <vscale x 2 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmornot.nxv4i1(
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmornot_mm_nxv4i1(<vscale x 4 x i1> %0, <vscale x 4 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmornot_mm_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmornot.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmornot.nxv4i1(
+    <vscale x 4 x i1> %0,
+    <vscale x 4 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i1> %a
+}
+
 declare <vscale x 8 x i1> @llvm.riscv.th.vmornot.nxv8i1(
   <vscale x 8 x i1>,
   <vscale x 8 x i1>,

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmpopc.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmpopc.ll
@@ -22,19 +22,6 @@ entry:
   ret iXLen %a
 }
 
-; define iXLen @intrinsic_vmpopc_m_nxv1i1_zero(<vscale x 1 x i1> %0) nounwind {
-; ; CHECK-LABEL: intrinsic_vmpopc_m_nxv1i1_zero:
-; ; CHECK:       # %bb.0: # %entry
-; ; CHECK-NEXT:    li a0, 0
-; ; CHECK-NEXT:    ret
-; entry:
-;   %a = call iXLen @llvm.riscv.th.vmpopc.iXLen.nxv1i1(
-;     <vscale x 1 x i1> %0,
-;     iXLen 0)
-;
-;   ret iXLen %a
-; }
-
 declare iXLen @llvm.riscv.th.vmpopc.mask.iXLen.nxv1i1(
   <vscale x 1 x i1>,
   <vscale x 1 x i1>,
@@ -64,20 +51,6 @@ entry:
 
   ret iXLen %a
 }
-
-; define iXLen @intrinsic_vmpopc_mask_m_nxv1i1_zero(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1) nounwind {
-; ; CHECK-LABEL: intrinsic_vmpopc_mask_m_nxv1i1_zero:
-; ; CHECK:       # %bb.0: # %entry
-; ; CHECK-NEXT:    li a0, 0
-; ; CHECK-NEXT:    ret
-; entry:
-;   %a = call iXLen @llvm.riscv.th.vmpopc.mask.iXLen.nxv1i1(
-;     <vscale x 1 x i1> %0,
-;     <vscale x 1 x i1> %1,
-;     iXLen 0)
-;
-;   ret iXLen %a
-; }
 
 declare iXLen @llvm.riscv.th.vmpopc.iXLen.nxv2i1(
   <vscale x 2 x i1>,

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmpopc.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmpopc.ll
@@ -4,6 +4,177 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare iXLen @llvm.riscv.th.vmpopc.iXLen.nxv1i1(
+  <vscale x 1 x i1>,
+  iXLen);
+
+define iXLen @intrinsic_vmpopc_m_nxv1i1(<vscale x 1 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmpopc_m_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmpopc.m a0, v0
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmpopc.iXLen.nxv1i1(
+    <vscale x 1 x i1> %0,
+    iXLen %1)
+
+  ret iXLen %a
+}
+
+; define iXLen @intrinsic_vmpopc_m_nxv1i1_zero(<vscale x 1 x i1> %0) nounwind {
+; ; CHECK-LABEL: intrinsic_vmpopc_m_nxv1i1_zero:
+; ; CHECK:       # %bb.0: # %entry
+; ; CHECK-NEXT:    li a0, 0
+; ; CHECK-NEXT:    ret
+; entry:
+;   %a = call iXLen @llvm.riscv.th.vmpopc.iXLen.nxv1i1(
+;     <vscale x 1 x i1> %0,
+;     iXLen 0)
+;
+;   ret iXLen %a
+; }
+
+declare iXLen @llvm.riscv.th.vmpopc.mask.iXLen.nxv1i1(
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define iXLen @intrinsic_vmpopc_mask_m_nxv1i1(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmpopc_mask_m_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v9, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmpopc.m a0, v9, v0.t
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmpopc.mask.iXLen.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    iXLen %2)
+
+  ret iXLen %a
+}
+
+; define iXLen @intrinsic_vmpopc_mask_m_nxv1i1_zero(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1) nounwind {
+; ; CHECK-LABEL: intrinsic_vmpopc_mask_m_nxv1i1_zero:
+; ; CHECK:       # %bb.0: # %entry
+; ; CHECK-NEXT:    li a0, 0
+; ; CHECK-NEXT:    ret
+; entry:
+;   %a = call iXLen @llvm.riscv.th.vmpopc.mask.iXLen.nxv1i1(
+;     <vscale x 1 x i1> %0,
+;     <vscale x 1 x i1> %1,
+;     iXLen 0)
+;
+;   ret iXLen %a
+; }
+
+declare iXLen @llvm.riscv.th.vmpopc.iXLen.nxv2i1(
+  <vscale x 2 x i1>,
+  iXLen);
+
+define iXLen @intrinsic_vmpopc_m_nxv2i1(<vscale x 2 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmpopc_m_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmpopc.m a0, v0
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmpopc.iXLen.nxv2i1(
+    <vscale x 2 x i1> %0,
+    iXLen %1)
+
+  ret iXLen %a
+}
+
+declare iXLen @llvm.riscv.th.vmpopc.mask.iXLen.nxv2i1(
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define iXLen @intrinsic_vmpopc_mask_m_nxv2i1(<vscale x 2 x i1> %0, <vscale x 2 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmpopc_mask_m_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v9, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmpopc.m a0, v9, v0.t
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmpopc.mask.iXLen.nxv2i1(
+    <vscale x 2 x i1> %0,
+    <vscale x 2 x i1> %1,
+    iXLen %2)
+
+  ret iXLen %a
+}
+
+declare iXLen @llvm.riscv.th.vmpopc.iXLen.nxv4i1(
+  <vscale x 4 x i1>,
+  iXLen);
+
+define iXLen @intrinsic_vmpopc_m_nxv4i1(<vscale x 4 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmpopc_m_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmpopc.m a0, v0
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmpopc.iXLen.nxv4i1(
+    <vscale x 4 x i1> %0,
+    iXLen %1)
+
+  ret iXLen %a
+}
+
+declare iXLen @llvm.riscv.th.vmpopc.mask.iXLen.nxv4i1(
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define iXLen @intrinsic_vmpopc_mask_m_nxv4i1(<vscale x 4 x i1> %0, <vscale x 4 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmpopc_mask_m_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v9, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmpopc.m a0, v9, v0.t
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmpopc.mask.iXLen.nxv4i1(
+    <vscale x 4 x i1> %0,
+    <vscale x 4 x i1> %1,
+    iXLen %2)
+
+  ret iXLen %a
+}
+
 declare iXLen @llvm.riscv.th.vmpopc.iXLen.nxv8i1(
   <vscale x 8 x i1>,
   iXLen);

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmsbf.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmsbf.ll
@@ -4,6 +4,156 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare <vscale x 1 x i1> @llvm.riscv.th.vmsbf.nxv1i1(
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmsbf_m_nxv1i1(<vscale x 1 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmsbf_m_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmsbf.m v8, v0
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmsbf.nxv1i1(
+    <vscale x 1 x i1> %0,
+    iXLen %1)
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 1 x i1> @llvm.riscv.th.vmsbf.mask.nxv1i1(
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmsbf_mask_m_nxv1i1_nxv1i1(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1, <vscale x 1 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_vmsbf_mask_m_nxv1i1_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v10, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v9
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmsbf.m v10, v8, v0.t
+; CHECK-NEXT:    th.vmv.v.v v0, v10
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmsbf.mask.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    <vscale x 1 x i1> %2,
+    iXLen %3)
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmsbf.nxv2i1(
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmsbf_m_nxv2i1(<vscale x 2 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmsbf_m_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmsbf.m v8, v0
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmsbf.nxv2i1(
+    <vscale x 2 x i1> %0,
+    iXLen %1)
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmsbf.mask.nxv2i1(
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmsbf_mask_m_nxv2i1_nxv2i1(<vscale x 2 x i1> %0, <vscale x 2 x i1> %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_vmsbf_mask_m_nxv2i1_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v10, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v9
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmsbf.m v10, v8, v0.t
+; CHECK-NEXT:    th.vmv.v.v v0, v10
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmsbf.mask.nxv2i1(
+    <vscale x 2 x i1> %0,
+    <vscale x 2 x i1> %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmsbf.nxv4i1(
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmsbf_m_nxv4i1(<vscale x 4 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmsbf_m_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmsbf.m v8, v0
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmsbf.nxv4i1(
+    <vscale x 4 x i1> %0,
+    iXLen %1)
+  ret <vscale x 4 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmsbf.mask.nxv4i1(
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmsbf_mask_m_nxv4i1_nxv4i1(<vscale x 4 x i1> %0, <vscale x 4 x i1> %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_vmsbf_mask_m_nxv4i1_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v10, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v9
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmsbf.m v10, v8, v0.t
+; CHECK-NEXT:    th.vmv.v.v v0, v10
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmsbf.mask.nxv4i1(
+    <vscale x 4 x i1> %0,
+    <vscale x 4 x i1> %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+  ret <vscale x 4 x i1> %a
+}
+
 declare <vscale x 8 x i1> @llvm.riscv.th.vmsbf.nxv8i1(
   <vscale x 8 x i1>,
   iXLen);

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmset.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmset.ll
@@ -4,6 +4,54 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare <vscale x 1 x i1> @llvm.riscv.th.vmset.nxv1i1(
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmset_m_pseudo_nxv1i1(iXLen %0) nounwind {
+; CHECK-LABEL: intrinsic_vmset_m_pseudo_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmset.m v0
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmset.nxv1i1(
+    iXLen %0)
+
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmset.nxv2i1(
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmset_m_pseudo_nxv2i1(iXLen %0) nounwind {
+; CHECK-LABEL: intrinsic_vmset_m_pseudo_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmset.m v0
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmset.nxv2i1(
+    iXLen %0)
+
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmset.nxv4i1(
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmset_m_pseudo_nxv4i1(iXLen %0) nounwind {
+; CHECK-LABEL: intrinsic_vmset_m_pseudo_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmset.m v0
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmset.nxv4i1(
+    iXLen %0)
+
+  ret <vscale x 4 x i1> %a
+}
+
 declare <vscale x 8 x i1> @llvm.riscv.th.vmset.nxv8i1(
   iXLen);
 

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmsif.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmsif.ll
@@ -4,6 +4,156 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare <vscale x 1 x i1> @llvm.riscv.th.vmsif.nxv1i1(
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmsif_m_nxv1i1(<vscale x 1 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmsif_m_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmsif.m v8, v0
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmsif.nxv1i1(
+    <vscale x 1 x i1> %0,
+    iXLen %1)
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 1 x i1> @llvm.riscv.th.vmsif.mask.nxv1i1(
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmsif_mask_m_nxv1i1_nxv1i1(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1, <vscale x 1 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_vmsif_mask_m_nxv1i1_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v10, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v9
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmsif.m v10, v8, v0.t
+; CHECK-NEXT:    th.vmv.v.v v0, v10
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmsif.mask.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    <vscale x 1 x i1> %2,
+    iXLen %3)
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmsif.nxv2i1(
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmsif_m_nxv2i1(<vscale x 2 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmsif_m_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmsif.m v8, v0
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmsif.nxv2i1(
+    <vscale x 2 x i1> %0,
+    iXLen %1)
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmsif.mask.nxv2i1(
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmsif_mask_m_nxv2i1_nxv2i1(<vscale x 2 x i1> %0, <vscale x 2 x i1> %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_vmsif_mask_m_nxv2i1_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v10, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v9
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmsif.m v10, v8, v0.t
+; CHECK-NEXT:    th.vmv.v.v v0, v10
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmsif.mask.nxv2i1(
+    <vscale x 2 x i1> %0,
+    <vscale x 2 x i1> %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmsif.nxv4i1(
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmsif_m_nxv4i1(<vscale x 4 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmsif_m_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmsif.m v8, v0
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmsif.nxv4i1(
+    <vscale x 4 x i1> %0,
+    iXLen %1)
+  ret <vscale x 4 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmsif.mask.nxv4i1(
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmsif_mask_m_nxv4i1_nxv4i1(<vscale x 4 x i1> %0, <vscale x 4 x i1> %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_vmsif_mask_m_nxv4i1_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v10, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v9
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmsif.m v10, v8, v0.t
+; CHECK-NEXT:    th.vmv.v.v v0, v10
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmsif.mask.nxv4i1(
+    <vscale x 4 x i1> %0,
+    <vscale x 4 x i1> %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+  ret <vscale x 4 x i1> %a
+}
+
 declare <vscale x 8 x i1> @llvm.riscv.th.vmsif.nxv8i1(
   <vscale x 8 x i1>,
   iXLen);

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmsof.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmsof.ll
@@ -4,6 +4,156 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare <vscale x 1 x i1> @llvm.riscv.th.vmsof.nxv1i1(
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmsof_m_nxv1i1(<vscale x 1 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmsof_m_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmsof.m v8, v0
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmsof.nxv1i1(
+    <vscale x 1 x i1> %0,
+    iXLen %1)
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 1 x i1> @llvm.riscv.th.vmsof.mask.nxv1i1(
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmsof_mask_m_nxv1i1_nxv1i1(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1, <vscale x 1 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_vmsof_mask_m_nxv1i1_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v10, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v9
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmsof.m v10, v8, v0.t
+; CHECK-NEXT:    th.vmv.v.v v0, v10
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmsof.mask.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    <vscale x 1 x i1> %2,
+    iXLen %3)
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmsof.nxv2i1(
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmsof_m_nxv2i1(<vscale x 2 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmsof_m_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmsof.m v8, v0
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmsof.nxv2i1(
+    <vscale x 2 x i1> %0,
+    iXLen %1)
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmsof.mask.nxv2i1(
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmsof_mask_m_nxv2i1_nxv2i1(<vscale x 2 x i1> %0, <vscale x 2 x i1> %1, <vscale x 2 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_vmsof_mask_m_nxv2i1_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v10, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v9
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmsof.m v10, v8, v0.t
+; CHECK-NEXT:    th.vmv.v.v v0, v10
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmsof.mask.nxv2i1(
+    <vscale x 2 x i1> %0,
+    <vscale x 2 x i1> %1,
+    <vscale x 2 x i1> %2,
+    iXLen %3)
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmsof.nxv4i1(
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmsof_m_nxv4i1(<vscale x 4 x i1> %0, iXLen %1) nounwind {
+; CHECK-LABEL: intrinsic_vmsof_m_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmsof.m v8, v0
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmsof.nxv4i1(
+    <vscale x 4 x i1> %0,
+    iXLen %1)
+  ret <vscale x 4 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmsof.mask.nxv4i1(
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmsof_mask_m_nxv4i1_nxv4i1(<vscale x 4 x i1> %0, <vscale x 4 x i1> %1, <vscale x 4 x i1> %2, iXLen %3) nounwind {
+; CHECK-LABEL: intrinsic_vmsof_mask_m_nxv4i1_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v10, v0
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    csrr a1, vl
+; CHECK-NEXT:    csrr a2, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v9
+; CHECK-NEXT:    th.vsetvl zero, a1, a2
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmsof.m v10, v8, v0.t
+; CHECK-NEXT:    th.vmv.v.v v0, v10
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmsof.mask.nxv4i1(
+    <vscale x 4 x i1> %0,
+    <vscale x 4 x i1> %1,
+    <vscale x 4 x i1> %2,
+    iXLen %3)
+  ret <vscale x 4 x i1> %a
+}
+
 declare <vscale x 8 x i1> @llvm.riscv.th.vmsof.nxv8i1(
   <vscale x 8 x i1>,
   iXLen);

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmxnor.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmxnor.ll
@@ -4,6 +4,66 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare <vscale x 1 x i1> @llvm.riscv.th.vmxnor.nxv1i1(
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmxnor_mm_nxv1i1(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmxnor_mm_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmxnor.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmxnor.nxv2i1(
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmxnor_mm_nxv2i1(<vscale x 2 x i1> %0, <vscale x 2 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmxnor_mm_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmxnor.nxv2i1(
+    <vscale x 2 x i1> %0,
+    <vscale x 2 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmxnor.nxv4i1(
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmxnor_mm_nxv4i1(<vscale x 4 x i1> %0, <vscale x 4 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmxnor_mm_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmxnor.nxv4i1(
+    <vscale x 4 x i1> %0,
+    <vscale x 4 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i1> %a
+}
+
 declare <vscale x 8 x i1> @llvm.riscv.th.vmxnor.nxv8i1(
   <vscale x 8 x i1>,
   <vscale x 8 x i1>,

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmxor.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmxor.ll
@@ -4,6 +4,66 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+xtheadvector \
 ; RUN:   -verify-machineinstrs | FileCheck %s
 
+declare <vscale x 1 x i1> @llvm.riscv.th.vmxor.nxv1i1(
+  <vscale x 1 x i1>,
+  <vscale x 1 x i1>,
+  iXLen);
+
+define <vscale x 1 x i1> @intrinsic_vmxor_mm_nxv1i1(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmxor_mm_nxv1i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmxor.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 1 x i1> @llvm.riscv.th.vmxor.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 1 x i1> %a
+}
+
+declare <vscale x 2 x i1> @llvm.riscv.th.vmxor.nxv2i1(
+  <vscale x 2 x i1>,
+  <vscale x 2 x i1>,
+  iXLen);
+
+define <vscale x 2 x i1> @intrinsic_vmxor_mm_nxv2i1(<vscale x 2 x i1> %0, <vscale x 2 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmxor_mm_nxv2i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e32, m1, d1
+; CHECK-NEXT:    th.vmxor.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 2 x i1> @llvm.riscv.th.vmxor.nxv2i1(
+    <vscale x 2 x i1> %0,
+    <vscale x 2 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 2 x i1> %a
+}
+
+declare <vscale x 4 x i1> @llvm.riscv.th.vmxor.nxv4i1(
+  <vscale x 4 x i1>,
+  <vscale x 4 x i1>,
+  iXLen);
+
+define <vscale x 4 x i1> @intrinsic_vmxor_mm_nxv4i1(<vscale x 4 x i1> %0, <vscale x 4 x i1> %1, iXLen %2) nounwind {
+; CHECK-LABEL: intrinsic_vmxor_mm_nxv4i1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    th.vsetvli zero, a0, e16, m1, d1
+; CHECK-NEXT:    th.vmxor.mm v0, v0, v8
+; CHECK-NEXT:    ret
+entry:
+  %a = call <vscale x 4 x i1> @llvm.riscv.th.vmxor.nxv4i1(
+    <vscale x 4 x i1> %0,
+    <vscale x 4 x i1> %1,
+    iXLen %2)
+
+  ret <vscale x 4 x i1> %a
+}
+
 declare <vscale x 8 x i1> @llvm.riscv.th.vmxor.nxv8i1(
   <vscale x 8 x i1>,
   <vscale x 8 x i1>,


### PR DESCRIPTION
This PR fixed an issue introduced in #95 where the element size of `vbool16/32/64_t` is computed from fractional LMUL, making it incompatible with XTHeadVector.

This PR applies another strategy of setting LMUL and SEW when computing `<n> = SEW/LMUL` in `vbool<n>_t`:
- for `<n> = 1, 2, 4, 8`, we assume `SEW = 8`, and set `LMUL = 8/4/2/1` respectively. This is the same as the old behavior and mainline RVV implementation.
- for `<n> = 16, 32, 64`, we assume `LMUL = 1`, and set `SEW = 16/32/64` respectively. Thus no fractional LMUL is involved, and the generated code can pass MC validation.