### PR TITLE
[LLVM][XTHeadVector] Fix `RISCVInsertVSETVLI`: handle `hasAVLImm` and constrain temporary register to be `GPRNoX0`

### DIFF
--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmfirst.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmfirst.ll
@@ -22,6 +22,21 @@ entry:
   ret iXLen %a
 }
 
+define iXLen @intrinsic_vmfirst_m_nxv1i1_zero(<vscale x 1 x i1> %0) nounwind {
+; CHECK-LABEL: intrinsic_vmfirst_m_nxv1i1_zero:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    li a0, 0
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmfirst.m a0, v0
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmfirst.iXLen.nxv1i1(
+    <vscale x 1 x i1> %0,
+    iXLen 0)
+
+  ret iXLen %a
+}
+
 declare iXLen @llvm.riscv.th.vmfirst.mask.iXLen.nxv1i1(
   <vscale x 1 x i1>,
   <vscale x 1 x i1>,
@@ -48,6 +63,32 @@ entry:
     <vscale x 1 x i1> %0,
     <vscale x 1 x i1> %1,
     iXLen %2)
+
+  ret iXLen %a
+}
+
+define iXLen @intrinsic_vmfirst_mask_m_nxv1i1_zero(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1) nounwind {
+; CHECK-LABEL: intrinsic_vmfirst_mask_m_nxv1i1_zero:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v9, v0
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
+; CHECK-NEXT:    li a0, 0
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmfirst.m a0, v9, v0.t
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmfirst.mask.iXLen.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    iXLen 0)
 
   ret iXLen %a
 }

--- a/llvm/test/CodeGen/RISCV/rvv0p71/vmpopc.ll
+++ b/llvm/test/CodeGen/RISCV/rvv0p71/vmpopc.ll
@@ -22,6 +22,21 @@ entry:
   ret iXLen %a
 }
 
+define iXLen @intrinsic_vmpopc_m_nxv1i1_zero(<vscale x 1 x i1> %0) nounwind {
+; CHECK-LABEL: intrinsic_vmpopc_m_nxv1i1_zero:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    li a0, 0
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmpopc.m a0, v0
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmpopc.iXLen.nxv1i1(
+    <vscale x 1 x i1> %0,
+    iXLen 0)
+
+  ret iXLen %a
+}
+
 declare iXLen @llvm.riscv.th.vmpopc.mask.iXLen.nxv1i1(
   <vscale x 1 x i1>,
   <vscale x 1 x i1>,
@@ -48,6 +63,32 @@ entry:
     <vscale x 1 x i1> %0,
     <vscale x 1 x i1> %1,
     iXLen %2)
+
+  ret iXLen %a
+}
+
+define iXLen @intrinsic_vmpopc_mask_m_nxv1i1_zero(<vscale x 1 x i1> %0, <vscale x 1 x i1> %1) nounwind {
+; CHECK-LABEL: intrinsic_vmpopc_mask_m_nxv1i1_zero:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v9, v0
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
+; CHECK-NEXT:    csrr a0, vl
+; CHECK-NEXT:    csrr a1, vtype
+; CHECK-NEXT:    th.vsetvli zero, zero, e8, m1, d1
+; CHECK-NEXT:    th.vmv.v.v v0, v8
+; CHECK-NEXT:    th.vsetvl zero, a0, a1
+; CHECK-NEXT:    li a0, 0
+; CHECK-NEXT:    th.vsetvli zero, a0, e64, m1, d1
+; CHECK-NEXT:    th.vmpopc.m a0, v9, v0.t
+; CHECK-NEXT:    ret
+entry:
+  %a = call iXLen @llvm.riscv.th.vmpopc.mask.iXLen.nxv1i1(
+    <vscale x 1 x i1> %0,
+    <vscale x 1 x i1> %1,
+    iXLen 0)
 
   ret iXLen %a
 }


### PR DESCRIPTION
Depends on #120, tests will be updated after #120 is merged