### PR TITLE
[Clang][XTHeadVector] Add more semacheck for xtheadvector

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4811,6 +4811,20 @@ bool Sema::CheckRISCVBuiltinFunctionCall(const TargetInfo &TI,
   case RISCVVector::BI__builtin_rvv_vnclip_wx:
   case RISCVVector::BI__builtin_rvv_vnclipu_wv:
   case RISCVVector::BI__builtin_rvv_vnclipu_wx:
+  case RISCVVector::BI__builtin_rvv_th_vaadd_vv:
+  case RISCVVector::BI__builtin_rvv_th_vaadd_vx:
+  case RISCVVector::BI__builtin_rvv_th_vasub_vv:
+  case RISCVVector::BI__builtin_rvv_th_vasub_vx:
+  case RISCVVector::BI__builtin_rvv_th_vsmul_vv:
+  case RISCVVector::BI__builtin_rvv_th_vsmul_vx:
+  case RISCVVector::BI__builtin_rvv_th_vssra_vv:
+  case RISCVVector::BI__builtin_rvv_th_vssra_vx:
+  case RISCVVector::BI__builtin_rvv_th_vssrl_vv:
+  case RISCVVector::BI__builtin_rvv_th_vssrl_vx:
+  case RISCVVector::BI__builtin_rvv_th_vnclip_wv:
+  case RISCVVector::BI__builtin_rvv_th_vnclip_wx:
+  case RISCVVector::BI__builtin_rvv_th_vnclipu_wv:
+  case RISCVVector::BI__builtin_rvv_th_vnclipu_wx:
     return SemaBuiltinConstantArgRange(TheCall, 2, 0, 3);
   case RISCVVector::BI__builtin_rvv_vaaddu_vv_tu:
   case RISCVVector::BI__builtin_rvv_vaaddu_vx_tu:
@@ -4848,6 +4862,34 @@ bool Sema::CheckRISCVBuiltinFunctionCall(const TargetInfo &TI,
   case RISCVVector::BI__builtin_rvv_vnclip_wx_m:
   case RISCVVector::BI__builtin_rvv_vnclipu_wv_m:
   case RISCVVector::BI__builtin_rvv_vnclipu_wx_m:
+  case RISCVVector::BI__builtin_rvv_th_vaadd_vv_tu:
+  case RISCVVector::BI__builtin_rvv_th_vaadd_vx_tu:
+  case RISCVVector::BI__builtin_rvv_th_vasub_vv_tu:
+  case RISCVVector::BI__builtin_rvv_th_vasub_vx_tu:
+  case RISCVVector::BI__builtin_rvv_th_vsmul_vv_tu:
+  case RISCVVector::BI__builtin_rvv_th_vsmul_vx_tu:
+  case RISCVVector::BI__builtin_rvv_th_vssra_vv_tu:
+  case RISCVVector::BI__builtin_rvv_th_vssra_vx_tu:
+  case RISCVVector::BI__builtin_rvv_th_vssrl_vv_tu:
+  case RISCVVector::BI__builtin_rvv_th_vssrl_vx_tu:
+  case RISCVVector::BI__builtin_rvv_th_vnclip_wv_tu:
+  case RISCVVector::BI__builtin_rvv_th_vnclip_wx_tu:
+  case RISCVVector::BI__builtin_rvv_th_vnclipu_wv_tu:
+  case RISCVVector::BI__builtin_rvv_th_vnclipu_wx_tu:
+  case RISCVVector::BI__builtin_rvv_th_vaadd_vv_m:
+  case RISCVVector::BI__builtin_rvv_th_vaadd_vx_m:
+  case RISCVVector::BI__builtin_rvv_th_vasub_vv_m:
+  case RISCVVector::BI__builtin_rvv_th_vasub_vx_m:
+  case RISCVVector::BI__builtin_rvv_th_vsmul_vv_m:
+  case RISCVVector::BI__builtin_rvv_th_vsmul_vx_m:
+  case RISCVVector::BI__builtin_rvv_th_vssra_vv_m:
+  case RISCVVector::BI__builtin_rvv_th_vssra_vx_m:
+  case RISCVVector::BI__builtin_rvv_th_vssrl_vv_m:
+  case RISCVVector::BI__builtin_rvv_th_vssrl_vx_m:
+  case RISCVVector::BI__builtin_rvv_th_vnclip_wv_m:
+  case RISCVVector::BI__builtin_rvv_th_vnclip_wx_m:
+  case RISCVVector::BI__builtin_rvv_th_vnclipu_wv_m:
+  case RISCVVector::BI__builtin_rvv_th_vnclipu_wx_m:
     return SemaBuiltinConstantArgRange(TheCall, 3, 0, 3);
   case RISCVVector::BI__builtin_rvv_vaaddu_vv_tum:
   case RISCVVector::BI__builtin_rvv_vaaddu_vv_tumu:
@@ -4903,6 +4945,48 @@ bool Sema::CheckRISCVBuiltinFunctionCall(const TargetInfo &TI,
   case RISCVVector::BI__builtin_rvv_vnclip_wx_tumu:
   case RISCVVector::BI__builtin_rvv_vnclipu_wv_tumu:
   case RISCVVector::BI__builtin_rvv_vnclipu_wx_tumu:
+  case RISCVVector::BI__builtin_rvv_th_vaadd_vv_tum:
+  case RISCVVector::BI__builtin_rvv_th_vaadd_vv_tumu:
+  case RISCVVector::BI__builtin_rvv_th_vaadd_vv_mu:
+  case RISCVVector::BI__builtin_rvv_th_vaadd_vx_tum:
+  case RISCVVector::BI__builtin_rvv_th_vaadd_vx_tumu:
+  case RISCVVector::BI__builtin_rvv_th_vaadd_vx_mu:
+  case RISCVVector::BI__builtin_rvv_th_vasub_vv_tum:
+  case RISCVVector::BI__builtin_rvv_th_vasub_vv_tumu:
+  case RISCVVector::BI__builtin_rvv_th_vasub_vv_mu:
+  case RISCVVector::BI__builtin_rvv_th_vasub_vx_tum:
+  case RISCVVector::BI__builtin_rvv_th_vasub_vx_tumu:
+  case RISCVVector::BI__builtin_rvv_th_vasub_vx_mu:
+  case RISCVVector::BI__builtin_rvv_th_vsmul_vv_mu:
+  case RISCVVector::BI__builtin_rvv_th_vsmul_vx_mu:
+  case RISCVVector::BI__builtin_rvv_th_vssra_vv_mu:
+  case RISCVVector::BI__builtin_rvv_th_vssra_vx_mu:
+  case RISCVVector::BI__builtin_rvv_th_vssrl_vv_mu:
+  case RISCVVector::BI__builtin_rvv_th_vssrl_vx_mu:
+  case RISCVVector::BI__builtin_rvv_th_vnclip_wv_mu:
+  case RISCVVector::BI__builtin_rvv_th_vnclip_wx_mu:
+  case RISCVVector::BI__builtin_rvv_th_vnclipu_wv_mu:
+  case RISCVVector::BI__builtin_rvv_th_vnclipu_wx_mu:
+  case RISCVVector::BI__builtin_rvv_th_vsmul_vv_tum:
+  case RISCVVector::BI__builtin_rvv_th_vsmul_vx_tum:
+  case RISCVVector::BI__builtin_rvv_th_vssra_vv_tum:
+  case RISCVVector::BI__builtin_rvv_th_vssra_vx_tum:
+  case RISCVVector::BI__builtin_rvv_th_vssrl_vv_tum:
+  case RISCVVector::BI__builtin_rvv_th_vssrl_vx_tum:
+  case RISCVVector::BI__builtin_rvv_th_vnclip_wv_tum:
+  case RISCVVector::BI__builtin_rvv_th_vnclip_wx_tum:
+  case RISCVVector::BI__builtin_rvv_th_vnclipu_wv_tum:
+  case RISCVVector::BI__builtin_rvv_th_vnclipu_wx_tum:
+  case RISCVVector::BI__builtin_rvv_th_vsmul_vv_tumu:
+  case RISCVVector::BI__builtin_rvv_th_vsmul_vx_tumu:
+  case RISCVVector::BI__builtin_rvv_th_vssra_vv_tumu:
+  case RISCVVector::BI__builtin_rvv_th_vssra_vx_tumu:
+  case RISCVVector::BI__builtin_rvv_th_vssrl_vv_tumu:
+  case RISCVVector::BI__builtin_rvv_th_vssrl_vx_tumu:
+  case RISCVVector::BI__builtin_rvv_th_vnclip_wv_tumu:
+  case RISCVVector::BI__builtin_rvv_th_vnclip_wx_tumu:
+  case RISCVVector::BI__builtin_rvv_th_vnclipu_wv_tumu:
+  case RISCVVector::BI__builtin_rvv_th_vnclipu_wx_tumu:
     return SemaBuiltinConstantArgRange(TheCall, 4, 0, 3);
   case RISCVVector::BI__builtin_rvv_vfsqrt_v_rm:
   case RISCVVector::BI__builtin_rvv_vfrec7_v_rm:

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vaadd-out-of-range.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vaadd-out-of-range.c
@@ -1,0 +1,26 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +f -target-feature +d \
+// RUN:   -target-feature +xtheadvector \
+// RUN:   -fsyntax-only -verify %s
+
+#include <riscv_vector.h>
+
+vint32m1_t test_vaadd_vv_i32m1(vint32m1_t op1, vint32m1_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vaadd_vv_i32m1(op1, op2, 5, vl);
+}
+
+vint32m1_t test_vaadd_vx_i32m1(vint32m1_t op1, int32_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vaadd_vx_i32m1(op1, op2, 5, vl);
+}
+
+vint32m1_t test_vaadd_vv_i32m1_m(vbool32_t mask, vint32m1_t maskedoff, vint32m1_t op1, vint32m1_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vaadd_vv_i32m1_m(mask, maskedoff, op1, op2, 5, vl);
+}
+
+vint32m1_t test_vaadd_vx_i32m1_m(vbool32_t mask, vint32m1_t maskedoff, vint32m1_t op1, int32_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vaadd_vx_i32m1_m(mask, maskedoff, op1, op2, 5, vl);
+}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vasub-out-of-range.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vasub-out-of-range.c
@@ -1,0 +1,26 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +f -target-feature +d \
+// RUN:   -target-feature +xtheadvector \
+// RUN:   -fsyntax-only -verify %s
+
+#include <riscv_vector.h>
+
+vint32m1_t test_vasub_vv_i32m1(vint32m1_t op1, vint32m1_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vasub_vv_i32m1(op1, op2, 5, vl);
+}
+
+vint32m1_t test_vasub_vx_i32m1(vint32m1_t op1, int32_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vasub_vx_i32m1(op1, op2, 5, vl);
+}
+
+vint32m1_t test_vasub_vv_i32m1_m(vbool32_t mask, vint32m1_t maskedoff, vint32m1_t op1, vint32m1_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vasub_vv_i32m1_m(mask, maskedoff, op1, op2, 5, vl);
+}
+
+vint32m1_t test_vasub_vx_i32m1_m(vbool32_t mask, vint32m1_t maskedoff, vint32m1_t op1, int32_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vasub_vx_i32m1_m(mask, maskedoff, op1, op2, 5, vl);
+}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vnclip-out-of-range.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vnclip-out-of-range.c
@@ -1,0 +1,26 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +f -target-feature +d \
+// RUN:   -target-feature +xtheadvector \
+// RUN:   -fsyntax-only -verify %s
+
+#include <riscv_vector.h>
+
+vint32m1_t test_vnclip_wv_i32m1(vint64m2_t op1, vuint32m1_t shift, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vnclip_wv_i32m1(op1, shift, 5, vl);
+}
+
+vint32m1_t test_vnclip_wx_i32m1(vint64m2_t op1, size_t shift, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vnclip_wx_i32m1(op1, shift, 5, vl);
+}
+
+vint32m1_t test_vnclip_wv_i32m1_m(vbool32_t mask, vint32m1_t maskedoff, vint64m2_t op1, vuint32m1_t shift, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vnclip_wv_i32m1_m(mask, maskedoff, op1, shift, 5, vl);
+}
+
+vint32m1_t test_vnclip_wx_i32m1_m(vbool32_t mask, vint32m1_t maskedoff, vint64m2_t op1, size_t shift, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vnclip_wx_i32m1_m(mask, maskedoff, op1, shift, 5, vl);
+}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vnclipu-out-of-range.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vnclipu-out-of-range.c
@@ -1,0 +1,26 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +f -target-feature +d \
+// RUN:   -target-feature +xtheadvector \
+// RUN:   -fsyntax-only -verify %s
+
+#include <riscv_vector.h>
+
+vuint32m1_t test_vnclipu_wv_u32m1(vuint64m2_t op1, vuint32m1_t shift, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vnclipu_wv_u32m1(op1, shift, 5, vl);
+}
+
+vuint32m1_t test_vnclipu_wx_u32m1(vuint64m2_t op1, size_t shift, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vnclipu_wx_u32m1(op1, shift, 5, vl);
+}
+
+vuint32m1_t test_vnclipu_wv_u32m1_m(vbool32_t mask, vuint32m1_t maskedoff, vuint64m2_t op1, vuint32m1_t shift, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vnclipu_wv_u32m1_m(mask, maskedoff, op1, shift, 5, vl);
+}
+
+vuint32m1_t test_vnclipu_wx_u32m1_m(vbool32_t mask, vuint32m1_t maskedoff, vuint64m2_t op1, size_t shift, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vnclipu_wx_u32m1_m(mask, maskedoff, op1, shift, 5, vl);
+}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vsmul-out-of-range.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vsmul-out-of-range.c
@@ -1,0 +1,26 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +f -target-feature +d \
+// RUN:   -target-feature +xtheadvector \
+// RUN:   -fsyntax-only -verify %s
+
+#include <riscv_vector.h>
+
+vint32m1_t test_vsmul_vv_i32m1(vint32m1_t op1, vint32m1_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vsmul_vv_i32m1(op1, op2, 5, vl);
+}
+
+vint32m1_t test_vsmul_vx_i32m1(vint32m1_t op1, int32_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vsmul_vx_i32m1(op1, op2, 5, vl);
+}
+
+vint32m1_t test_vsmul_vv_i32m1_m(vbool32_t mask, vint32m1_t maskedoff, vint32m1_t op1, vint32m1_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vsmul_vv_i32m1_m(mask, maskedoff, op1, op2, 5, vl);
+}
+
+vint32m1_t test_vsmul_vx_i32m1_m(vbool32_t mask, vint32m1_t maskedoff, vint32m1_t op1, int32_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vsmul_vx_i32m1_m(mask, maskedoff, op1, op2, 5, vl);
+}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vssra-out-of-range.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vssra-out-of-range.c
@@ -1,0 +1,26 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +f -target-feature +d \
+// RUN:   -target-feature +xtheadvector \
+// RUN:   -fsyntax-only -verify %s
+
+#include <riscv_vector.h>
+
+vuint32m1_t test_vssrl_vv_u32m1(vuint32m1_t op1, vuint32m1_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vssrl_vv_u32m1(op1, op2, 5, vl);
+}
+
+vuint32m1_t test_vssrl_vx_u32m1(vuint32m1_t op1, uint32_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vssrl_vx_u32m1(op1, op2, 5, vl);
+}
+
+vuint32m1_t test_vssrl_vv_u32m1_m(vbool32_t mask, vuint32m1_t maskedoff, vuint32m1_t op1, vuint32m1_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vssrl_vv_u32m1_m(mask, maskedoff, op1, op2, 5, vl);
+}
+
+vuint32m1_t test_vssrl_vx_u32m1_m(vbool32_t mask, vuint32m1_t maskedoff, vuint32m1_t op1, uint32_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vssrl_vx_u32m1_m(mask, maskedoff, op1, op2, 5, vl);
+}

--- a/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vssrl-out-of-range.c
+++ b/clang/test/CodeGen/RISCV/rvv0p71-intrinsics-handcrafted/vssrl-out-of-range.c
@@ -1,0 +1,26 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -target-feature +f -target-feature +d \
+// RUN:   -target-feature +xtheadvector \
+// RUN:   -fsyntax-only -verify %s
+
+#include <riscv_vector.h>
+
+vuint32m1_t test_vssrl_vv_u32m1(vuint32m1_t op1, vuint32m1_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vssrl_vv_u32m1(op1, op2, 5, vl);
+}
+
+vuint32m1_t test_vssrl_vx_u32m1(vuint32m1_t op1, uint32_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vssrl_vx_u32m1(op1, op2, 5, vl);
+}
+
+vuint32m1_t test_vssrl_vv_u32m1_m(vbool32_t mask, vuint32m1_t maskedoff, vuint32m1_t op1, vuint32m1_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vssrl_vv_u32m1_m(mask, maskedoff, op1, op2, 5, vl);
+}
+
+vuint32m1_t test_vssrl_vx_u32m1_m(vbool32_t mask, vuint32m1_t maskedoff, vuint32m1_t op1, uint32_t op2, size_t vl) {
+  // expected-error@+1 {{argument value 5 is outside the valid range [0, 3]}}
+  return __riscv_vssrl_vx_u32m1_m(mask, maskedoff, op1, op2, 5, vl);
+}


### PR DESCRIPTION
partially fixes some illegal instructions caused by bad immediate numbers